### PR TITLE
Shorten the 1.0.0 F-Droid changelog under the 500 character limit

### DIFF
--- a/fastlane/metadata/android/en-US/changelogs/76.txt
+++ b/fastlane/metadata/android/en-US/changelogs/76.txt
@@ -1,10 +1,3 @@
-First Tallybook release.
+First Tallybook release, a maintained fork of MoneyWallet shipped as a separate app with its own application id, so it installs side by side. Move your data across with a manual backup and restore (see MIGRATION.md).
 
-Tallybook is a maintained community fork of MoneyWallet, shipped as a separate app. It has its own application id, so it installs side by side with MoneyWallet and does not read the original's data automatically. To move your data across, create a backup in MoneyWallet and restore it in Tallybook. See MIGRATION.md in the project for the verified steps.
-
-Highlights:
-* Android 14 and 15 compatibility, including a fix for the startup crash that stopped the original launching on recent Android.
-* Import and export fixed under scoped storage.
-* Local folder backup option that works with file sync tools such as Syncthing.
-* Android 15 edge-to-edge UI polish so toolbars and controls are not drawn under the system bars.
-* Original Tallybook launcher and welcome artwork.
+Also in this release: Android 14 and 15 compatibility with a startup crash fix, scoped-storage import and export fixes, a local folder backup option for file sync tools, Android 15 edge-to-edge UI polish, and original Tallybook artwork.


### PR DESCRIPTION
Metadata-only fix for the F-Droid Fastlane changelog. No code, resource, version, or build changes.

## What changed

The F-Droid Fastlane quick start caps `changelogs/<versionCode>.txt` at 500 characters. The 1.0.0 entry (`changelogs/76.txt`) was 799 characters. This condenses it to 455 while keeping the key points:

- First Tallybook release, a separate app from MoneyWallet installed side by side.
- Manual backup and restore migration (see MIGRATION.md).
- Android 14 and 15 compatibility with the startup crash fix.
- Scoped-storage import and export fixes.
- Local folder backup option for file sync tools.
- Android 15 edge-to-edge UI polish.
- Original Tallybook artwork.

Wording stays factual and does not claim F-Droid has accepted or published the app.

## Scope

- Single file changed: fastlane/metadata/android/en-US/changelogs/76.txt (text only).
- No code, resource, version, or build changes. Text-only, so no build was run.
