### PR TITLE
Clarify the local folder backup option for offline sync

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -652,10 +652,8 @@
     <string name="title_activity_edit_recurrence">Wiederkehrende Zahlung bearbeiten</string>
     <string name="title_fragment_item_saving">Erspartes</string>
     <string name="title_fragment_item_recurrence">Wiederkehrende Zahlung</string>
-    <string name="cover_message_backup_storage_access_framework_title">Die Anwednung kann Sicherungen auf jedem Dokument-Provider (z. B. Dropbox, Nextcloud, OneDrive, etc.) anlegen und abrufen.</string>
     <string name="cover_message_backup_storage_access_framework_button">Weiter</string>
     <string name="message_multiply_currency_decimals">Die Zahlenwerte in der Datenbank müssen auf die neue Anzahl Dezimalstellen angepasst werden. Dieser Vorgang kann einige Zeit in Anspruch nehemen. Der Vorgang kann auch übersprungen werden. In diesem Fall werden die Zahlenwerte allerdings dividiert durch %d angezeigt.</string>
-    <string name="message_backup_service_storage_access_framework_disconnect">Sicher, dass du den aktuellen Dokument-Provider trennen möchtest? Es werden keine Dateien gelöscht.</string>
     <string name="spinner_item_group_type_daily">Tägliche Gruppierung</string>
     <string name="spinner_item_group_type_weekly">Wöchentliche Gruppierung</string>
     <string name="spinner_item_group_type_monthly">Monatliche Gruppierung</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -340,7 +340,6 @@
     <string name="message_no_file_found">"Nenhum arquivo encontrado"</string>
     <string name="message_error_backend_recoverable">"Problema de conexão. Tente novamente."</string>
 
-    <string name="cover_message_backup_storage_access_framework_title">"O aplicativo consegue criar e restaurar backups de qualquer provedor de arquivo (ex: Nextcloud, Dropbox ou seu sistema de arquivos)"</string>
     <string name="cover_message_backup_external_memory_title">"O aplicativo consegue criar e restaurar backups diretamente de fontes de armazenamento externo do dispositivo"</string>
     <string name="cover_message_backup_dropbox_title">"O aplicativo consegue criar e restaurar backups diretamente da sua conta pessoal do Dropbox"</string>
     <string name="cover_message_backup_google_drive_title">"O aplicativo consegue criar e restaurar backups diretamente da sua conta pessoal do Google Drive"</string>
@@ -388,7 +387,6 @@
     <string name="message_backup_creation_failed">"Falha durante a criação do arquivo de backup. Mensagem: %s"</string>
     <string name="message_backup_restoring_failed">"Falha durante a restauração do arquivo de backup. Mensagem: %s"</string>
     <string name="message_backup_service_dropbox_disconnect">"Tem certeza que deseja desconectar da sua conta do Dropbox?"</string>
-    <string name="message_backup_service_storage_access_framework_disconnect">"Tem certeza que deseja liberar o provedor de conteúdo atual? Nenhum arquivo será removido."</string>
     <string name="message_backup_service_google_drive_disconnect">"Tem certeza que deseja desconectar da sua conta do Google Drive?"</string>
     <string name="message_action_archive_wallet">"Tem certeza que deseja arquivar essa carteira? Ela não ficara mais visível no menu."</string>
     <string name="message_action_unarchive_wallet">"Tem certeza que deseja desarquivar essa carteira? Ela ficara visível no menu novamente."</string>
@@ -455,7 +453,6 @@
     <string name="service_backup_drop_box">"DropBox"</string>
     <string name="service_backup_google_drive">"Google Drive"</string>
     <string name="service_backup_external_memory">"Armazenamento Externo"</string>
-    <string name="service_backup_storage_access_framework" translatable="false">"Framework de Acesso ao Armazenamento"</string>
 
     <string name="setting_title_user_interface">"Interface de usuário"</string>
     <string name="setting_title_utility">"Utilidades"</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -342,7 +342,7 @@
     <string name="message_no_file_found">"No file found"</string>
     <string name="message_error_backend_recoverable">"Connection problem. Please retry."</string>
 
