### PR TITLE
Consolidate money scale arithmetic into one module

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/background/OverviewDataLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/OverviewDataLoader.java
@@ -38,6 +38,7 @@ import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IRadarDataSet;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Money;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.model.OverviewData;
 import com.oriondev.moneywallet.model.OverviewSetting;
 import com.oriondev.moneywallet.model.PeriodMoney;
@@ -159,11 +160,10 @@ public class OverviewDataLoader extends AbstractGenericLoader<OverviewData> {
             List<RadarEntry> radarEntryList = new ArrayList<>();
             // iterate period money items
             CurrencyUnit currencyUnit = CurrencyManager.getCurrency(currency);
-            double divider = Math.pow(10, currencyUnit.getDecimals());
             for (int i = 0; i < periodMoneyList.size(); i++) {
                 PeriodMoney periodMoney = periodMoneyList.get(i);
                 long money = periodMoney.getNetIncomes().getMoney(currency);
-                float value = (float) ((double) money / divider);
+                float value = MoneyScale.toHumanAmount(money, currencyUnit.getDecimals()).floatValue();
                 barEntryList.add(new BarEntry(i, value));
                 lineEntryList.add(new Entry(i, value));
                 radarEntryList.add(new RadarEntry(value));

--- a/app/src/main/java/com/oriondev/moneywallet/model/MoneyScale.java
+++ b/app/src/main/java/com/oriondev/moneywallet/model/MoneyScale.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.model;
+
+import java.math.BigDecimal;
+
+/**
+ * Canonical conversions between a human readable decimal amount and the bare
+ * {@code long} minor units value the app stores for money. The scale of a
+ * currency is 10^decimals, with decimals in the range 0..3.
+ *
+ * Every conversion shifts the decimal point with {@link BigDecimal} so the
+ * arithmetic is exact, and truncates toward zero when narrowing back to a
+ * {@code long} (the same rounding the individual call sites relied on before
+ * this was consolidated). The class is intentionally free of Android
+ * dependencies so it can be unit tested on the JVM.
+ */
+public final class MoneyScale {
+
+    private MoneyScale() {
+    }
+
+    /**
+     * Convert a human amount in major units (for example 64.99) into the stored
+     * minor units value (6499 for a two decimal currency). Any fraction beyond
+     * the currency scale is truncated toward zero. A null amount maps to zero.
+     */
+    public static long toMinorUnits(BigDecimal amount, int decimals) {
+        if (amount == null) {
+            return 0L;
+        }
+        return amount.movePointRight(decimals).longValue();
+    }
+
+    /**
+     * Convert a stored minor units value back into a human amount in major
+     * units. This is the exact inverse of {@link #toMinorUnits(BigDecimal, int)}
+     * for any value that fits the currency scale.
+     */
+    public static BigDecimal toHumanAmount(long minorUnits, int decimals) {
+        return BigDecimal.valueOf(minorUnits).movePointLeft(decimals);
+    }
+
+    /**
+     * Rescale a stored minor units value by shifting its decimal point right by
+     * {@code decimalOffset} places; a negative offset shifts left. Used when a
+     * currency changes its number of decimals. Truncates toward zero.
+     */
+    public static long rescale(long minorUnits, int decimalOffset) {
+        return BigDecimal.valueOf(minorUnits).movePointRight(decimalOffset).longValue();
+    }
+
+    /**
+     * Apply an exchange rate to a stored minor units amount and re-scale the
+     * result from the source currency scale to the target currency scale. The
+     * rate is applied exactly once and the result is truncated toward zero.
+     *
+     * The rate is taken through {@link BigDecimal#valueOf(double)} so it is read
+     * from its canonical decimal form rather than the raw binary expansion of
+     * the double, which is what {@code new BigDecimal(double)} would capture.
+     */
+    public static long convert(long minorUnits, int fromDecimals, int toDecimals, double rate) {
+        return BigDecimal.valueOf(minorUnits)
+                .movePointLeft(fromDecimals)
+                .multiply(BigDecimal.valueOf(rate))
+                .movePointRight(toDecimals)
+                .longValue();
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/picker/CurrencyConverterPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/CurrencyConverterPicker.java
@@ -28,10 +28,9 @@ import androidx.fragment.app.FragmentManager;
 
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.ExchangeRate;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.ui.fragment.dialog.CurrencyConverterDialog;
 import com.oriondev.moneywallet.utils.CurrencyManager;
-
-import java.math.BigDecimal;
 
 /**
  * Created by andrea on 15/03/18.
@@ -172,11 +171,7 @@ public class CurrencyConverterPicker extends Fragment implements CurrencyConvert
     }
 
     public long convert(long money) {
-        return new BigDecimal(money)
-                .movePointLeft(mCurrency1.getDecimals())
-                .multiply(new BigDecimal(mConversionRate))
-                .movePointRight(mCurrency2.getDecimals())
-                .longValue();
+        return MoneyScale.convert(money, mCurrency1.getDecimals(), mCurrency2.getDecimals(), mConversionRate);
     }
 
     public void notifyMoneyChanged() {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 
 import com.opencsv.CSVReaderHeaderAware;
 import com.oriondev.moneywallet.model.CurrencyUnit;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.data.AbstractDataImporter;
 import com.oriondev.moneywallet.utils.CurrencyManager;
@@ -61,9 +62,7 @@ public class CSVDataImporter extends AbstractDataImporter {
             } catch (NumberFormatException e) {
                 throw new RuntimeException("Invalid money amount (" + e.getMessage() + ")");
             }
-            BigDecimal decimalMultiply = new BigDecimal(Math.pow(10, currencyUnit.getDecimals()));
-            moneyDecimal = moneyDecimal.multiply(decimalMultiply);
-            long money = moneyDecimal.longValue();
+            long money = MoneyScale.toMinorUnits(moneyDecimal, currencyUnit.getDecimals());
             int direction = money < 0 ? Contract.Direction.EXPENSE : Contract.Direction.INCOME;
             Date datetime = DateUtils.getDateFromSQLDateTimeString(datetimeString);
             insertTransaction(wallet, currencyUnit, category, datetime, Math.abs(money), direction, description, event, place, people, note);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/CurrencyConverterActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/CurrencyConverterActivity.java
@@ -41,6 +41,7 @@ import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.ExchangeRate;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.picker.CurrencyPicker;
 import com.oriondev.moneywallet.service.AbstractCurrencyRateDownloadIntentService;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
@@ -241,10 +242,9 @@ public class CurrencyConverterActivity extends SinglePanelActivity implements Vi
         );
         if (exchangeRate != null) {
             CurrencyUnit currencyUnit = mCurrencyToPicker.getCurrentCurrency();
-            long money = new BigDecimal(text)
-                    .multiply(BigDecimal.valueOf(exchangeRate.getRate()))
-                    .movePointRight(currencyUnit.getDecimals())
-                    .longValue();
+            long money = MoneyScale.toMinorUnits(
+                    new BigDecimal(text).multiply(BigDecimal.valueOf(exchangeRate.getRate())),
+                    currencyUnit.getDecimals());
             mTextMoneyTo.setText(mMoneyFormatter.getNotTintedString(currencyUnit, money, MoneyFormatter.CurrencyMode.ALWAYS_HIDDEN));
         } else {
             mTextMoneyTo.setText(R.string.hint_unknown);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditCurrencyActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditCurrencyActivity.java
@@ -22,6 +22,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.database.SQLiteDataException;
@@ -273,12 +274,12 @@ public class NewEditCurrencyActivity extends SinglePanelScrollActivity {
                             if (currencyUnit.getDecimals() < decimalCount) {
                                 // in this case we have to multiply the current values
                                 int exponent = decimalCount - currencyUnit.getDecimals();
-                                int multiplier = (int) Math.pow(10, exponent);
+                                int multiplier = (int) MoneyScale.rescale(1L, exponent);
                                 builder.content(R.string.message_multiply_currency_decimals, multiplier);
                             } else {
                                 // in this case we have to divide the current values
                                 int exponent = currencyUnit.getDecimals() - decimalCount;
-                                int divider = (int) Math.pow(10, exponent);
+                                int divider = (int) MoneyScale.rescale(1L, exponent);
                                 builder.content(R.string.message_divide_currency_decimals, divider);
                             }
                             builder.show();

--- a/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
@@ -24,6 +24,7 @@ import android.os.Bundle;
 import androidx.annotation.VisibleForTesting;
 
 import com.oriondev.moneywallet.model.CurrencyUnit;
+import com.oriondev.moneywallet.model.MoneyScale;
 
 import java.math.BigDecimal;
 
@@ -64,7 +65,7 @@ public class EquationSolver {
 
     public void setValue(CurrencyUnit currency, long money) {
         if (currency != null && money != 0L && currency.hasDecimals()) {
-            mFirstNumber = String.valueOf(money / Math.pow(10, currency.getDecimals()));
+            mFirstNumber = MoneyScale.toHumanAmount(money, currency.getDecimals()).toPlainString();
         } else {
             mFirstNumber = String.valueOf(money);
         }
@@ -181,7 +182,7 @@ public class EquationSolver {
         }
         BigDecimal parsedNumber = parseNumber(mFirstNumber);
         if (mCurrency != null) {
-            return parsedNumber.movePointRight(mCurrency.getDecimals()).longValue();
+            return MoneyScale.toMinorUnits(parsedNumber, mCurrency.getDecimals());
         }
         return parsedNumber.longValue();
     }

--- a/app/src/main/java/com/oriondev/moneywallet/utils/MoneyFormatter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/MoneyFormatter.java
@@ -26,6 +26,7 @@ import android.widget.TextView;
 
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Money;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 
@@ -86,8 +87,7 @@ public class MoneyFormatter {
     }
 
     public static long normalize(long money, int decimalOffset) {
-        double exponential = Math.pow(10d, decimalOffset);
-        return (long) (money * exponential);
+        return MoneyScale.rescale(money, decimalOffset);
     }
 
     private MoneyFormatter() {

--- a/app/src/test/java/com/oriondev/moneywallet/model/MoneyScaleTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/model/MoneyScaleTest.java
@@ -1,0 +1,176 @@
+package com.oriondev.moneywallet.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+
+/**
+ * Pure JVM tests for the canonical money scaling arithmetic. No Android
+ * dependencies are needed because {@link MoneyScale} is plain Java.
+ */
+public class MoneyScaleTest {
+
+    // long minor units -> human amount -> long minor units must round trip exactly
+
+    @Test
+    public void roundTrip_zeroDecimalCurrency() {
+        assertRoundTrip(0L, 0);
+        assertRoundTrip(64L, 0);
+        assertRoundTrip(-64L, 0);
+        assertRoundTrip(123456789L, 0);
+    }
+
+    @Test
+    public void roundTrip_twoDecimalCurrency() {
+        assertRoundTrip(0L, 2);
+        assertRoundTrip(6499L, 2);
+        assertRoundTrip(-6499L, 2);
+        assertRoundTrip(100L, 2);
+        assertRoundTrip(-1L, 2);
+    }
+
+    @Test
+    public void roundTrip_threeDecimalCurrency() {
+        assertRoundTrip(0L, 3);
+        assertRoundTrip(64999L, 3);
+        assertRoundTrip(-64999L, 3);
+        assertRoundTrip(1L, 3);
+    }
+
+    @Test
+    public void roundTrip_largeValueNearDoublePrecisionEdge() {
+        // 2^53 is the last integer a double can represent exactly. Values just
+        // beyond it are what the old "money / Math.pow(10, d)" display path and
+        // the old "(long)(money * Math.pow(10, offset))" migration path corrupt.
+        long edge = 9007199254740993L; // 2^53 + 1, not representable as a double
+        assertRoundTrip(edge, 0);
+        assertRoundTrip(edge, 2);
+        assertRoundTrip(-edge, 3);
+        assertRoundTrip(Long.MAX_VALUE, 0);
+    }
+
+    @Test
+    public void toHumanAmount_producesExactDecimalString() {
+        assertEquals("64.99", MoneyScale.toHumanAmount(6499L, 2).toPlainString());
+        assertEquals("-64.99", MoneyScale.toHumanAmount(-6499L, 2).toPlainString());
+        assertEquals("0.001", MoneyScale.toHumanAmount(1L, 3).toPlainString());
+        assertEquals("64", MoneyScale.toHumanAmount(64L, 0).toPlainString());
+        // the old double path would have rendered this as a lossy 9.007199254740992E15
+        assertEquals("9007199254740993", MoneyScale.toHumanAmount(9007199254740993L, 0).toPlainString());
+    }
+
+    // human amount -> long minor units truncates toward zero (the policy every
+    // call site relied on, and the one EquationSolverTest pins)
+
+    @Test
+    public void toMinorUnits_truncatesExtraFractionTowardZero() {
+        assertEquals(6499L, MoneyScale.toMinorUnits(new BigDecimal("64.999"), 2));
+        assertEquals(-6499L, MoneyScale.toMinorUnits(new BigDecimal("-64.999"), 2));
+        assertEquals(6490L, MoneyScale.toMinorUnits(new BigDecimal("64.9"), 2));
+        assertEquals(64L, MoneyScale.toMinorUnits(new BigDecimal("64.9"), 0));
+        assertEquals(-64L, MoneyScale.toMinorUnits(new BigDecimal("-64.9"), 0));
+    }
+
+    @Test
+    public void toMinorUnits_nullAmountIsZero() {
+        assertEquals(0L, MoneyScale.toMinorUnits(null, 2));
+    }
+
+    // exchange rate conversion across differing decimal counts
+
+    @Test
+    public void convert_zeroDecimalToTwoDecimal() {
+        // 100000 JPY at 0.0068 USD per JPY = 680.00 USD = 68000 cents
+        assertEquals(68000L, MoneyScale.convert(100000L, 0, 2, 0.0068d));
+    }
+
+    @Test
+    public void convert_twoDecimalToZeroDecimal() {
+        // 68000 cents (680.00 USD) at 147 JPY per USD = 99960 JPY
+        assertEquals(99960L, MoneyScale.convert(68000L, 2, 0, 147.0d));
+    }
+
+    @Test
+    public void convert_appliesRateExactlyOnce() {
+        // 5.00 USD doubled must be 10.00 USD (1000 cents), not 5.00 and not 20.00
+        assertEquals(1000L, MoneyScale.convert(500L, 2, 2, 2.0d));
+    }
+
+    @Test
+    public void convert_sameCurrencyUnitRateIsIdentity() {
+        assertEquals(1234L, MoneyScale.convert(1234L, 2, 2, 1.0d));
+        assertEquals(0L, MoneyScale.convert(0L, 3, 3, 1.0d));
+    }
+
+    // rescale (used by MoneyFormatter.normalize, which feeds the FIX_MONEY_DECIMALS
+    // database migration and the legacy database import)
+
+    @Test
+    public void rescale_matchesOldDoublePathWhereDoubleWasExact() {
+        // widening the scale (offset > 0) is exact integer growth
+        assertEquals(6490L, MoneyScale.rescale(649L, 1));
+        assertEquals(64900L, MoneyScale.rescale(649L, 2));
+        // narrowing the scale (offset < 0) truncates toward zero
+        assertEquals(64L, MoneyScale.rescale(649L, -1));
+        assertEquals(-64L, MoneyScale.rescale(-649L, -1));
+        assertEquals(0L, MoneyScale.rescale(1234L, 0) - 1234L);
+    }
+
+    @Test
+    public void rescale_isExactWhereOldDoublePathCorrupted() {
+        // The migration used (long)(money * Math.pow(10, offset)). With offset 0
+        // that is (long)(money * 1.0), which still routes money through a double
+        // and loses the low bit past 2^53. The exact path must not.
+        long money = 9007199254740993L; // 2^53 + 1
+        long oldDoublePath = (long) (money * Math.pow(10d, 0));
+        assertEquals(9007199254740992L, oldDoublePath); // the pre-existing corruption
+        assertEquals(money, MoneyScale.rescale(money, 0)); // exact
+        assertNotEquals(oldDoublePath, MoneyScale.rescale(money, 0));
+    }
+
+    // regression: the CSV importer used new BigDecimal(Math.pow(10, decimals))
+    // as the scaling multiplier. That is the classic double-constructor pattern.
+
+    @Test
+    public void csvImporter_canonicalMatchesOldPathForSupportedDecimals() {
+        // For the decimals the app actually supports (0..3), Math.pow(10, d) is an
+        // exact double, so the fix does not change any stored value. Lock that in.
+        String[] amounts = {"0", "12345.67", "-0.99", "1000000.5", "70.07"};
+        for (int d = 0; d <= 3; d++) {
+            for (String amount : amounts) {
+                BigDecimal money = new BigDecimal(amount);
+                long oldPath = money.multiply(new BigDecimal(Math.pow(10, d))).longValue();
+                long canonical = MoneyScale.toMinorUnits(money, d);
+                assertEquals("amount=" + amount + " decimals=" + d, oldPath, canonical);
+            }
+        }
+        assertEquals(1234567L, MoneyScale.toMinorUnits(new BigDecimal("12345.67"), 2));
+    }
+
+    @Test
+    public void csvImporter_doubleConstructorMultiplierIsCorruptWhereCanonicalIsExact() {
+        // 10^23 is the first power of ten that is not an exact double. new
+        // BigDecimal(Math.pow(10, 23)) captures the binary tail and yields
+        // 99999999999999991611392 instead of 10^23, so the old multiply would
+        // mangle the amount. The canonical movePointRight path is exact.
+        BigDecimal amount = new BigDecimal("1");
+        BigDecimal buggyMultiplier = new BigDecimal(Math.pow(10, 23));
+        BigDecimal buggyResult = amount.multiply(buggyMultiplier);
+        BigDecimal canonicalResult = amount.movePointRight(23);
+        BigDecimal exact = BigDecimal.TEN.pow(23);
+
+        assertNotEquals(exact, buggyResult);
+        assertTrue(buggyResult.compareTo(new BigDecimal("99999999999999991611392")) == 0);
+        assertTrue(canonicalResult.compareTo(exact) == 0);
+    }
+
+    private static void assertRoundTrip(long minorUnits, int decimals) {
+        BigDecimal human = MoneyScale.toHumanAmount(minorUnits, decimals);
+        assertEquals("round trip minorUnits=" + minorUnits + " decimals=" + decimals,
+                minorUnits, MoneyScale.toMinorUnits(human, decimals));
+    }
+}


### PR DESCRIPTION
## What

Money is stored as a bare long in per-currency minor units (scale = 10^decimals, with decimals 0 to 3). The conversion between that stored long and a human decimal amount was re-derived at many call sites using three different mechanisms: lossy double Math.pow, exact BigDecimal movePoint, and a double-constructor pattern. This adds one canonical module, model.MoneyScale, and routes every site through it.

## Mechanism

MoneyScale is plain Java (no Android imports, so it is JVM testable) with four exact conversions, all built on BigDecimal.movePointLeft/movePointRight and all truncating toward zero, which is the single rounding policy every call site already used:

- toMinorUnits(BigDecimal amount, int decimals): human amount to stored long
- toHumanAmount(long minorUnits, int decimals): stored long to human amount
- rescale(long minorUnits, int decimalOffset): shift the scale when a currency changes its decimals
- convert(long minorUnits, int fromDecimals, int toDecimals, double rate): apply an exchange rate once and re-scale between two currencies

## Blast radius (call sites migrated)

- utils/EquationSolver: the seed string and getResult now use toHumanAmount / toMinorUnits. Rounding is unchanged, so EquationSolverTest passes untouched.
- picker/CurrencyConverterPicker.convert: delegates to MoneyScale.convert.
- ui/activity/CurrencyConverterActivity.makeConversion: the scale-to-long step delegates to toMinorUnits.
- background/OverviewDataLoader: chart values use toHumanAmount().floatValue() instead of dividing by Math.pow.
- ui/activity/NewEditCurrencyActivity: the multiplier/divider shown in the decimal-change dialog now comes from the same rescale used by the migration.
- storage/database/data/csv/CSVDataImporter: the precision fix, see below.
- utils/MoneyFormatter.normalize: now exact, see below.

CurrencyConverterDialog was checked and only reads getRate(); it re-derives no scaling, so it is unchanged. MoneyFormatter's display-only dividers are deliberately left on the double path.

## CSV import precision fix

The importer scaled amounts with new BigDecimal(Math.pow(10, decimals)), the classic double-constructor pattern. For the supported decimals (0 to 3) Math.pow(10, d) happens to be an exact double, so no stored amount was actually wrong, but the code is exact only by floating-point accident. The first power of ten that is not an exact double is 10^23: there new BigDecimal(Math.pow(10, 23)) is 99999999999999991611392, not 10^23. Routing through toMinorUnits (movePointRight) makes the scaling exact by construction and drops the dependency on Math.pow.

## Deliberate behavior change to scrutinize (normalize / migration)

MoneyFormatter.normalize feeds the FIX_MONEY_DECIMALS database migration (run when a currency's decimal count is edited) and the legacy database import. It moved from (long)(money * Math.pow(10d, offset)) to exact BigDecimal. The result changes only where the old double math was already wrong:

- values past 2^53 lost their low bits through the double multiply; they are now exact.
- narrowing the scale (offset < 0) went through 0.1 / 0.01 doubles that could produce an off-by-one; it is now an exact truncation toward zero.

Every input the old path handled correctly is unchanged, and the direction of truncation (toward zero) is the same.

## Verified

- New JVM unit tests in MoneyScaleTest (15 tests): long to human to long round trips for 0, 2, 3 decimal currencies including negatives and values at the 2^53 double-precision edge; truncation toward zero; exchange conversion across differing decimal counts (JPY 0-dec and USD 2-dec) with the rate applied once plus same-currency identity; the normalize correctness change; and a regression for the importer double-constructor pattern.
- ./gradlew clean testFlossOsmDebugUnitTest assembleFlossOsmDebug: BUILD SUCCESSFUL. The existing EquationSolverTest (26 tests) passes unchanged.
