### PR TITLE
Prepare v1.0.2 F-Droid release artifact cleanup

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId "io.github.herrerad85.tallybook"
         minSdk 24
         targetSdk 35
-        versionCode 77
-        versionName "1.0.1"
+        versionCode 78
+        versionName "1.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         multiDexEnabled true
@@ -59,6 +59,10 @@ android {
             applicationIdSuffix ".dev"
             debuggable true
         }
+    }
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
     }
     flavorDimensions "version", "map"
     productFlavors {

--- a/app/src/main/res/xml/changelog.xml
+++ b/app/src/main/res/xml/changelog.xml
@@ -20,6 +20,10 @@
 
 <changelog>
 
+    <version versionName="1.0.2" versionDate="Jul 01, 2026">
+        <change>Build-system update for F-Droid binary transparency checks. No user-facing feature changes.</change>
+    </version>
+
     <version versionName="1.0.1" versionDate="Jul 01, 2026">
         <change>Build-system update to support F-Droid reproducible builds. No user-facing feature changes.</change>
     </version>

--- a/fastlane/metadata/android/en-US/changelogs/78.txt
+++ b/fastlane/metadata/android/en-US/changelogs/78.txt
@@ -1,0 +1,1 @@
+Build-system update for F-Droid binary transparency checks. No user-facing feature changes.


### PR DESCRIPTION
Summary:
- Bump Tallybook to versionCode 78 and versionName 1.0.2.
- Disable AGP dependency metadata in release APK/AAB artifacts.
- Add v1.0.2 changelog entries noting no user-facing feature changes.

Validation:
- Built floss+osm release with JDK 21.
- Confirmed the APK still does not contain META-INF/version-control-info.textproto.
- Confirmed a throwaway signed build does not contain the AGP dependency metadata signing block.
- Confirmed versionCode 78 and versionName 1.0.2 in the APK.
- Confirmed repeated clean JDK 21 release builds are byte-identical.
- Confirmed changelog.xml is well-formed.
