### PR TITLE
Prepare v1.0.1 reproducible release build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId "io.github.herrerad85.tallybook"
         minSdk 24
         targetSdk 35
-        versionCode 76
-        versionName "1.0.0"
+        versionCode 77
+        versionName "1.0.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         multiDexEnabled true
@@ -51,6 +51,9 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            vcsInfo {
+                include false
+            }
         }
         debug {
             applicationIdSuffix ".dev"

--- a/app/src/main/res/xml/changelog.xml
+++ b/app/src/main/res/xml/changelog.xml
@@ -20,6 +20,10 @@
 
 <changelog>
 
+    <version versionName="1.0.1" versionDate="Jul 01, 2026">
+        <change>Build-system update to support F-Droid reproducible builds. No user-facing feature changes.</change>
+    </version>
+
     <version versionName="1.0.0" versionDate="Jul 01, 2026">
         <change>[b]New![/b] First Tallybook release, a maintained fork of MoneyWallet.</change>
         <change>Tallybook is a separate app with its own application id and installs side by side with MoneyWallet.</change>

--- a/fastlane/metadata/android/en-US/changelogs/77.txt
+++ b/fastlane/metadata/android/en-US/changelogs/77.txt
@@ -1,0 +1,1 @@
+Build-system update to support F-Droid reproducible builds. No user-facing feature changes.


### PR DESCRIPTION
Summary:
- Bump Tallybook to versionCode 77 and versionName 1.0.1.
- Disable AGP release VCS metadata embedding for reproducible APK builds.
- Add v1.0.1 changelog entries noting no user-facing feature changes.

Validation:
- Built floss+osm release with JDK 21.
- Confirmed the APK no longer contains META-INF/version-control-info.textproto.
- Confirmed versionCode 77 and versionName 1.0.1 in the APK.
- Confirmed two clean JDK 21 release builds are byte-identical.
- Confirmed changelog.xml is well-formed.
