### PR TITLE
Rebrand fork as Tallybook

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,29 @@
+# Migrating from MoneyWallet to Tallybook
+
+Tallybook is a **separate app** from the original MoneyWallet. It uses a different application id (`io.github.herrerad85.tallybook`), which means:
+
+- Both apps can be installed at the same time, side by side.
+- Installing Tallybook does **not** update or replace MoneyWallet, and it does **not** read MoneyWallet's data automatically.
+- Tallybook starts empty. To bring your data across, migrate it manually using the steps below.
+
+## Recommended: full migration via Backup and Restore
+
+Because Tallybook shares MoneyWallet's data format, a full backup made in MoneyWallet can be restored into Tallybook, bringing across your wallets, transactions, categories, budgets, and the rest.
+
+1. In the original **MoneyWallet**: open Settings and create a local **Backup**. If you set a backup password, remember it , you will need it to restore.
+2. Find the backup file in the backup folder the app used, and keep it somewhere safe (for example copy it to your computer, or to another folder on the device).
+3. Install **Tallybook** (it installs alongside MoneyWallet, it does not overwrite it).
+4. In **Tallybook**: open Settings and **Restore** from that backup file, entering the password if one was set.
+5. Check that your wallets and recent transactions appear, then carry on in Tallybook.
+
+Keep MoneyWallet installed and your backup file safe until you are confident everything came across. This process does not delete anything from MoneyWallet.
+
+## Notes and current limitations
+
+- **Backup/Restore is the recommended path** for a complete copy of your data. CSV, Excel, and PDF export are meant for use in other tools, not as a full round-trip migration.
+- **File export/import under modern Android scoped storage still needs follow-up work** and may not behave correctly in every case yet (tracked in the project issues). If a backup file is hard to locate or restore, please open an issue and include your Android version.
+- Coming from a very old (pre-4.0) MoneyWallet? The app also includes a legacy importer for the old database; prefer Backup/Restore where possible and use the legacy import only as a fallback.
+
+## Why Tallybook is a separate app
+
+The original application id belongs to the upstream MoneyWallet project and cannot be reused for a distributed fork, so Tallybook ships under its own id. This keeps the two apps independent and lets you run them side by side while you migrate.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -6,11 +6,11 @@ Tallybook is a **separate app** from the original MoneyWallet. It uses a differe
 - Installing Tallybook does **not** update or replace MoneyWallet, and it does **not** read MoneyWallet's data automatically.
 - Tallybook starts empty. To bring your data across, migrate it manually using the steps below.
 
-## Recommended: full migration via Backup and Restore
+## Intended migration path: Backup and Restore
 
-Because Tallybook shares MoneyWallet's data format, a full backup made in MoneyWallet can be restored into Tallybook, bringing across your wallets, transactions, categories, budgets, and the rest.
+Tallybook is expected to restore MoneyWallet backups because it preserves the legacy data format, but this still needs end-to-end verification before a public release. The intended flow brings across your wallets, transactions, categories, budgets, and the rest:
 
-1. In the original **MoneyWallet**: open Settings and create a local **Backup**. If you set a backup password, remember it , you will need it to restore.
+1. In the original **MoneyWallet**: open Settings and create a local **Backup**. If you set a backup password, remember it, you will need it to restore.
 2. Find the backup file in the backup folder the app used, and keep it somewhere safe (for example copy it to your computer, or to another folder on the device).
 3. Install **Tallybook** (it installs alongside MoneyWallet, it does not overwrite it).
 4. In **Tallybook**: open Settings and **Restore** from that backup file, entering the password if one was set.
@@ -20,7 +20,8 @@ Keep MoneyWallet installed and your backup file safe until you are confident eve
 
 ## Notes and current limitations
 
