### PR TITLE
Refresh backup list after creating a backup

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
@@ -476,6 +476,11 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
                 } else if (operation == BackupHandlerIntentService.ACTION_BACKUP) {
                     IFile backup = intent.getParcelableExtra(BackupHandlerIntentService.BACKUP_FILE);
                     mBackupAdapter.addFileToList(backup);
+                    // reveal the list in case the folder was empty before this backup,
+                    // otherwise the empty state keeps hiding the newly created file
+                    if (mBackupAdapter.getItemCount() > 0) {
+                        mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.READY);
+                    }
                 }
             } else if (TextUtils.equals(action, LocalAction.ACTION_BACKUP_SERVICE_FAILED)) {
                 int operation = intent.getIntExtra(BackupHandlerIntentService.ACTION, 0);


### PR DESCRIPTION
## Bug

When the backup folder is empty, creating a backup writes the file correctly but the list keeps showing the "No file found" empty state. The new backup only appears after a pull-to-refresh, leaving and re-entering the screen, or relaunching the app. This was observed with the Local folder backend on Android 15.

## Cause

In `BackupHandlerFragment`, the broadcast handler for a finished list operation sets the list view to `EMPTY` or `READY` based on the item count. The handler for a finished backup operation added the new file to the adapter with `addFileToList(backup)` but did not transition the `AdvancedRecyclerView` from `EMPTY` to `READY`, so the empty view continued to hide the now-populated list.

## Fix

After adding the new backup to the adapter, set the list state to `READY` when there is at least one item, mirroring the list-operation handler. No backend reload, backup format, restore, or sync behavior changed.

## Verification

- Build gate green: clean `testFlossOsmDebugUnitTest` and `assembleFlossOsmDebug`.
- Verified on an Android 15 emulator with the Local folder backend, using a freshly created empty folder:
  - The empty folder first shows "No file found".
  - Creating an unprotected backup makes the new `.mwbx` appear in the list immediately, with no pull-to-refresh and without leaving the screen, and the empty state is gone.
  - Creating a password-protected backup makes the `.mwbs` appear immediately too.
  - Pull-to-refresh still works, the folder choice still persists across a force-stop and relaunch, and restoring from a listed file still works.
  - Logcat showed no fatal backup or restore errors.
