### PR TITLE
Refresh README status for first-release readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This fork is independent and is not endorsed by or affiliated with the original 
 ## Status
 The Android 14/15 compatibility work has landed: a modernized FOSS/OpenStreetMap build, the Android 12+ manifest and PendingIntent updates, and a fix for the startup crash caused by a legacy auto-backup path (reported upstream as [#177](https://github.com/AndreAle94/moneywallet/issues/177) and [#286](https://github.com/AndreAle94/moneywallet/issues/286)). It has been verified on an Android 15 emulator (launch, wallet creation, income and expense entry, totals, and relaunch persistence).
 
-The rebrand to Tallybook is complete: a new name and application id, a verified backup and restore migration path (see [MIGRATION.md](MIGRATION.md)), export and import fixed under scoped storage, and a local-folder backup option that works with file sync tools. No public release has been published yet. Self-hosted WebDAV/Nextcloud sync and an F-Droid submission are still planned. Progress is tracked in this repository's [issues](https://github.com/herrerad85/moneywallet/issues) and milestones.
+The rebrand to Tallybook is complete: a new name and application id, a verified backup and restore migration path (see [MIGRATION.md](MIGRATION.md)), export and import fixed under scoped storage, a local-folder backup option that works with file sync tools, and Android 15 edge-to-edge UI polish. The F-Droid listing metadata and screenshots are prepared in the repository. No public release has been published yet. Self-hosted WebDAV/Nextcloud sync and the F-Droid submission are still planned. Progress is tracked in this repository's [issues](https://github.com/herrerad85/moneywallet/issues) and milestones.
 
 ## Build from source
 The fully open-source variant uses OpenStreetMap and no proprietary services. Build the `floss` + `osm` flavors:
@@ -33,7 +33,8 @@ Note on icons: the original precompiled app bundled an icon pack that is not red
 - Rebrand: new name and application id, build and migration docs. (Done.)
 - Backup and export: fix export and import under scoped storage, and a local-file, Syncthing-friendly backup option. (Done.)
 - Self-hosted sync: WebDAV/Nextcloud (upstream [#67](https://github.com/AndreAle94/moneywallet/issues/67)). (Planned.)
-- F-Droid: metadata and submission. (Planned.)
+- F-Droid: listing metadata and screenshots. (Done.)
+- F-Droid: submission to the f-droiddata build-recipe repository. (Planned.)
 
 See the pinned [roadmap](https://github.com/herrerad85/moneywallet/issues/15) for current details.
 


### PR DESCRIPTION
Docs-only README refresh ahead of the first release. No code, resource, version, or build changes.

## What changed

The status and roadmap sections under-reported completed work:

- The roadmap listed "F-Droid: metadata and submission. (Planned.)", but the listing metadata and screenshots already landed (issue #9, closed). It is now split into "listing metadata and screenshots. (Done.)" and "submission to the f-droiddata build-recipe repository. (Planned.)".
- The status paragraph now mentions the Android 15 edge-to-edge UI polish and notes that the F-Droid listing metadata is prepared, while still stating clearly that no public release has been published yet.

## Scope

- Single file changed: README.md (text only).
- No code, resource, manifest, version, or build changes.
- versionCode, versionName, the in-app changelog, and the per-version Fastlane changelog are intentionally unchanged. Those are tied to a versioning decision and are out of scope here.