-    <string name="cover_message_backup_storage_access_framework_title">"The application can create and restore the backups from any document provider (e.g. Nextcloud, Dropbox or your filesystem)"</string>
+    <string name="cover_message_backup_storage_access_framework_title">"Create and restore backups in a folder you choose on this device. Because it is an ordinary folder, you can keep it in sync with a tool such as Syncthing or your own setup, with no account required. Document providers like Nextcloud also work."</string>
     <string name="cover_message_backup_external_memory_title">"The application can create and restore the backups directly from the external storage of the device"</string>
     <string name="cover_message_backup_dropbox_title">"The application can create and restore the backups from your personal Dropbox account"</string>
     <string name="cover_message_backup_google_drive_title">"The application can create and restore the backups from your personal Google Drive account"</string>
@@ -390,7 +390,7 @@
     <string name="message_backup_creation_failed">"Failure during the creation of the backup. Message: %s"</string>
     <string name="message_backup_restoring_failed">"Failure during the restoring of the backup. Message: %s"</string>
     <string name="message_backup_service_dropbox_disconnect">"Are you sure you want to disconnect your Dropbox account?"</string>
-    <string name="message_backup_service_storage_access_framework_disconnect">"Are you sure you want to release the current content provider? No files will be deleted."</string>
+    <string name="message_backup_service_storage_access_framework_disconnect">"Are you sure you want to disconnect the current folder? No files will be deleted."</string>
     <string name="message_backup_service_google_drive_disconnect">"Are you sure you want to disconnect your Google Drive account?"</string>
     <string name="message_action_archive_wallet">"Are you sure you want to archive this wallet? It will not be visible in the menu anymore."</string>
     <string name="message_action_unarchive_wallet">"Are you sure you want to unarchive this wallet? It will be visible in the menu again."</string>
@@ -457,7 +457,7 @@
     <string name="service_backup_drop_box">"DropBox"</string>
     <string name="service_backup_google_drive">"Google Drive"</string>
     <string name="service_backup_external_memory">"External Memory"</string>
-    <string name="service_backup_storage_access_framework" translatable="false">"Storage Access Framework"</string>
+    <string name="service_backup_storage_access_framework" translatable="false">"Local folder"</string>
 
     <string name="setting_title_user_interface">"User interface"</string>
     <string name="setting_title_utility">"Utilities"</string>


### PR DESCRIPTION
## Background

The app already has a backup backend that lets you pick an ordinary folder through the Android system picker and create, list, and restore backups there. The folder choice is kept with a persisted permission, so it survives relaunch. Because it is a normal folder, it can be synced by an external tool such as Syncthing, or copied however the user likes, with no third-party account. That is exactly what issue #14 asks for.

The gap was discoverability: the backend was labeled "Storage Access Framework" and its description led with cloud providers, so a user looking for a plain local folder or a Syncthing target would not recognize it.

## Change

Strings only, no behavior change:

- Renamed the backup service from "Storage Access Framework" to "Local folder".
- Rewrote its description to explain that you pick a folder on the device, that it can be kept in sync with a tool such as Syncthing or your own setup with no account, and that document providers like Nextcloud still work.
- Updated the disconnect confirmation to refer to the folder instead of a "content provider".
- Removed stale German and Portuguese (pt-rBR) overrides for these strings so every locale now uses the updated default wording. The base label stays `translatable="false"` as "Local folder".

No backend, backup format, or migration behavior changed.

## Verification

- Build gate green: clean `testFlossOsmDebugUnitTest` and `assembleFlossOsmDebug`.
- Verified on an Android 15 emulator:
  - The backup services list shows the renamed "Local folder" backend, and its description renders with the new wording.
  - Picking a folder uses the system file picker. I chose `Download/tallybook-backups`.
  - An unprotected backup (`.mwbx`) and a password-protected backup (`.mwbs`) were both created as ordinary files in that folder.
  - Restoring from the folder succeeds.
  - The folder choice persists across a force-stop and relaunch: reopening the backend goes straight to the backup list with no re-pick, which is what lets an external tool keep the folder in sync.
  - Logcat showed no fatal backup or restore errors.
