### PR TITLE
Prepare version 1.0.0 for the first Tallybook release

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId "io.github.herrerad85.tallybook"
         minSdk 24
         targetSdk 35
-        versionCode 75
-        versionName "4.0.5.10"
+        versionCode 76
+        versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         multiDexEnabled true

--- a/app/src/main/res/xml/changelog.xml
+++ b/app/src/main/res/xml/changelog.xml
@@ -20,6 +20,17 @@
 
 <changelog>
 
+    <version versionName="1.0.0" versionDate="Jun 30, 2026">
+        <change>[b]New![/b] First Tallybook release, a maintained fork of MoneyWallet.</change>
+        <change>Tallybook is a separate app with its own application id and installs side by side with MoneyWallet.</change>
+        <change>Move your data across manually with backup and restore. See MIGRATION.md in the project for the verified steps.</change>
+        <change>Android 14 and 15 compatibility, including a fix for the startup crash on recent Android.</change>
+        <change>Import and export fixed under scoped storage.</change>
+        <change>Local folder backup option that works with file sync tools such as Syncthing.</change>
+        <change>Android 15 edge-to-edge UI polish so toolbars and controls are not covered by the system bars.</change>
+        <change>Original Tallybook launcher and welcome artwork.</change>
+    </version>
+
     <version versionName="4.0.5" versionDate="Jan 25, 2019">
         <change>[b]New![/b] You can now sort the wallets.</change>
         <change>[b]New![/b] You can now sort the categories.</change>

--- a/fastlane/metadata/android/en-US/changelogs/76.txt
+++ b/fastlane/metadata/android/en-US/changelogs/76.txt
@@ -1,0 +1,10 @@
+First Tallybook release.
+
+Tallybook is a maintained community fork of MoneyWallet, shipped as a separate app. It has its own application id, so it installs side by side with MoneyWallet and does not read the original's data automatically. To move your data across, create a backup in MoneyWallet and restore it in Tallybook. See MIGRATION.md in the project for the verified steps.
+
+Highlights:
+* Android 14 and 15 compatibility, including a fix for the startup crash that stopped the original launching on recent Android.
+* Import and export fixed under scoped storage.
+* Local folder backup option that works with file sync tools such as Syncthing.
+* Android 15 edge-to-edge UI polish so toolbars and controls are not drawn under the system bars.
+* Original Tallybook launcher and welcome artwork.


### PR DESCRIPTION
Version and release-notes prep for the first Tallybook release. No release, tag, or upload is part of this change, and F-Droid has not accepted or published it.

## What changed

- `app/build.gradle`: versionCode 76, versionName 1.0.0 (owner-approved). These replace the inherited MoneyWallet values 75 / 4.0.5.10.
- `app/src/main/res/xml/changelog.xml`: a top entry for Tallybook 1.0.0 (the in-app changelog).
- `fastlane/metadata/android/en-US/changelogs/76.txt`: a new F-Droid listing changelog for versionCode 76.

## Release notes content

Both changelogs cover:

- First Tallybook release as a separate app from MoneyWallet, with its own application id, installed side by side.
- Manual backup and restore migration from MoneyWallet (see MIGRATION.md for the verified steps).
- Android 14 and 15 compatibility and the startup crash fix.
- Scoped-storage import and export fixes.
- Local folder backup option for file sync tools such as Syncthing.
- Android 15 edge-to-edge UI polish.
- Original Tallybook launcher and welcome artwork.

## Verification

- `clean testFlossOsmDebugUnitTest assembleFlossOsmDebug` on JDK 17: BUILD SUCCESSFUL, unit tests pass.
- Debug APK badging: package `io.github.herrerad85.tallybook.dev`, versionCode 76, versionName 1.0.0, label Tallybook.

## Not in scope

No GitHub release, tag, APK or AAB upload, or F-Droid submission. Those are separate steps for after this lands.