-- **Backup/Restore is the recommended path** for a complete copy of your data. CSV, Excel, and PDF export are meant for use in other tools, not as a full round-trip migration.
+- **End-to-end restore from the original MoneyWallet into Tallybook is still a required pre-release verification step.** It has not yet been validated end to end, so treat the steps above as the intended path rather than a confirmed one.
+- **Backup/Restore is the intended path** for a complete copy of your data. CSV, Excel, and PDF export are meant for use in other tools, not as a full round-trip migration.
 - **File export/import under modern Android scoped storage still needs follow-up work** and may not behave correctly in every case yet (tracked in the project issues). If a backup file is hard to locate or restore, please open an issue and include your Android version.
 - Coming from a very old (pre-4.0) MoneyWallet? The app also includes a legacy importer for the old database; prefer Backup/Restore where possible and use the legacy import only as a fallback.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Tallybook is a private, offline-first expense and budget tracker for Android: mu
 
 **Tallybook is a maintained fork of [MoneyWallet](https://github.com/AndreAle94/moneywallet)** by AndreAle94, a GPL-licensed Android expense manager whose last release was in 2021. This fork modernizes the open-source build, fixes the startup crash that stopped the app launching on recent Android, and continues maintenance under a new name and application id.
 
-> **Tallybook is a separate app, not an automatic update to MoneyWallet.** It uses a different application id (`io.github.herrerad85.tallybook`), so it installs side by side with the original and does not replace it or migrate its data automatically. See [MIGRATION.md](MIGRATION.md) to move your data across.
+> **Tallybook is a separate app, not an automatic update to MoneyWallet.** It uses a different application id (`io.github.herrerad85.tallybook`), so it installs side by side with the original and does not replace it or migrate its data automatically. See [MIGRATION.md](MIGRATION.md) for the intended manual migration path and current limitations.
 
 This fork is independent and is not endorsed by or affiliated with the original author.
 

--- a/README.md
+++ b/README.md
@@ -1,50 +1,41 @@
-# Maintained MoneyWallet Fork
+# Tallybook
 
 [![License: GPLv3](https://img.shields.io/badge/license-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
 
-This repository is a maintained fork of [MoneyWallet](https://github.com/AndreAle94/moneywallet), a GPL-licensed Android expense manager.
+Tallybook is a private, offline-first expense and budget tracker for Android: multiple wallets, categories, budgets, recurring transactions, multi-currency, reports, and local backup, with no account required.
 
-The immediate goal is to make the FOSS/OpenStreetMap build work reliably on current Android versions, including fixing the startup crash reported by existing users and modernizing the build toolchain.
+**Tallybook is a maintained fork of [MoneyWallet](https://github.com/AndreAle94/moneywallet)** by AndreAle94, a GPL-licensed Android expense manager whose last release was in 2021. This fork modernizes the open-source build, fixes the startup crash that stopped the app launching on recent Android, and continues maintenance under a new name and application id.
 
-This fork is not yet a published replacement for the original app. A rebranded release, a new application id, migration notes, and an F-Droid submission are planned before public distribution.
+> **Tallybook is a separate app, not an automatic update to MoneyWallet.** It uses a different application id (`io.github.herrerad85.tallybook`), so it installs side by side with the original and does not replace it or migrate its data automatically. See [MIGRATION.md](MIGRATION.md) to move your data across.
 
-> "Maintained MoneyWallet Fork" is a temporary working name. The final name and application id will be chosen before any release.
+This fork is independent and is not endorsed by or affiliated with the original author.
 
 ![Showcase](pictures/showcase.png)
 
-## About this fork
-MoneyWallet is an on-device expense manager: multiple wallets, categories, budgets, recurring transactions, multi-currency, reports, and local backup, with no account required. The upstream project has not had a release since 2021 and no longer starts on recent Android for many users. This fork picks up maintenance, beginning with compatibility, and aims to continue it as a privacy-respecting, offline-first expense tracker.
+## Status
+The Android 14/15 compatibility work has landed: a modernized FOSS/OpenStreetMap build, the Android 12+ manifest and PendingIntent updates, and a fix for the startup crash caused by a legacy auto-backup path (reported upstream as [#177](https://github.com/AndreAle94/moneywallet/issues/177) and [#286](https://github.com/AndreAle94/moneywallet/issues/286)). It has been verified on an Android 15 emulator (launch, wallet creation, income and expense entry, totals, and relaunch persistence).
 
-## Current status
-Modernization is in progress on a development branch and has not been released. The most recent published upstream build does not launch on Android 14 and 15 for users who had auto-backup enabled. Making the app build and start again on current Android is the first priority. Until a release is published, this fork is not an installable replacement for the original app.
-
-## What is being fixed first
-- Modernizing the FOSS/OpenStreetMap Android build to a current toolchain and SDK level.
-- The Android 12+ manifest and PendingIntent requirements needed to run on modern Android.
-- The startup crash caused by a legacy auto-backup path (upstream [#177](https://github.com/AndreAle94/moneywallet/issues/177) and [#286](https://github.com/AndreAle94/moneywallet/issues/286)).
-- Verifying the core flow (create a wallet, add income and expense, totals, relaunch persistence) on Android 14 and 15.
-
-Progress is tracked in this repository's [issues](https://github.com/herrerad85/moneywallet/issues) and milestones.
+No public release has been published yet. Export/import under scoped storage and self-hosted sync are still to come, and an F-Droid submission is planned. Progress is tracked in this repository's [issues](https://github.com/herrerad85/moneywallet/issues) and milestones.
 
 ## Build from source
-The fully open-source variant uses OpenStreetMap and no proprietary services. Build it with the `floss` and `osm` flavors:
+The fully open-source variant uses OpenStreetMap and no proprietary services. Build the `floss` + `osm` flavors:
 
 ```
 ./gradlew assembleFlossOsmDebug
 ```
 
-Requirements: a recent Android SDK and a JDK. The `proprietary` flavor (Google Drive, Dropbox) and the `gmap` flavor (Google Maps) need API keys in `gradle.properties` and are not the focus of this fork. The build-toolchain modernization is landing on the development branch, so the most reliable build comes from there once it is published.
+Requirements: a recent Android SDK and JDK 17. The `proprietary` flavor (Google Drive, Dropbox) and the `gmap` flavor (Google Maps) require API keys in `gradle.properties` and are not the focus of this fork.
 
-Note on icons: the original precompiled app bundled an icon pack that is not redistributable; only the small free subset is in the source tree. Providing a distributable icon set is part of the rebranded-release work.
+Note on icons: the original precompiled app bundled an icon pack that is not redistributable; only the small free subset is in the source tree. Providing a distributable icon set is part of the ongoing release work.
 
 ## Roadmap
-- Android 14/15 compatibility: modernize the build, fix the startup crash, verify core flows.
-- Rebranded release: choose a fork name and application id, present the README and license cleanly for a GPL fork, add build and migration docs, and submit to F-Droid.
+- Android 14/15 compatibility: modernize the build, fix the startup crash, verify core flows. (Done.)
+- Rebranded release: new name and application id, build and migration docs, F-Droid metadata and submission.
 - Backup, export, and sync: fix export and import under scoped storage, add WebDAV/Nextcloud sync (upstream [#67](https://github.com/AndreAle94/moneywallet/issues/67)), and a local-file, Syncthing-friendly option.
 
-See the pinned [roadmap issue](https://github.com/herrerad85/moneywallet/issues/15) for current details.
+See the pinned [roadmap](https://github.com/herrerad85/moneywallet/issues/15) for current details.
 
 ## Upstream and license
-This is a fork of [AndreAle94/moneywallet](https://github.com/AndreAle94/moneywallet). MoneyWallet is free software licensed under the GNU General Public License v3.0, and this fork remains under the same license. See [LICENSE.md](LICENSE.md).
+Tallybook is a fork of [AndreAle94/moneywallet](https://github.com/AndreAle94/moneywallet). MoneyWallet is free software licensed under the GNU General Public License v3.0, and Tallybook remains under the same license. See [LICENSE.md](LICENSE.md).
 
 Original work and credits: MoneyWallet was created by its upstream author and contributors. Logo by Adam Lapinski; first-start images from Freepik; internal icon set from RoundIcons.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
     }
 
     defaultConfig {
-        applicationId "com.oriondev.moneywallet"
+        applicationId "io.github.herrerad85.tallybook"
         minSdk 24
         targetSdk 35
         versionCode 75

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataExporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataExporter.java
@@ -33,7 +33,7 @@ public abstract class AbstractDataExporter {
 
     protected String getDefaultFileName(String extension) {
         String dateTimeString = DateUtils.getFilenameDateTimeString(new Date());
-        return "MoneyWallet_export_" + dateTimeString + extension;
+        return "Tallybook_export_" + dateTimeString + extension;
     }
 
     public abstract boolean isMultiWalletSupported();

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/pdf/PDFDataExporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/pdf/PDFDataExporter.java
@@ -52,7 +52,7 @@ public class PDFDataExporter extends AbstractDataExporter {
         } catch (DocumentException e) {
             throw new IOException(e);
         }
-        mDocument.addAuthor("MoneyWallet - Expense Manager");
+        mDocument.addAuthor("Tallybook - Expense Manager");
         mDocument.open();
     }
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -186,7 +186,7 @@
     <string name="about_hint_version">"Version"</string>
     <string name="about_hint_changelog">"Changelog"</string>
     <string name="about_hint_translators">"Übersetzer"</string>
-    <string name="activity_launcher_first_start_title">Willkommen bei MoneyWallet</string>
+    <string name="activity_launcher_first_start_title">Willkommen bei Tallybook</string>
     <string name="activity_launcher_first_start_content">Benutzt du die App zum ersten Mal oder möchtest du ein Backup wiederherstellen?</string>
     <string name="activity_launcher_first_start_button_restore_backup">Backup wiederherstellen</string>
     <string name="activity_intro_title_slide_1">Keine bösen Überraschungen mehr</string>
@@ -256,7 +256,7 @@
     <string name="adapter_needed_money">Benötigt:</string>
     <string name="adapter_tax_money">Steuer</string>
     <string name="adapter_used_money">Verwendet:</string>
-    <string name="app_name">MoneyWallet</string>
+    <string name="app_name">Tallybook</string>
     <string name="bottom_sheet_icon_picker_action_change_bg_color">Hintergrundfarbe ändern</string>
     <string name="bottom_sheet_icon_picker_action_change_icon">Symbol ändern</string>
     <string name="bottom_sheet_icon_picker_action_remove_icon">Symbol entfernen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -18,7 +18,7 @@
   -->
 
 <resources>
-    <string name="app_name">MoneyWallet</string>
+    <string name="app_name">Tallybook</string>
 
     <string name="menu_transaction">"Συναλλαγές"</string>
     <string name="menu_category">"Κατηγορίες"</string>
@@ -558,7 +558,7 @@
     <string name="about_hint_translators">"Μεταφραστές"</string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title">"Γίνεται ενημέρωση.."</string>
-    <string name="activity_launcher_first_start_title">"Καλωσήρθατε στο MoneyWallet"</string>
+    <string name="activity_launcher_first_start_title">"Καλωσήρθατε στο Tallybook"</string>
     <string name="activity_launcher_first_start_content">"Είναι η πρώτη σας φορά που χρησιμοποιείτε αυτή την εφαρμογή ή θέλετε να επαναφέρετε κάποιο προηγούμενο αντίγραφο ασφαλείας;"</string>
     <string name="activity_launcher_first_start_button_first_time">"Πρώτη φορά"</string>
     <string name="activity_launcher_first_start_button_restore_backup">"Επαναφορά αντίγραφου ασφαλείας"</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -18,7 +18,7 @@
   -->
 
 <resources>
-    <string name="app_name">MoneyWallet</string>
+    <string name="app_name">Tallybook</string>
 
     <string name="menu_transaction">"معاملات"</string>
     <string name="menu_category">"دسته بندی‌ها"</string>
@@ -510,7 +510,7 @@
     <string name="about_hint_translators">"مترجمان"</string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title">"ارتقاء …"</string>
-    <string name="activity_launcher_first_start_title">"به MoneyWallet خوش آمدید"</string>
+    <string name="activity_launcher_first_start_title">"به Tallybook خوش آمدید"</string>
     <string name="activity_launcher_first_start_content">"آیا اولین بار است که شما از این برنامه استفاده می کنید یا میخواهید پشتیبان قبلی را بازگردانید؟"</string>
     <string name="activity_launcher_first_start_button_first_time">"بار اول"</string>
     <string name="activity_launcher_first_start_button_restore_backup">"بازگرداندن پشتیبان"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -18,7 +18,7 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">MoneyWallet</string>
+    <string name="app_name">Tallybook</string>
 
     <string name="menu_transaction">"Transactions"</string>
     <string name="menu_category">"Catégories"</string>
@@ -557,7 +557,7 @@
     <string name="about_hint_translators">Traducteurs</string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title">"Mise à jour…"</string>
-    <string name="activity_launcher_first_start_title">Bienvenue sur MoneyWallet</string>
+    <string name="activity_launcher_first_start_title">Bienvenue sur Tallybook</string>
     <string name="activity_launcher_first_start_content">C\'est la première fois que vous utilisez cette application ou voulez-vous restaurer une sauvegarde?</string>
     <string name="activity_launcher_first_start_button_first_time">Première fois</string>
     <string name="activity_launcher_first_start_button_restore_backup">Restaurer une sauvegarde</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">MoneyWallet</string>
+    <string name="app_name">Tallybook</string>
     <string name="about_hint_developer">Fejlesztő</string>
     <string name="about_hint_author">Tulajdonos</string>
     <string name="about_hint_changelog">Változások listája</string>
@@ -64,7 +64,7 @@
     <string name="activity_launcher_first_start_button_first_time">Első alkalom</string>
     <string name="activity_launcher_first_start_button_restore_backup">Biztonsági mentés visszaállítása</string>
     <string name="activity_launcher_first_start_content">Ez az első alkalom, hogy ezt az alkalmazást használod, vagy szeretnéd visszaállítani a biztonsági mentésedet?</string>
-    <string name="activity_launcher_first_start_title">Üdvözöllek a MoneyWallet-ben</string>
+    <string name="activity_launcher_first_start_title">Üdvözöllek a Tallybook-ben</string>
     <string name="activity_launcher_legacy_edition_upgrade_title">Frissítés...</string>
     <string name="adapter_available_money">Elérhető:</string>
     <string name="adapter_current_money">Jelenlegi:</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -18,7 +18,7 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    <string name="app_name">MoneyWallet</string>
+    <string name="app_name">Tallybook</string>
 
     <string name="menu_transaction">"Transazioni"</string>
     <string name="menu_category">"Categorie"</string>
@@ -557,7 +557,7 @@
     <string name="about_hint_translators">"Traduttori"</string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title">"Aggiornamento…"</string>
-    <string name="activity_launcher_first_start_title">"Benvenuto in MoneyWallet"</string>
+    <string name="activity_launcher_first_start_title">"Benvenuto in Tallybook"</string>
     <string name="activity_launcher_first_start_content">"è la prima volta che usi l'applicazione o vuoi ripristinare un backup precedente?"</string>
     <string name="activity_launcher_first_start_button_first_time">"Prima volta"</string>
     <string name="activity_launcher_first_start_button_restore_backup">"Ripristina backup"</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -2,7 +2,7 @@
 ~ translated by haneefi
 -->
 <resources>
-    <string name="app_name">മണി വാലറ്റ്</string>
+    <string name="app_name">Tallybook</string>
 
     <string name="menu_transaction">"ഇടപാടുകൾ"</string>
     <string name="menu_category">"വിഭാഗങ്ങൾ"</string>
@@ -545,7 +545,7 @@
     <string name="about_hint_translators">"വിവർത്തകർ"</string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title">"നവീകരിക്കുന്നു…"</string>
-    <string name="activity_launcher_first_start_title">"മണി വാലറ്റിലേക്ക് സ്വാഗതം"</string>
+    <string name="activity_launcher_first_start_title">"Tallybookിലേക്ക് സ്വാഗതം"</string>
     <string name="activity_launcher_first_start_content">"നിങ്ങൾ ആദ്യമായാണ് ഈ അപ്ലിക്കേഷൻ ഉപയോഗിക്കുന്നത് അല്ലെങ്കിൽ മുമ്പത്തെ ബാക്കപ്പ് പുന restore സ്ഥാപിക്കാൻ നിങ്ങൾ ആഗ്രഹിക്കുന്നുണ്ടോ?"</string>
     <string name="activity_launcher_first_start_button_first_time">"ആദ്യതവണ"</string>
     <string name="activity_launcher_first_start_button_restore_backup">"ബാക്കപ്പ് പുന ore സ്ഥാപിക്കുക"</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -561,7 +561,7 @@
     <string name="about_hint_translators">"Tłumacze"</string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title">"Aktualizacja…"</string>
-    <string name="activity_launcher_first_start_title">"Witamy w MoneyWallet"</string>
+    <string name="activity_launcher_first_start_title">"Witamy w Tallybook"</string>
     <string name="activity_launcher_first_start_content">"Czy używasz tej aplikacji po raz pierwszy, czy chcesz przywrócić poprzednią kopię zapasową?"</string>
     <string name="activity_launcher_first_start_button_first_time">"Pierwszy raz"</string>
     <string name="activity_launcher_first_start_button_restore_backup">"Przywróc kopię zapasową"</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -563,7 +563,7 @@
     <string name="about_hint_translators">"Tradutores"</string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title">"Atualizando…"</string>
-    <string name="activity_launcher_first_start_title">"Bem vindo ao MoneyWallet"</string>
+    <string name="activity_launcher_first_start_title">"Bem vindo ao Tallybook"</string>
     <string name="activity_launcher_first_start_content">"É a primeira vez que você usa o aplicativo ou gostaria de restaurar um backup anterior?"</string>
     <string name="activity_launcher_first_start_button_first_time">"Primeira vez"</string>
     <string name="activity_launcher_first_start_button_restore_backup">"Restaurar backup"</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -18,7 +18,7 @@
   -->
 
 <resources>
-    <string name="app_name">MoneyWallet</string>
+    <string name="app_name">Tallybook</string>
 
     <string name="menu_transaction"> "İşlemler" </string>
     <string name="menu_category"> "Kategoriler" </string>
@@ -543,7 +543,7 @@
     <string name="about_hint_translators"> "Çevirmenler" </string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title"> "Yükseltme…" </string>
-    <string name="activity_launcher_first_start_title"> "MoneyWallet'e Hoş Geldiniz" </string>
+    <string name="activity_launcher_first_start_title"> "Tallybook'e Hoş Geldiniz" </string>
     <string name="activity_launcher_first_start_content"> "Bu uygulamayı ilk kez kullanıyor musunuz veya önceki bir yedeği geri yüklemek mi istiyorsunuz?" </string>
     <string name="activity_launcher_first_start_button_first_time"> "İlk kez" </string>
     <string name="activity_launcher_first_start_button_restore_backup"> "Yedeklemeyi geri yükle" </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,7 +18,7 @@
   -->
 
 <resources>
-    <string name="app_name">MoneyWallet</string>
+    <string name="app_name">Tallybook</string>
 
     <string name="menu_transaction">"Transactions"</string>
     <string name="menu_category">"Categories"</string>
@@ -565,7 +565,7 @@
     <string name="about_hint_translators">"Translators"</string>
 
     <string name="activity_launcher_legacy_edition_upgrade_title">"Upgrading…"</string>
-    <string name="activity_launcher_first_start_title">"Welcome to MoneyWallet"</string>
+    <string name="activity_launcher_first_start_title">"Welcome to Tallybook"</string>
     <string name="activity_launcher_first_start_content">"Is it the first time you use this application or do you want to restore a previous backup?"</string>
     <string name="activity_launcher_first_start_button_first_time">"First time"</string>
     <string name="activity_launcher_first_start_button_restore_backup">"Restore backup"</string>

--- a/app/src/main/res/xml-v25/shortcuts.xml
+++ b/app/src/main/res/xml-v25/shortcuts.xml
@@ -9,7 +9,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="com.oriondev.moneywallet.ui.activity.NewEditTransferActivity"
-            android:targetPackage="com.oriondev.moneywallet" />
+            android:targetPackage="io.github.herrerad85.tallybook" />
 
     </shortcut>
 
@@ -22,7 +22,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity"
-            android:targetPackage="com.oriondev.moneywallet" />
+            android:targetPackage="io.github.herrerad85.tallybook" />
 
     </shortcut>
 


### PR DESCRIPTION
## App identity
- Name: **Tallybook**
- applicationId: **io.github.herrerad85.tallybook** (debug builds keep the `.dev` suffix)
- Source package stays `com.oriondev.moneywallet` (no Java namespace refactor)

## Separate install, not an update
Tallybook uses a new applicationId, so it installs **side by side** with the original MoneyWallet and does not replace it or migrate its data automatically. The provider/FileProvider authorities are applicationId-derived, so they are now unique and there is no install conflict.

## Migration
Adds **MIGRATION.md** describing the **intended** manual migration path: Backup (in MoneyWallet) and Restore (in Tallybook). Tallybook is expected to restore MoneyWallet backups because it preserves the legacy data format, but **this has not been verified end to end yet**, and the guide states that plainly. It is also honest about current scoped-storage export/import limitations.

## Attribution and license
GPL-3.0 preserved. README and MIGRATION.md keep clear attribution to AndreAle94/moneywallet and do not imply endorsement. Legacy import database names and paths are kept so data from the original app can still be imported.

## Scope
FOSS/OpenStreetMap (`flossOsm`) build. No Java package/source refactor.

## Verification
- Build/tests: `testFlossOsmDebugUnitTest assembleFlossOsmDebug` -> BUILD SUCCESSFUL, unit tests pass.
- Package/identity: APK package id `io.github.herrerad85.tallybook.dev`, launcher label `Tallybook` (aapt2 badging).
- Device (Android 15 emulator): cold launch with no fatal crash ("Welcome to Tallybook"); created a wallet and a transaction that persisted across force-stop and relaunch (exercises the content provider at the new authority); installed side by side with the original `com.oriondev.moneywallet` (both packages coexist, distinct authorities, no provider conflict).
- Identity grep verified; legacy and attribution references intentionally kept.

## Known follow-up
- **Backup/Restore migration from the original MoneyWallet into Tallybook still needs end-to-end verification before any release.** The migration guide is written as the intended path, not a confirmed one.
- App-shortcuts `targetPackage` is hardcoded to the release applicationId (debug `.dev` shortcuts are not wired), mirroring upstream; can be made variant-aware later.
- F-Droid metadata is not included in this PR (it belongs with the F-Droid submission).

## No release
No APK/AAB published, no tag, no release created. Not opened against upstream.

Likely addresses #6, #7, #8. **#11 (migration guide) should stay open** until the guide reflects an end-to-end-verified migration path.
