### PR TITLE
Give transaction and transfer inserts one column-set home

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/service/RecurrenceHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/RecurrenceHandlerIntentService.java
@@ -31,6 +31,8 @@ import androidx.core.app.JobIntentService;
 import com.oriondev.moneywallet.broadcast.RecurrenceBroadcastReceiver;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.TransactionContentValuesBuilder;
+import com.oriondev.moneywallet.storage.database.TransferContentValuesBuilder;
 import com.oriondev.moneywallet.utils.DateUtils;
 
 import org.dmfs.rfc5545.DateTime;
@@ -80,24 +82,25 @@ public class RecurrenceHandlerIntentService extends JobIntentService {
                         DateTime nextInstance = iterator.nextDateTime();
                         if (!nextInstance.after(currentDateTime)) {
                             Date transactionDate = DateUtils.getFixedDate(nextInstance);
-                            ContentValues contentValues = new ContentValues();
-                            contentValues.put(Contract.Transaction.MONEY, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.MONEY)));
-                            contentValues.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(transactionDate));
-                            contentValues.put(Contract.Transaction.DESCRIPTION, cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.DESCRIPTION)));
-                            contentValues.put(Contract.Transaction.CATEGORY_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.CATEGORY_ID)));
-                            contentValues.put(Contract.Transaction.DIRECTION, cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.DIRECTION)));
-                            contentValues.put(Contract.Transaction.TYPE, Contract.TransactionType.STANDARD);
-                            contentValues.put(Contract.Transaction.WALLET_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.WALLET_ID)));
-                            contentValues.put(Contract.Transaction.NOTE, cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.NOTE)));
+                            TransactionContentValuesBuilder builder = new TransactionContentValuesBuilder()
+                                    .money(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.MONEY)))
+                                    .date(DateUtils.getSQLDateTimeString(transactionDate))
+                                    .description(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.DESCRIPTION)))
+                                    .categoryId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.CATEGORY_ID)))
+                                    .direction(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.DIRECTION)))
+                                    .type(Contract.TransactionType.STANDARD)
+                                    .walletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.WALLET_ID)))
+                                    .note(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.NOTE)));
                             if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransaction.PLACE_ID))) {
-                                contentValues.put(Contract.Transaction.PLACE_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.PLACE_ID)));
+                                builder.placeId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.PLACE_ID)));
                             }
                             if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransaction.EVENT_ID))) {
-                                contentValues.put(Contract.Transaction.EVENT_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.EVENT_ID)));
+                                builder.eventId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.EVENT_ID)));
                             }
-                            contentValues.put(Contract.Transaction.RECURRENCE_ID, transactionId);
-                            contentValues.put(Contract.Transaction.CONFIRMED, cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.CONFIRMED)) == 1);
-                            contentValues.put(Contract.Transaction.COUNT_IN_TOTAL, cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.COUNT_IN_TOTAL)) == 1);
+                            builder.recurrenceId(transactionId)
+                                    .confirmed(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.CONFIRMED)) == 1)
+                                    .countInTotal(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.COUNT_IN_TOTAL)) == 1);
+                            ContentValues contentValues = builder.build();
                             getContentResolver().insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
                             lastOccurrence = nextInstance;
                         } else {
@@ -141,25 +144,26 @@ public class RecurrenceHandlerIntentService extends JobIntentService {
                         DateTime nextInstance = iterator.nextDateTime();
                         if (!nextInstance.after(currentDateTime)) {
                             Date transferDate = DateUtils.getFixedDate(nextInstance);
-                            ContentValues contentValues = new ContentValues();
-                            contentValues.put(Contract.Transfer.DESCRIPTION, cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.DESCRIPTION)));
-                            contentValues.put(Contract.Transfer.DATE, DateUtils.getSQLDateTimeString(transferDate));
-                            contentValues.put(Contract.Transfer.TRANSACTION_FROM_WALLET_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_FROM_ID)));
-                            contentValues.put(Contract.Transfer.TRANSACTION_TO_WALLET_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_TO_ID)));
-                            contentValues.put(Contract.Transfer.TRANSACTION_TAX_WALLET_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_FROM_ID)));
-                            contentValues.put(Contract.Transfer.TRANSACTION_FROM_MONEY, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_FROM)));
-                            contentValues.put(Contract.Transfer.TRANSACTION_TO_MONEY, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_TO)));
-                            contentValues.put(Contract.Transfer.TRANSACTION_TAX_MONEY, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_TAX)));
-                            contentValues.put(Contract.Transfer.NOTE, cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.NOTE)));
+                            TransferContentValuesBuilder builder = new TransferContentValuesBuilder()
+                                    .description(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.DESCRIPTION)))
+                                    .date(DateUtils.getSQLDateTimeString(transferDate))
+                                    .fromWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_FROM_ID)))
+                                    .toWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_TO_ID)))
+                                    .taxWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_FROM_ID)))
+                                    .fromMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_FROM)))
+                                    .toMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_TO)))
+                                    .taxMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_TAX)))
+                                    .note(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.NOTE)));
                             if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransfer.PLACE_ID))) {
-                                contentValues.put(Contract.Transfer.PLACE_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.PLACE_ID)));
+                                builder.placeId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.PLACE_ID)));
                             }
                             if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransfer.EVENT_ID))) {
-                                contentValues.put(Contract.Transfer.EVENT_ID, cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.EVENT_ID)));
+                                builder.eventId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.EVENT_ID)));
                             }
