### PR TITLE
Register backup backends from one descriptor list per flavor

### DIFF
--- a/app/src/floss/java/com/oriondev/moneywallet/api/BackendServiceFactory.java
+++ b/app/src/floss/java/com/oriondev/moneywallet/api/BackendServiceFactory.java
@@ -43,43 +43,87 @@ public class BackendServiceFactory {
     public static final String SERVICE_ID_EXTERNAL_MEMORY = "external_memory";
     public static final String SERVICE_ID_SAF = "storage_access_framework";
 
-    public static AbstractBackendServiceDelegate getServiceById(String backendId, AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
-        switch (backendId) {
-            case SERVICE_ID_EXTERNAL_MEMORY:
+    private static final List<BackendDescriptor> DESCRIPTORS = buildDescriptors();
+
+    private static List<BackendDescriptor> buildDescriptors() {
+        List<BackendDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(new BackendDescriptor(SERVICE_ID_EXTERNAL_MEMORY, R.drawable.ic_sd_24dp) {
+            @Override
+            public AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
                 return new DiskBackendService(listener);
-            case SERVICE_ID_SAF:
+            }
+
+            @Override
+            public IBackendServiceAPI createServiceApi(Context context) throws BackendException {
+                return new DiskBackendServiceAPI();
+            }
+
+            @Override
+            public IFile createFile(String encoded) {
+                return new LocalFile(encoded);
+            }
+        });
+        descriptors.add(new BackendDescriptor(SERVICE_ID_SAF, R.drawable.ic_storage_black_24dp) {
+            @Override
+            public boolean isAvailable() {
+                return Build.VERSION.SDK_INT >= 21;
+            }
+
+            @Override
+            public AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
                 return new SAFBackendService(listener);
+            }
+
+            @Override
+            public IBackendServiceAPI createServiceApi(Context context) throws BackendException {
+                return new SAFBackendServiceAPI(context);
+            }
+
+            @Override
+            public IFile createFile(String encoded) {
+                return SAFFile.decode(encoded);
+            }
+        });
+        return descriptors;
+    }
+
+    private static BackendDescriptor findDescriptor(String backendId) {
+        for (BackendDescriptor descriptor : DESCRIPTORS) {
+            if (descriptor.getId().equals(backendId)) {
+                return descriptor;
+            }
         }
         return null;
     }
 
+    public static AbstractBackendServiceDelegate getServiceById(String backendId, AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
+        BackendDescriptor descriptor = findDescriptor(backendId);
+        return descriptor != null ? descriptor.createDelegate(listener) : null;
+    }
+
     public static IBackendServiceAPI getServiceAPIById(Context context, String backendId) throws BackendException {
-        switch (backendId) {
-            case SERVICE_ID_EXTERNAL_MEMORY:
-                return new DiskBackendServiceAPI();
-            case SERVICE_ID_SAF:
-                return new SAFBackendServiceAPI(context);
-            default:
-                throw new BackendException("Invalid backend");
+        BackendDescriptor descriptor = findDescriptor(backendId);
+        if (descriptor == null) {
+            throw new BackendException("Invalid backend");
         }
+        return descriptor.createServiceApi(context);
     }
 
     public static List<BackupService> getBackupServices() {
         List<BackupService> services = new ArrayList<>();
-        services.add(new BackupService(SERVICE_ID_EXTERNAL_MEMORY, R.drawable.ic_sd_24dp, R.string.service_backup_external_memory));
-        if (Build.VERSION.SDK_INT >= 21) {
-            services.add(new BackupService(SERVICE_ID_SAF, R.drawable.ic_storage_black_24dp, R.string.service_backup_storage_access_framework));
+        for (BackendDescriptor descriptor : DESCRIPTORS) {
+            if (descriptor.isAvailable()) {
+                services.add(new BackupService(descriptor.getId(), descriptor.getIconRes(), descriptor.getNameRes()));
+            }
         }
         return services;
     }
 
     public static IFile getFile(String backendId, String encoded) {
         if (encoded != null) {
-            switch (backendId) {
-                case SERVICE_ID_EXTERNAL_MEMORY:
-                    return new LocalFile(encoded);
-                case SERVICE_ID_SAF:
-                    return SAFFile.decode(encoded);
+            BackendDescriptor descriptor = findDescriptor(backendId);
+            if (descriptor != null) {
+                return descriptor.createFile(encoded);
             }
         }
         return null;

--- a/app/src/main/java/com/oriondev/moneywallet/api/AbstractBackendServiceDelegate.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/AbstractBackendServiceDelegate.java
@@ -62,6 +62,14 @@ public abstract class AbstractBackendServiceDelegate {
         return false;
     }
 
+    /**
+     * Whether the user can disconnect (forget/revoke) this backend. Most backends can be
+     * disconnected; the local external-memory backend cannot, since it holds no session to drop.
+     */
+    public boolean isDisconnectable() {
+        return true;
+    }
+
     protected void setBackendServiceEnabled(boolean enabled) {
         if (mListener != null) {
             mListener.onBackendStatusChange(enabled);

--- a/app/src/main/java/com/oriondev/moneywallet/api/BackendDescriptor.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/BackendDescriptor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.api;
+
+import android.content.Context;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.StringRes;
+
+import com.oriondev.moneywallet.model.IFile;
+
+/**
+ * Single source of truth for one backup backend. Each flavor's {@code BackendServiceFactory}
+ * holds a list of these instead of four parallel switch statements: the id is the lookup key,
+ * the icon is carried here (the delegate has no icon accessor), and everything else is created
+ * on demand. The backend name is read back from the delegate so it is not re-declared here.
+ */
+public abstract class BackendDescriptor {
+
+    private final String mId;
+    private final int mIconRes;
+
+    protected BackendDescriptor(String id, @DrawableRes int iconRes) {
+        mId = id;
+        mIconRes = iconRes;
+    }
+
+    public String getId() {
+        return mId;
+    }
+
+    @DrawableRes
+    public int getIconRes() {
+        return mIconRes;
+    }
+
+    /**
+     * The backend name, taken from the delegate's own metadata so it lives in exactly one place.
+     */
+    @StringRes
+    public int getNameRes() {
+        return createDelegate(null).getName();
+    }
+
+    /**
+     * Whether this backend is usable on the current device. Defaults to true; backends gated on
+     * an SDK level (e.g. the storage access framework) override this.
+     */
+    public boolean isAvailable() {
+        return true;
+    }
+
+    public abstract AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener);
+
+    public abstract IBackendServiceAPI createServiceApi(Context context) throws BackendException;
+
+    public abstract IFile createFile(String encoded);
+}

--- a/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendService.java
@@ -76,6 +76,13 @@ public class DiskBackendService extends AbstractBackendServiceDelegate {
     }
 
     @Override
+    public boolean isDisconnectable() {
+        // The local external-memory backend cannot be disconnected: there is no remote session
+        // or persisted grant to revoke, only a runtime storage permission.
+        return false;
+    }
+
+    @Override
     public void setup(final ComponentActivity activity) throws BackendException {
         final ActivityResultLauncher<String> launcher = activity.registerForActivityResult(
                 new ActivityResultContracts.RequestPermission(),

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
@@ -267,7 +267,7 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
     protected void hideCoverView() {
         if (mCoverLayout != null) {
             // setup menu item visibility
-            setMenuItemVisibility(R.id.action_disconnect, !BackendServiceFactory.SERVICE_ID_EXTERNAL_MEMORY.equals(mBackendService.getId()));
+            setMenuItemVisibility(R.id.action_disconnect, mBackendService.isDisconnectable());
             // setup layout visibility
             mCoverLayout.setVisibility(View.GONE);
             mPrimaryLayout.setVisibility(View.VISIBLE);

--- a/app/src/proprietary/java/com/oriondev/moneywallet/api/BackendServiceFactory.java
+++ b/app/src/proprietary/java/com/oriondev/moneywallet/api/BackendServiceFactory.java
@@ -51,57 +51,119 @@ public class BackendServiceFactory {
     public static final String SERVICE_ID_EXTERNAL_MEMORY = "external_memory";
     public static final String SERVICE_ID_SAF = "storage_access_framework";
 
-    public static AbstractBackendServiceDelegate getServiceById(String backendId, AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
-        switch (backendId) {
-            case SERVICE_ID_DROPBOX:
+    private static final List<BackendDescriptor> DESCRIPTORS = buildDescriptors();
+
+    private static List<BackendDescriptor> buildDescriptors() {
+        List<BackendDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(new BackendDescriptor(SERVICE_ID_DROPBOX, R.drawable.ic_dropbox_24dp) {
+            @Override
+            public AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
                 return new DropboxBackendService(listener);
-            case SERVICE_ID_GOOGLE_DRIVE:
+            }
+
+            @Override
+            public IBackendServiceAPI createServiceApi(Context context) throws BackendException {
+                return new DropboxBackendServiceAPI(context);
+            }
+
+            @Override
+            public IFile createFile(String encoded) {
+                return new DropBoxFile(encoded);
+            }
+        });
+        descriptors.add(new BackendDescriptor(SERVICE_ID_GOOGLE_DRIVE, R.drawable.ic_google_drive_24dp) {
+            @Override
+            public AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
                 return new GoogleDriveBackendService(listener);
-            case SERVICE_ID_EXTERNAL_MEMORY:
+            }
+
+            @Override
+            public IBackendServiceAPI createServiceApi(Context context) throws BackendException {
+                return new GoogleDriveBackendServiceAPI(context);
+            }
+
+            @Override
+            public IFile createFile(String encoded) {
+                return new GoogleDriveFile(encoded);
+            }
+        });
+        descriptors.add(new BackendDescriptor(SERVICE_ID_EXTERNAL_MEMORY, R.drawable.ic_sd_24dp) {
+            @Override
+            public AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
                 return new DiskBackendService(listener);
-            case SERVICE_ID_SAF:
+            }
+
+            @Override
+            public IBackendServiceAPI createServiceApi(Context context) throws BackendException {
+                return new DiskBackendServiceAPI();
+            }
+
+            @Override
+            public IFile createFile(String encoded) {
+                return new LocalFile(encoded);
+            }
+        });
+        descriptors.add(new BackendDescriptor(SERVICE_ID_SAF, R.drawable.ic_storage_black_24dp) {
+            @Override
+            public boolean isAvailable() {
+                return Build.VERSION.SDK_INT >= 21;
+            }
+
+            @Override
+            public AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
                 return new SAFBackendService(listener);
+            }
+
+            @Override
+            public IBackendServiceAPI createServiceApi(Context context) throws BackendException {
+                return new SAFBackendServiceAPI(context);
+            }
+
+            @Override
+            public IFile createFile(String encoded) {
+                return SAFFile.decode(encoded);
+            }
+        });
+        return descriptors;
+    }
+
+    private static BackendDescriptor findDescriptor(String backendId) {
+        for (BackendDescriptor descriptor : DESCRIPTORS) {
+            if (descriptor.getId().equals(backendId)) {
+                return descriptor;
+            }
         }
         return null;
     }
 
+    public static AbstractBackendServiceDelegate getServiceById(String backendId, AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
+        BackendDescriptor descriptor = findDescriptor(backendId);
+        return descriptor != null ? descriptor.createDelegate(listener) : null;
+    }
+
     public static IBackendServiceAPI getServiceAPIById(Context context, String backendId) throws BackendException {
-        switch (backendId) {
-            case SERVICE_ID_DROPBOX:
-                return new DropboxBackendServiceAPI(context);
-            case SERVICE_ID_GOOGLE_DRIVE:
-                return new GoogleDriveBackendServiceAPI(context);
-            case SERVICE_ID_EXTERNAL_MEMORY:
-                return new DiskBackendServiceAPI();
-            case SERVICE_ID_SAF:
-                return new SAFBackendServiceAPI(context);
-            default:
-                throw new BackendException("Invalid backend");
+        BackendDescriptor descriptor = findDescriptor(backendId);
+        if (descriptor == null) {
+            throw new BackendException("Invalid backend");
         }
+        return descriptor.createServiceApi(context);
     }
 
     public static List<BackupService> getBackupServices() {
         List<BackupService> services = new ArrayList<>();
-        services.add(new BackupService(SERVICE_ID_DROPBOX, R.drawable.ic_dropbox_24dp, R.string.service_backup_drop_box));
-        services.add(new BackupService(SERVICE_ID_GOOGLE_DRIVE, R.drawable.ic_google_drive_24dp, R.string.service_backup_google_drive));
-        services.add(new BackupService(SERVICE_ID_EXTERNAL_MEMORY, R.drawable.ic_sd_24dp, R.string.service_backup_external_memory));
-        if (Build.VERSION.SDK_INT >= 21) {
-            services.add(new BackupService(SERVICE_ID_SAF, R.drawable.ic_storage_black_24dp, R.string.service_backup_storage_access_framework));
+        for (BackendDescriptor descriptor : DESCRIPTORS) {
+            if (descriptor.isAvailable()) {
+                services.add(new BackupService(descriptor.getId(), descriptor.getIconRes(), descriptor.getNameRes()));
+            }
         }
         return services;
     }
 
     public static IFile getFile(String backendId, String encoded) {
         if (encoded != null) {
-            switch (backendId) {
-                case SERVICE_ID_DROPBOX:
-                    return new DropBoxFile(encoded);
-                case SERVICE_ID_GOOGLE_DRIVE:
-                    return new GoogleDriveFile(encoded);
-                case SERVICE_ID_EXTERNAL_MEMORY:
-                    return new LocalFile(encoded);
-                case SERVICE_ID_SAF:
-                    return new SAFFile(encoded);
+            BackendDescriptor descriptor = findDescriptor(backendId);
+            if (descriptor != null) {
+                return descriptor.createFile(encoded);
             }
         }
         return null;


### PR DESCRIPTION
## What

Backend registration for the backup services used to be four parallel `switch`
statements per flavor. Each flavor's `BackendServiceFactory` switched over the
same set of `SERVICE_ID_*` in `getServiceById`, `getServiceAPIById`,
`getBackupServices`, and `getFile`, and `getBackupServices` re-declared each
backend's name string even though the delegate already exposes it. Adding a
backend meant editing four switches in both flavor files.

This replaces those switches with a single list of descriptors per flavor. The
backup-backend seam itself (`IBackendServiceAPI`, `AbstractBackendServiceDelegate`,
the per-backend adapters) is untouched; only registration changed.

## Mechanism

New `BackendDescriptor` (shared main source) carries a backend's id and icon and
knows how to create its delegate, its service API, and its `IFile` from an encoded
string. Each flavor factory assembles one list of descriptors; the four public
methods became a lookup or a loop over that list:

- `getServiceById` / `getServiceAPIById` / `getFile` look the id up in the list.
- `getBackupServices` loops the list, skipping any descriptor whose `isAvailable()`
  is false (the storage-access-framework descriptor gates itself on SDK >= 21, as
  before).

Public method signatures are unchanged, so every caller elsewhere in the app keeps
compiling untouched. The backend name is read back from the delegate's own
`getName()` so it is declared in one place; the icon stays on the descriptor
because the delegate has no icon accessor.

## SAF getFile: decode, not the raw constructor

For `SERVICE_ID_SAF` the two flavors had diverged. floss already used
`SAFFile.decode(encoded)`; proprietary still used `new SAFFile(encoded)`. Both
flavors now use `SAFFile.decode(encoded)`. Reasoning:

- `new SAFFile(encoded)` throws a `RuntimeException` when the value is not a valid
  encoded descriptor (for example a legacy raw path persisted by an older version).
- `SAFFile.decode(encoded)` returns null for that same input instead of throwing
  (added for issue #177, where a legacy auto-backup path crashed the app in
  `Application.onCreate`).
- Both `getFile` callers already treat null as "location missing, skip":
  `AutoBackupBroadcastReceiver` explicitly logs and continues on null, and
  `AutoBackupSettingDialog` stores the null and renders the empty-folder state.

So the fail-soft `decode` is the correct semantic for an encoded string that may be
a legacy or corrupt value, and the proprietary flavor was the one carrying the
crashing behavior. Unifying on `decode` fixes that divergence.

## Capability moved onto the seam

`hideCoverView()` in the backup handler fragment hard-coded
`SERVICE_ID_EXTERNAL_MEMORY.equals(...)` to decide whether the disconnect action is
shown. That "cannot be disconnected" fact belongs on the backend, not the fragment.
`AbstractBackendServiceDelegate` now exposes `isDisconnectable()` (default true,
overridden to false by the external-memory delegate, which has no session or grant
to revoke), and the fragment asks the delegate. Behavior is identical.

`LocalFilePicker`'s use of `SERVICE_ID_EXTERNAL_MEMORY` is left as is: it is the
local file picker deliberately selecting the local backend to browse on-device
storage, not a capability check, so it stays a direct reference.

## Blast radius

- `app/src/main/.../api/BackendDescriptor.java` (new, shared)
- `app/src/floss/.../api/BackendServiceFactory.java` (2 descriptors)
- `app/src/proprietary/.../api/BackendServiceFactory.java` (4 descriptors, plus the SAF unification)
- `app/src/main/.../api/AbstractBackendServiceDelegate.java` (+ `isDisconnectable()`)
- `app/src/main/.../api/disk/DiskBackendService.java` (overrides `isDisconnectable()`)
- `app/src/main/.../ui/fragment/secondary/BackupHandlerFragment.java` (asks the delegate)

## Verification

- floss debug variant: `clean testFlossOsmDebugUnitTest assembleFlossOsmDebug`
  BUILD SUCCESSFUL, 30 unit tests pass, 0 failures. This compiles the new descriptor
  and the floss factory and assembles them into the APK.
- proprietary flavor Java changes mirror the floss ones and reuse the exact
  delegate, API, and `IFile` constructor signatures the old proprietary switches
  used (all verified present). The proprietary variant cannot be assembled in this
  environment because of a pre-existing, unrelated manifest-merger requirement
  (the Dropbox SDK's `AuthActivity` needs an explicit `android:exported` for Android
  12 and higher); that failure reproduces identically on `master` and happens before
  Java compilation, so it is not introduced by this change.
