### PR TITLE
Update v1.0.0 changelog date

### DIFF
--- a/app/src/main/res/xml/changelog.xml
+++ b/app/src/main/res/xml/changelog.xml
@@ -20,7 +20,7 @@
 
 <changelog>
 
-    <version versionName="1.0.0" versionDate="Jun 30, 2026">
+    <version versionName="1.0.0" versionDate="Jul 01, 2026">
         <change>[b]New![/b] First Tallybook release, a maintained fork of MoneyWallet.</change>
         <change>Tallybook is a separate app with its own application id and installs side by side with MoneyWallet.</change>
         <change>Move your data across manually with backup and restore. See MIGRATION.md in the project for the verified steps.</change>


### PR DESCRIPTION
Summary:
- Update the in-app v1.0.0 changelog date to Jul 01, 2026.

Validation:
- Confirmed changelog.xml is well-formed XML.
- Confirmed the diff only updates the one intended date.