-                            contentValues.put(Contract.Transfer.RECURRENCE_ID, recurrenceId);
-                            contentValues.put(Contract.Transfer.CONFIRMED, cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.CONFIRMED)) == 1);
-                            contentValues.put(Contract.Transfer.COUNT_IN_TOTAL, cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.COUNT_IN_TOTAL)) == 1);
+                            builder.recurrenceId(recurrenceId)
+                                    .confirmed(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.CONFIRMED)) == 1)
+                                    .countInTotal(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.COUNT_IN_TOTAL)) == 1);
+                            ContentValues contentValues = builder.build();
                             getContentResolver().insert(DataContentProvider.CONTENT_TRANSFERS, contentValues);
                             lastOccurrence = nextInstance;
                         } else {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/TransactionContentValuesBuilder.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/TransactionContentValuesBuilder.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.storage.database;
+
+import android.content.ContentValues;
+
+/**
+ * Single home, outside {@link SQLDatabase}, for the set of {@code Contract.Transaction}
+ * columns that make up a transaction row on the write path (inserts and updates through
+ * the content provider). Each column name is written here rather than repeated at every
+ * call site.
+ *
+ * Every setter is optional: a caller sets only the columns it actually provides, so the
+ * per-caller column set is preserved. A nullable column keeps its caller's null convention,
+ * call the setter (even with a null argument) to write the column, or omit the call to
+ * leave it unset.
+ */
+public class TransactionContentValuesBuilder {
+
+    private final ContentValues mValues = new ContentValues();
+
+    public TransactionContentValuesBuilder money(Long value) {
+        mValues.put(Contract.Transaction.MONEY, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder date(String value) {
+        mValues.put(Contract.Transaction.DATE, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder description(String value) {
+        mValues.put(Contract.Transaction.DESCRIPTION, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder categoryId(long value) {
+        mValues.put(Contract.Transaction.CATEGORY_ID, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder direction(int value) {
+        mValues.put(Contract.Transaction.DIRECTION, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder type(int value) {
+        mValues.put(Contract.Transaction.TYPE, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder walletId(long value) {
+        mValues.put(Contract.Transaction.WALLET_ID, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder placeId(Long value) {
+        mValues.put(Contract.Transaction.PLACE_ID, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder note(String value) {
+        mValues.put(Contract.Transaction.NOTE, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder eventId(Long value) {
+        mValues.put(Contract.Transaction.EVENT_ID, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder savingId(Long value) {
+        mValues.put(Contract.Transaction.SAVING_ID, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder debtId(Long value) {
+        mValues.put(Contract.Transaction.DEBT_ID, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder recurrenceId(long value) {
+        mValues.put(Contract.Transaction.RECURRENCE_ID, value);
+        return this;
+    }
+
+    // Two confirmed()/countInTotal() overloads exist on purpose: most call sites store a
+    // boolean, but the model-to-transaction mapping stores the raw cursor int. Keeping both
+    // signatures preserves each site's exact ContentValues value type with no conversion.
+
+    public TransactionContentValuesBuilder confirmed(boolean value) {
+        mValues.put(Contract.Transaction.CONFIRMED, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder confirmed(int value) {
+        mValues.put(Contract.Transaction.CONFIRMED, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder countInTotal(boolean value) {
+        mValues.put(Contract.Transaction.COUNT_IN_TOTAL, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder countInTotal(int value) {
+        mValues.put(Contract.Transaction.COUNT_IN_TOTAL, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder peopleIds(String value) {
+        mValues.put(Contract.Transaction.PEOPLE_IDS, value);
+        return this;
+    }
+
+    public TransactionContentValuesBuilder attachmentIds(String value) {
+        mValues.put(Contract.Transaction.ATTACHMENT_IDS, value);
+        return this;
+    }
+
+    public ContentValues build() {
+        return mValues;
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/TransferContentValuesBuilder.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/TransferContentValuesBuilder.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.storage.database;
+
+import android.content.ContentValues;
+
+/**
+ * Single home, outside {@link SQLDatabase}, for the set of {@code Contract.Transfer}
+ * columns that make up a transfer row on the write path (inserts and updates through the
+ * content provider). Each column name is written here rather than repeated at every call
+ * site.
+ *
+ * Every setter is optional: a caller sets only the columns it actually provides, so the
+ * per-caller column set is preserved. A nullable column keeps its caller's null convention,
+ * call the setter (even with a null argument) to write the column, or omit the call to
+ * leave it unset.
+ */
+public class TransferContentValuesBuilder {
+
+    private final ContentValues mValues = new ContentValues();
+
+    public TransferContentValuesBuilder description(String value) {
+        mValues.put(Contract.Transfer.DESCRIPTION, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder date(String value) {
+        mValues.put(Contract.Transfer.DATE, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder fromWalletId(long value) {
+        mValues.put(Contract.Transfer.TRANSACTION_FROM_WALLET_ID, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder toWalletId(long value) {
+        mValues.put(Contract.Transfer.TRANSACTION_TO_WALLET_ID, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder taxWalletId(long value) {
+        mValues.put(Contract.Transfer.TRANSACTION_TAX_WALLET_ID, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder fromMoney(long value) {
+        mValues.put(Contract.Transfer.TRANSACTION_FROM_MONEY, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder toMoney(long value) {
+        mValues.put(Contract.Transfer.TRANSACTION_TO_MONEY, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder taxMoney(long value) {
+        mValues.put(Contract.Transfer.TRANSACTION_TAX_MONEY, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder note(String value) {
+        mValues.put(Contract.Transfer.NOTE, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder placeId(Long value) {
+        mValues.put(Contract.Transfer.PLACE_ID, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder eventId(Long value) {
+        mValues.put(Contract.Transfer.EVENT_ID, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder recurrenceId(long value) {
+        mValues.put(Contract.Transfer.RECURRENCE_ID, value);
+        return this;
+    }
+
+    // Two confirmed()/countInTotal() overloads exist on purpose: most call sites store a
+    // boolean, but the model-to-transfer mapping stores the raw cursor int. Keeping both
+    // signatures preserves each site's exact ContentValues value type with no conversion.
+
+    public TransferContentValuesBuilder confirmed(boolean value) {
+        mValues.put(Contract.Transfer.CONFIRMED, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder confirmed(int value) {
+        mValues.put(Contract.Transfer.CONFIRMED, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder countInTotal(boolean value) {
+        mValues.put(Contract.Transfer.COUNT_IN_TOTAL, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder countInTotal(int value) {
+        mValues.put(Contract.Transfer.COUNT_IN_TOTAL, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder peopleIds(String value) {
+        mValues.put(Contract.Transfer.PEOPLE_IDS, value);
+        return this;
+    }
+
+    public TransferContentValuesBuilder attachmentIds(String value) {
+        mValues.put(Contract.Transfer.ATTACHMENT_IDS, value);
+        return this;
+    }
+
+    public ContentValues build() {
+        return mValues;
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
@@ -14,6 +14,7 @@ import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.picker.IconPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.TransactionContentValuesBuilder;
 import com.oriondev.moneywallet.utils.DateUtils;
 import com.oriondev.moneywallet.utils.Utils;
 
@@ -45,33 +46,34 @@ public abstract class AbstractDataImporter {
                                      Date datetime, Long money, int direction, String description,
                                      String event, String place, String people, String note) {
         ContentResolver contentResolver = getContext().getContentResolver();
-        ContentValues contentValues = new ContentValues();
-        // the first step consists in checking if a wallet with the same name and currency already
-        // exists in the database, if not, create it and keep the id as reference
-        contentValues.put(Contract.Transaction.WALLET_ID, getOrCreateWallet(contentResolver, wallet, currencyUnit));
-        // the second step consists in checking if a category with the same name and direction
-        // already exists in the database, if not, create it and keep the id as reference
-        contentValues.put(Contract.Transaction.CATEGORY_ID, getOrCreateCategory(contentResolver, category, direction));
-        // the third step consists in adding the datetime, the money and the direction, the
-        // description and the note related to this transaction
-        contentValues.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(datetime));
-        contentValues.put(Contract.Transaction.DIRECTION, direction);
-        contentValues.put(Contract.Transaction.MONEY, money);
-        contentValues.put(Contract.Transaction.DESCRIPTION, description);
-        contentValues.put(Contract.Transaction.NOTE, note);
-        // the fourth step consists in checking if the event has been provided,
-        // if not, simply ignore it because we cannot know the date range
-        contentValues.put(Contract.Transaction.EVENT_ID, getEvent(contentResolver, event));
-        // the fifth step consists in checking if a place with the same name already
-        // exists in the database, if not, create it and keep the id as reference
-        contentValues.put(Contract.Transaction.PLACE_ID, getOrCreatePlace(contentResolver, place));
-        // the sixth step consists in checking if a set of people with the same name already
-        // exists in the database, if not, create them and keep the ids as reference
-        contentValues.put(Contract.Transaction.PEOPLE_IDS, getOrCreatePeople(contentResolver, people));
-        // the last step consists in inserting the entity inside the database
-        contentValues.put(Contract.Transaction.TYPE, Contract.TransactionType.STANDARD);
-        contentValues.put(Contract.Transaction.CONFIRMED, true);
-        contentValues.put(Contract.Transaction.COUNT_IN_TOTAL, true);
+        ContentValues contentValues = new TransactionContentValuesBuilder()
+                // the first step consists in checking if a wallet with the same name and currency already
+                // exists in the database, if not, create it and keep the id as reference
+                .walletId(getOrCreateWallet(contentResolver, wallet, currencyUnit))
+                // the second step consists in checking if a category with the same name and direction
+                // already exists in the database, if not, create it and keep the id as reference
+                .categoryId(getOrCreateCategory(contentResolver, category, direction))
+                // the third step consists in adding the datetime, the money and the direction, the
+                // description and the note related to this transaction
+                .date(DateUtils.getSQLDateTimeString(datetime))
+                .direction(direction)
+                .money(money)
+                .description(description)
+                .note(note)
+                // the fourth step consists in checking if the event has been provided,
+                // if not, simply ignore it because we cannot know the date range
+                .eventId(getEvent(contentResolver, event))
+                // the fifth step consists in checking if a place with the same name already
+                // exists in the database, if not, create it and keep the id as reference
+                .placeId(getOrCreatePlace(contentResolver, place))
+                // the sixth step consists in checking if a set of people with the same name already
+                // exists in the database, if not, create them and keep the ids as reference
+                .peopleIds(getOrCreatePeople(contentResolver, people))
+                // the last step consists in inserting the entity inside the database
+                .type(Contract.TransactionType.STANDARD)
+                .confirmed(true)
+                .countInTotal(true)
+                .build();
         contentResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -55,6 +55,7 @@ import com.oriondev.moneywallet.picker.PlacePicker;
 import com.oriondev.moneywallet.picker.WalletPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.TransactionContentValuesBuilder;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.AttachmentView;
 import com.oriondev.moneywallet.ui.view.text.MaterialEditText;
@@ -903,23 +904,24 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     @Override
     protected void onSaveChanges(Mode mode) {
         if (validate()) {
-            ContentValues contentValues = new ContentValues();
-            contentValues.put(Contract.Transaction.MONEY, mMoneyPicker.getCurrentMoney());
-            contentValues.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(mDateTimePicker.getCurrentDateTime()));
-            contentValues.put(Contract.Transaction.DESCRIPTION, mDescriptionEditText.getTextAsString());
-            contentValues.put(Contract.Transaction.CATEGORY_ID, mCategoryPicker.getCurrentCategory().getId());
-            contentValues.put(Contract.Transaction.DIRECTION, mCategoryPicker.getCurrentCategory().getDirection());
-            contentValues.put(Contract.Transaction.TYPE, mType);
-            contentValues.put(Contract.Transaction.WALLET_ID, mWalletPicker.getCurrentWallet().getId());
-            contentValues.put(Contract.Transaction.PLACE_ID, mPlacePicker.isSelected() ? mPlacePicker.getCurrentPlace().getId() : null);
-            contentValues.put(Contract.Transaction.NOTE, mNoteEditText.getTextAsString());
-            contentValues.put(Contract.Transaction.EVENT_ID, mEventPicker.isSelected() ? mEventPicker.getCurrentEvent().getId() : null);
-            contentValues.put(Contract.Transaction.SAVING_ID, mSavingId);
-            contentValues.put(Contract.Transaction.DEBT_ID, mDebtId);
-            contentValues.put(Contract.Transaction.CONFIRMED, mConfirmedCheckBox.isChecked());
-            contentValues.put(Contract.Transaction.COUNT_IN_TOTAL, mCountInTotalCheckBox.isChecked());
-            contentValues.put(Contract.Transaction.PEOPLE_IDS, Contract.getObjectIds(mPersonPicker.getCurrentPeople()));
-            contentValues.put(Contract.Transaction.ATTACHMENT_IDS, Contract.getObjectIds(mAttachmentPicker.getCurrentAttachments()));
+            ContentValues contentValues = new TransactionContentValuesBuilder()
+                    .money(mMoneyPicker.getCurrentMoney())
+                    .date(DateUtils.getSQLDateTimeString(mDateTimePicker.getCurrentDateTime()))
+                    .description(mDescriptionEditText.getTextAsString())
+                    .categoryId(mCategoryPicker.getCurrentCategory().getId())
+                    .direction(mCategoryPicker.getCurrentCategory().getDirection())
+                    .type(mType)
+                    .walletId(mWalletPicker.getCurrentWallet().getId())
+                    .placeId(mPlacePicker.isSelected() ? mPlacePicker.getCurrentPlace().getId() : null)
+                    .note(mNoteEditText.getTextAsString())
+                    .eventId(mEventPicker.isSelected() ? mEventPicker.getCurrentEvent().getId() : null)
+                    .savingId(mSavingId)
+                    .debtId(mDebtId)
+                    .confirmed(mConfirmedCheckBox.isChecked())
+                    .countInTotal(mCountInTotalCheckBox.isChecked())
+                    .peopleIds(Contract.getObjectIds(mPersonPicker.getCurrentPeople()))
+                    .attachmentIds(Contract.getObjectIds(mAttachmentPicker.getCurrentAttachments()))
+                    .build();
             ContentResolver contentResolver = getContentResolver();
             switch (mode) {
                 case NEW_ITEM:
@@ -965,19 +967,20 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         if (cursor != null) {
             Uri resultUri = null;
             if (cursor.moveToFirst()) {
-                ContentValues contentValues = new ContentValues();
-                contentValues.put(Contract.Transaction.MONEY, cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.MONEY)));
-                contentValues.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(new Date()));
-                contentValues.put(Contract.Transaction.DESCRIPTION, cursor.getString(cursor.getColumnIndex(Contract.TransactionModel.DESCRIPTION)));
-                contentValues.put(Contract.Transaction.CATEGORY_ID, cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.CATEGORY_ID)));
-                contentValues.put(Contract.Transaction.DIRECTION, cursor.getInt(cursor.getColumnIndex(Contract.TransactionModel.DIRECTION)));
-                contentValues.put(Contract.Transaction.TYPE, Contract.TransactionType.STANDARD);
-                contentValues.put(Contract.Transaction.WALLET_ID, cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.WALLET_ID)));
-                contentValues.put(Contract.Transaction.PLACE_ID, cursor.isNull(cursor.getColumnIndex(Contract.TransactionModel.PLACE_ID)) ? null : cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.PLACE_ID)));
-                contentValues.put(Contract.Transaction.NOTE, cursor.getString(cursor.getColumnIndex(Contract.TransactionModel.NOTE)));
-                contentValues.put(Contract.Transaction.EVENT_ID, cursor.isNull(cursor.getColumnIndex(Contract.TransactionModel.EVENT_ID)) ? null : cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.EVENT_ID)));
-                contentValues.put(Contract.Transaction.CONFIRMED, cursor.getInt(cursor.getColumnIndex(Contract.TransactionModel.CONFIRMED)));
-                contentValues.put(Contract.Transaction.COUNT_IN_TOTAL, cursor.getInt(cursor.getColumnIndex(Contract.TransactionModel.COUNT_IN_TOTAL)));
+                ContentValues contentValues = new TransactionContentValuesBuilder()
+                        .money(cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.MONEY)))
+                        .date(DateUtils.getSQLDateTimeString(new Date()))
+                        .description(cursor.getString(cursor.getColumnIndex(Contract.TransactionModel.DESCRIPTION)))
+                        .categoryId(cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.CATEGORY_ID)))
+                        .direction(cursor.getInt(cursor.getColumnIndex(Contract.TransactionModel.DIRECTION)))
+                        .type(Contract.TransactionType.STANDARD)
+                        .walletId(cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.WALLET_ID)))
+                        .placeId(cursor.isNull(cursor.getColumnIndex(Contract.TransactionModel.PLACE_ID)) ? null : cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.PLACE_ID)))
+                        .note(cursor.getString(cursor.getColumnIndex(Contract.TransactionModel.NOTE)))
+                        .eventId(cursor.isNull(cursor.getColumnIndex(Contract.TransactionModel.EVENT_ID)) ? null : cursor.getLong(cursor.getColumnIndex(Contract.TransactionModel.EVENT_ID)))
+                        .confirmed(cursor.getInt(cursor.getColumnIndex(Contract.TransactionModel.CONFIRMED)))
+                        .countInTotal(cursor.getInt(cursor.getColumnIndex(Contract.TransactionModel.COUNT_IN_TOTAL)))
+                        .build();
                 resultUri = contentResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
             }
             cursor.close();

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferActivity.java
@@ -55,6 +55,7 @@ import com.oriondev.moneywallet.picker.PlacePicker;
 import com.oriondev.moneywallet.picker.WalletPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.TransferContentValuesBuilder;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.AttachmentView;
 import com.oriondev.moneywallet.ui.view.text.MaterialEditText;
@@ -638,22 +639,23 @@ public class NewEditTransferActivity extends NewEditItemActivity  implements Cur
     @Override
     protected void onSaveChanges(Mode mode) {
         if (validate()) {
-            ContentValues contentValues = new ContentValues();
-            contentValues.put(Contract.Transfer.DESCRIPTION, mDescriptionEditText.getTextAsString());
-            contentValues.put(Contract.Transfer.DATE, DateUtils.getSQLDateTimeString(mDateTimePicker.getCurrentDateTime()));
-            contentValues.put(Contract.Transfer.TRANSACTION_FROM_WALLET_ID, mWalletFromPicker.getCurrentWallet().getId());
-            contentValues.put(Contract.Transfer.TRANSACTION_TO_WALLET_ID, mWalletToPicker.getCurrentWallet().getId());
-            contentValues.put(Contract.Transfer.TRANSACTION_TAX_WALLET_ID, mWalletFromPicker.getCurrentWallet().getId());
-            contentValues.put(Contract.Transfer.TRANSACTION_FROM_MONEY, mMoneyPicker.getCurrentMoney());
-            contentValues.put(Contract.Transfer.TRANSACTION_TO_MONEY, mConverterPicker.convert(mMoneyPicker.getCurrentMoney()));
-            contentValues.put(Contract.Transfer.TRANSACTION_TAX_MONEY, mTaxPicker.getCurrentMoney());
-            contentValues.put(Contract.Transfer.NOTE, mNoteEditText.getTextAsString());
-            contentValues.put(Contract.Transfer.PLACE_ID, mPlacePicker.isSelected() ? mPlacePicker.getCurrentPlace().getId() : null);
-            contentValues.put(Contract.Transfer.EVENT_ID, mEventPicker.isSelected() ? mEventPicker.getCurrentEvent().getId() : null);
-            contentValues.put(Contract.Transfer.CONFIRMED, mConfirmedCheckBox.isChecked());
-            contentValues.put(Contract.Transfer.COUNT_IN_TOTAL, mCountInTotalCheckBox.isChecked());
-            contentValues.put(Contract.Transfer.PEOPLE_IDS, Contract.getObjectIds(mPersonPicker.getCurrentPeople()));
-            contentValues.put(Contract.Transfer.ATTACHMENT_IDS, Contract.getObjectIds(mAttachmentPicker.getCurrentAttachments()));
+            ContentValues contentValues = new TransferContentValuesBuilder()
+                    .description(mDescriptionEditText.getTextAsString())
+                    .date(DateUtils.getSQLDateTimeString(mDateTimePicker.getCurrentDateTime()))
+                    .fromWalletId(mWalletFromPicker.getCurrentWallet().getId())
+                    .toWalletId(mWalletToPicker.getCurrentWallet().getId())
+                    .taxWalletId(mWalletFromPicker.getCurrentWallet().getId())
+                    .fromMoney(mMoneyPicker.getCurrentMoney())
+                    .toMoney(mConverterPicker.convert(mMoneyPicker.getCurrentMoney()))
+                    .taxMoney(mTaxPicker.getCurrentMoney())
+                    .note(mNoteEditText.getTextAsString())
+                    .placeId(mPlacePicker.isSelected() ? mPlacePicker.getCurrentPlace().getId() : null)
+                    .eventId(mEventPicker.isSelected() ? mEventPicker.getCurrentEvent().getId() : null)
+                    .confirmed(mConfirmedCheckBox.isChecked())
+                    .countInTotal(mCountInTotalCheckBox.isChecked())
+                    .peopleIds(Contract.getObjectIds(mPersonPicker.getCurrentPeople()))
+                    .attachmentIds(Contract.getObjectIds(mAttachmentPicker.getCurrentAttachments()))
+                    .build();
             ContentResolver contentResolver = getContentResolver();
             switch (mode) {
                 case NEW_ITEM:
@@ -690,20 +692,21 @@ public class NewEditTransferActivity extends NewEditItemActivity  implements Cur
         if (cursor != null) {
             Uri resultUri = null;
             if (cursor.moveToFirst()) {
-                ContentValues contentValues = new ContentValues();
-                contentValues.put(Contract.Transfer.DESCRIPTION, cursor.getString(cursor.getColumnIndex(Contract.TransferModel.DESCRIPTION)));
-                contentValues.put(Contract.Transfer.DATE, DateUtils.getSQLDateTimeString(new Date()));
-                contentValues.put(Contract.Transfer.TRANSACTION_FROM_WALLET_ID, cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.WALLET_FROM_ID)));
-                contentValues.put(Contract.Transfer.TRANSACTION_TO_WALLET_ID, cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.WALLET_TO_ID)));
-                contentValues.put(Contract.Transfer.TRANSACTION_TAX_WALLET_ID, cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.WALLET_FROM_ID)));
-                contentValues.put(Contract.Transfer.TRANSACTION_FROM_MONEY, cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.MONEY_FROM)));
-                contentValues.put(Contract.Transfer.TRANSACTION_TO_MONEY, cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.MONEY_TO)));
-                contentValues.put(Contract.Transfer.TRANSACTION_TAX_MONEY, cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.MONEY_TAX)));
-                contentValues.put(Contract.Transfer.NOTE, cursor.getString(cursor.getColumnIndex(Contract.TransferModel.NOTE)));
-                contentValues.put(Contract.Transfer.PLACE_ID, cursor.isNull(cursor.getColumnIndex(Contract.TransferModel.PLACE_ID)) ? null : cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.PLACE_ID)));
-                contentValues.put(Contract.Transfer.EVENT_ID, cursor.isNull(cursor.getColumnIndex(Contract.TransferModel.EVENT_ID)) ? null : cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.EVENT_ID)));
-                contentValues.put(Contract.Transfer.CONFIRMED, cursor.getInt(cursor.getColumnIndex(Contract.TransferModel.CONFIRMED)));
-                contentValues.put(Contract.Transfer.COUNT_IN_TOTAL, cursor.getInt(cursor.getColumnIndex(Contract.TransferModel.COUNT_IN_TOTAL)));
+                ContentValues contentValues = new TransferContentValuesBuilder()
+                        .description(cursor.getString(cursor.getColumnIndex(Contract.TransferModel.DESCRIPTION)))
+                        .date(DateUtils.getSQLDateTimeString(new Date()))
+                        .fromWalletId(cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.WALLET_FROM_ID)))
+                        .toWalletId(cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.WALLET_TO_ID)))
+                        .taxWalletId(cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.WALLET_FROM_ID)))
+                        .fromMoney(cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.MONEY_FROM)))
+                        .toMoney(cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.MONEY_TO)))
+                        .taxMoney(cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.MONEY_TAX)))
+                        .note(cursor.getString(cursor.getColumnIndex(Contract.TransferModel.NOTE)))
+                        .placeId(cursor.isNull(cursor.getColumnIndex(Contract.TransferModel.PLACE_ID)) ? null : cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.PLACE_ID)))
+                        .eventId(cursor.isNull(cursor.getColumnIndex(Contract.TransferModel.EVENT_ID)) ? null : cursor.getLong(cursor.getColumnIndex(Contract.TransferModel.EVENT_ID)))
+                        .confirmed(cursor.getInt(cursor.getColumnIndex(Contract.TransferModel.CONFIRMED)))
+                        .countInTotal(cursor.getInt(cursor.getColumnIndex(Contract.TransferModel.COUNT_IN_TOTAL)))
+                        .build();
                 resultUri = contentResolver.insert(DataContentProvider.CONTENT_TRANSFERS, contentValues);
             }
             cursor.close();


### PR DESCRIPTION
## What

The column set that defines a transaction row, and the column set that defines a transfer row, were duplicated across several `ContentValues` put blocks in four files. This change gives each entity one home for its write-path column names.

Two small builders now hold every `Contract.Transaction.*` / `Contract.Transfer.*` column name used on the write path (outside `SQLDatabase`, which stays the implementation side of the seam):

- `storage/database/TransactionContentValuesBuilder.java`
- `storage/database/TransferContentValuesBuilder.java`

Each builder wraps a `ContentValues` and exposes one optional typed setter per column, returning `this` for chaining, with a final `build()`. A caller sets only the columns it actually provides, so per-caller column sets are preserved exactly.

## Blast radius

Seven put blocks in four files became builder calls, and no other file was touched:

1. `ui/activity/NewEditTransactionActivity.java`, two transaction blocks (the manual `onSaveChanges`, and the model-to-transaction insert).
2. `ui/activity/NewEditTransferActivity.java`, two transfer blocks (the manual `onSaveChanges`, and the model-to-transfer insert).
3. `service/RecurrenceHandlerIntentService.java`, one transaction block and one transfer block when materializing a recurrence occurrence.
4. `storage/database/data/AbstractDataImporter.java`, one transaction block for an imported row.

`SQLDatabase.java` is intentionally left untouched: its puts are the persistence side of the seam, not the caller side.

## Behavior preserved, including the asymmetries between blocks

This is a pure locality change with zero behavior change. The blocks did not all set the same columns or use the same value types, and those differences are preserved rather than unified:

- Optional columns stay optional per caller: `SAVING_ID` and `DEBT_ID` are set only by the manual add/edit screen; `RECURRENCE_ID` only by the recurrence path; `PEOPLE_IDS` by the manual screen and the importer only; `ATTACHMENT_IDS` by the manual screen only. Each caller now simply omits the setter it never called before.
- `CONFIRMED` and `COUNT_IN_TOTAL` are stored as a boolean by the manual, recurrence, and import paths, but as the raw cursor int by the two model-to-row paths. Both builders keep a `boolean` and an `int` overload for these two setters, so every call site stores the same value type it stored before, with no conversion.
- `PLACE_ID` and `EVENT_ID` null convention differs by caller: the manual, model, and import paths always write the column (with an explicit null when absent), while the recurrence path omits the column entirely when the source is null. This is preserved by keeping the recurrence path's `if (!cursor.isNull(...))` guard around the setter call; the always-write callers just pass their existing nullable value.

`ContentValues` is a map, so put order does not affect the stored row; the builders keep each caller's exact key set and value types.

## Verified

- Clean floss debug gate green under JDK 17: `./gradlew clean testFlossOsmDebugUnitTest assembleFlossOsmDebug` reports `BUILD SUCCESSFUL`.
- Existing unit tests pass (30 tests, 0 failures, 0 errors, 0 skipped).
- Block-by-block review of the seven sites: same columns, same value expressions, same null handling as before.

No JVM unit test was added. `ContentValues` is an Android framework class that is not usable from plain JVM unit tests, and the only clean ways to exercise it here would need Robolectric (not a current dependency) or a design change to inject the map. The win here is locality, verified by the build gate and the block-by-block diff.
