### PR TITLE
Document reinstalling MoneyWallet to create a migration backup

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -18,6 +18,19 @@ This path is verified. A backup made by the original MoneyWallet restores into T
 
 Keep MoneyWallet installed and your backup file safe until you are confident everything came across. This process does not delete anything from MoneyWallet.
 
+## Don't have a MoneyWallet backup yet?
+
+The path above relies on a backup file created by MoneyWallet. The primary migration path is unchanged: create a backup in MoneyWallet, then restore that `.mwbs` or `.mwbx` file in Tallybook. How you get that backup depends on whether MoneyWallet is still on your device.
+
+**If MoneyWallet is still installed:** open MoneyWallet and create a backup first, before you install Tallybook or start relying on it. Keep that file somewhere safe (see the steps above).
+
+**If MoneyWallet is no longer installed:** reinstall it from the same source you originally used, then open it and create a backup if your old data appears. The same source matters because Android only lets an app read existing app data when the new install is signed with the same key as the original. A copy from a different source, or a locally built APK, has a different signature and cannot open the old data.
+
+- Installed from **F-Droid**? MoneyWallet is still available there: https://f-droid.org/packages/com.oriondev.moneywallet/
+- Installed from **Google Play or another source**? You need the app from that same source, signed with the same key. A locally built APK will not have a matching signature.
+
+Reinstalling MoneyWallet does **not** recover data that Android already deleted when the app was uninstalled. If MoneyWallet opens empty after you reinstall it, the old app data is no longer on the device. In that case you need an existing backup file, or an Android or device backup that includes the app's data, to restore from.
+
 ## Verification
 
 End-to-end restore was verified on 2026-06-29. A backup produced by the genuine MoneyWallet from F-Droid (version 4.0.5.10, versionCode 75), running on Android 15, restored into Tallybook with full data fidelity: wallets, transactions, categories, amounts, timestamps, and balances all came across, and the data persisted across an app relaunch. Both an unprotected backup and a password-protected, AES-encrypted backup were restored successfully.


### PR DESCRIPTION
Docs-only clarification to MIGRATION.md. No code, resource, or build changes.

## What changed

MIGRATION.md already documents the backup and restore path, but it assumed MoneyWallet was still installed. This adds a short section for users who no longer have MoneyWallet, so the guidance stays honest about what is and is not recoverable.

The primary path is unchanged: create a backup in MoneyWallet, then restore that `.mwbs` or `.mwbx` file in Tallybook. The new section covers how to get that backup:

- If MoneyWallet is still installed, open it and create a backup before installing or relying on Tallybook.
- If MoneyWallet is no longer installed, reinstall it from the same source originally used, then open it and create a backup if the old data appears.
- F-Droid users can still get MoneyWallet at https://f-droid.org/packages/com.oriondev.moneywallet/ . Users who installed from Google Play or another source need the app from that same source and signature, not a locally built APK.
- Same-source reinstall matters because Android only grants access to existing app data when the new install is signed with the same key as the original.
- Reinstalling does not recover data Android already deleted during uninstall. If MoneyWallet opens empty after reinstall, the old data is gone, and an existing backup file, or an Android or device backup restore, is needed.

The wording is deliberately cautious and does not imply guaranteed recovery.

## Scope

- Single file changed: MIGRATION.md.
- No code, resource, manifest, or build changes. README is left unchanged; its existing pointer to MIGRATION.md is still accurate.
