### PR TITLE
Compute recurrence occurrences once in the model

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/broadcast/RecurrenceBroadcastReceiver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/broadcast/RecurrenceBroadcastReceiver.java
@@ -45,8 +45,10 @@ public class RecurrenceBroadcastReceiver extends BroadcastReceiver {
     public static void scheduleRecurrenceTask(Context context) {
         cancelPendingIntent(context);
         ContentResolver contentResolver = context.getContentResolver();
-        Date nextOccurrence1 = getMinNextRecurrentTransactionOccurrence(contentResolver);
-        Date nextOccurrence2 = getMinNextRecurrentTransferOccurrence(contentResolver);
+        Date nextOccurrence1 = getMinNextOccurrence(contentResolver,
+                DataContentProvider.CONTENT_RECURRENT_TRANSACTIONS, Contract.RecurrentTransaction.NEXT_OCCURRENCE);
+        Date nextOccurrence2 = getMinNextOccurrence(contentResolver,
+                DataContentProvider.CONTENT_RECURRENT_TRANSFERS, Contract.RecurrentTransfer.NEXT_OCCURRENCE);
         Date nextOccurrence = getMinDate(nextOccurrence1, nextOccurrence2);
         if (nextOccurrence != null) {
             System.out.println("[ALARM] Next occurrence is at: " + nextOccurrence.toString());
@@ -58,31 +60,11 @@ public class RecurrenceBroadcastReceiver extends BroadcastReceiver {
         }
     }
 
-    private static Date getMinNextRecurrentTransactionOccurrence(ContentResolver contentResolver) {
-        Uri uri = DataContentProvider.CONTENT_RECURRENT_TRANSACTIONS;
+    private static Date getMinNextOccurrence(ContentResolver contentResolver, Uri uri, String nextOccurrenceColumn) {
         String[] projection = new String[] {
-                "MIN(" + Contract.RecurrentTransaction.NEXT_OCCURRENCE + ")"
+                "MIN(" + nextOccurrenceColumn + ")"
         };
-        String selection = Contract.RecurrentTransaction.NEXT_OCCURRENCE  + " IS NOT NULL";
-        Cursor cursor = contentResolver.query(uri, projection, selection, null, null);
-        if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                String nextOccurrenceString = cursor.getString(0);
-                if (!TextUtils.isEmpty(nextOccurrenceString)) {
-                    return DateUtils.getDateFromSQLDateString(nextOccurrenceString);
-                }
-            }
-            cursor.close();
-        }
-        return null;
-    }
-
-    private static Date getMinNextRecurrentTransferOccurrence(ContentResolver contentResolver) {
-        Uri uri = DataContentProvider.CONTENT_RECURRENT_TRANSFERS;
-        String[] projection = new String[] {
-                "MIN(" + Contract.RecurrentTransfer.NEXT_OCCURRENCE + ")"
-        };
-        String selection = Contract.RecurrentTransfer.NEXT_OCCURRENCE  + " IS NOT NULL";
+        String selection = nextOccurrenceColumn + " IS NOT NULL";
         Cursor cursor = contentResolver.query(uri, projection, selection, null, null);
         if (cursor != null) {
             if (cursor.moveToFirst()) {

--- a/app/src/main/java/com/oriondev/moneywallet/model/RecurrenceSetting.java
+++ b/app/src/main/java/com/oriondev/moneywallet/model/RecurrenceSetting.java
@@ -280,6 +280,97 @@ public class RecurrenceSetting implements Parcelable {
         return nextOccurrenceDateTime != null ? DateUtils.getFixedDate(nextOccurrenceDateTime) : null;
     }
 
+    /**
+     * Immutable result of {@link #computeOccurrences(String, Date, Date)}: the occurrence dates
+     * that have come due inside the window, plus the values the LAST_OCCURRENCE and
+     * NEXT_OCCURRENCE columns must be updated to afterwards. Every date is already normalised
+     * through {@link DateUtils#getFixedDate(DateTime)}, so callers only format and store it.
+     */
+    public static class OccurrenceUpdate {
+
+        private final List<Date> mOccurrenceDates;
+        private final Date mLastOccurrence;
+        private final Date mNextOccurrence;
+
+        private OccurrenceUpdate(List<Date> occurrenceDates, Date lastOccurrence, Date nextOccurrence) {
+            mOccurrenceDates = occurrenceDates;
+            mLastOccurrence = lastOccurrence;
+            mNextOccurrence = nextOccurrence;
+        }
+
+        /**
+         * The occurrence dates, in chronological order, for which a ledger row must be inserted.
+         */
+        public List<Date> getOccurrenceDates() {
+            return mOccurrenceDates;
+        }
+
+        /**
+         * The value the LAST_OCCURRENCE column must be set to: the last due occurrence, or the
+         * seed itself when nothing came due.
+         */
+        public Date getLastOccurrence() {
+            return mLastOccurrence;
+        }
+
+        /**
+         * The value the NEXT_OCCURRENCE column must be set to: the first instance after the
+         * window, or null when the rule is exhausted (or failed to parse).
+         */
+        public Date getNextOccurrence() {
+            return mNextOccurrence;
+        }
+    }
+
+    /**
+     * Pure, Android-free computation of the recurrence occurrences that have come due, extracted
+     * verbatim from the loop that {@code RecurrenceHandlerIntentService} used to run inline.
+     *
+     * The rfc5545 iterator is seeded from {@code seedDate} (the stored next occurrence), which per
+     * RFC 5545 is itself the first instance produced. Every instance that is not strictly after
+     * {@code now} (that is, {@code !instance.after(now)}) is collected as due and becomes the new
+     * last occurrence; the first instance strictly after {@code now} becomes the next occurrence
+     * and stops the walk. When the rule exhausts (UNTIL / COUNT) or fails to parse, the next
+     * occurrence is null and the last occurrence stays at the seed, exactly as the service behaved.
+     *
+     * The rule is parsed here from its raw string rather than through a {@link RecurrenceSetting}
+     * instance, so an invalid rule yields no occurrences instead of silently falling back to a
+     * daily rule the way the {@code (Date, String)} constructor does.
+     *
+     * @param rule     the RFC 5545 recurrence rule string stored on the row
+     * @param seedDate the stored next occurrence used to seed the iterator (inclusive first instance)
+     * @param now      the moment the window closes at, compared at day granularity
+     * @return the due occurrence dates and the updated last / next occurrence values
+     */
+    public static OccurrenceUpdate computeOccurrences(String rule, Date seedDate, Date now) {
+        List<Date> occurrenceDates = new ArrayList<>();
+        DateTime currentDateTime = DateUtils.getFixedDateTime(now);
+        DateTime startDateTime = DateUtils.getFixedDateTime(seedDate);
+        DateTime lastOccurrence = DateUtils.getFixedDateTime(seedDate);
+        DateTime nextOccurrence = null;
+        try {
+            RecurrenceRule recurrenceRule = new RecurrenceRule(rule);
+            RecurrenceRuleIterator iterator = recurrenceRule.iterator(startDateTime);
+            while (iterator.hasNext()) {
+                DateTime nextInstance = iterator.nextDateTime();
+                if (!nextInstance.after(currentDateTime)) {
+                    occurrenceDates.add(DateUtils.getFixedDate(nextInstance));
+                    lastOccurrence = nextInstance;
+                } else {
+                    nextOccurrence = nextInstance;
+                    break;
+                }
+            }
+        } catch (InvalidRecurrenceRuleException ignore) {
+            // leave nextOccurrence null so the row is not processed again, matching the old service
+        }
+        return new OccurrenceUpdate(
+                occurrenceDates,
+                DateUtils.getFixedDate(lastOccurrence),
+                nextOccurrence != null ? DateUtils.getFixedDate(nextOccurrence) : null
+        );
+    }
+
     public static class Builder {
 
         private Date mStartDate;

--- a/app/src/main/java/com/oriondev/moneywallet/service/RecurrenceHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/RecurrenceHandlerIntentService.java
@@ -29,16 +29,12 @@ import androidx.annotation.NonNull;
 import androidx.core.app.JobIntentService;
 
 import com.oriondev.moneywallet.broadcast.RecurrenceBroadcastReceiver;
+import com.oriondev.moneywallet.model.RecurrenceSetting;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.database.TransactionContentValuesBuilder;
 import com.oriondev.moneywallet.storage.database.TransferContentValuesBuilder;
 import com.oriondev.moneywallet.utils.DateUtils;
-
-import org.dmfs.rfc5545.DateTime;
-import org.dmfs.rfc5545.recur.InvalidRecurrenceRuleException;
-import org.dmfs.rfc5545.recur.RecurrenceRule;
-import org.dmfs.rfc5545.recur.RecurrenceRuleIterator;
 
 import java.util.Date;
 
@@ -70,51 +66,33 @@ public class RecurrenceHandlerIntentService extends JobIntentService {
                 long transactionId = cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.ID));
                 String firstOccurrenceDateString = cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.NEXT_OCCURRENCE));
                 Date firstOccurrenceDate = DateUtils.getDateFromSQLDateString(firstOccurrenceDateString);
-                DateTime currentDateTime = DateUtils.getFixedDateTime(new Date());
-                DateTime startDateTime = DateUtils.getFixedDateTime(firstOccurrenceDate);
-                DateTime lastOccurrence = DateUtils.getFixedDateTime(firstOccurrenceDate);
-                DateTime nextOccurrence = null;
-                RecurrenceRule recurrenceRule;
-                try {
-                    recurrenceRule = new RecurrenceRule(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.RULE)));
-                    RecurrenceRuleIterator iterator = recurrenceRule.iterator(startDateTime);
-                    while (iterator.hasNext()) {
-                        DateTime nextInstance = iterator.nextDateTime();
-                        if (!nextInstance.after(currentDateTime)) {
-                            Date transactionDate = DateUtils.getFixedDate(nextInstance);
-                            TransactionContentValuesBuilder builder = new TransactionContentValuesBuilder()
-                                    .money(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.MONEY)))
-                                    .date(DateUtils.getSQLDateTimeString(transactionDate))
-                                    .description(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.DESCRIPTION)))
-                                    .categoryId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.CATEGORY_ID)))
-                                    .direction(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.DIRECTION)))
-                                    .type(Contract.TransactionType.STANDARD)
-                                    .walletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.WALLET_ID)))
-                                    .note(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.NOTE)));
-                            if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransaction.PLACE_ID))) {
-                                builder.placeId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.PLACE_ID)));
-                            }
-                            if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransaction.EVENT_ID))) {
-                                builder.eventId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.EVENT_ID)));
-                            }
-                            builder.recurrenceId(transactionId)
-                                    .confirmed(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.CONFIRMED)) == 1)
-                                    .countInTotal(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.COUNT_IN_TOTAL)) == 1);
-                            ContentValues contentValues = builder.build();
-                            getContentResolver().insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
-                            lastOccurrence = nextInstance;
-                        } else {
-                            nextOccurrence = nextInstance;
-                            break;
-                        }
+                String rule = cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.RULE));
+                RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(rule, firstOccurrenceDate, new Date());
+                for (Date occurrenceDate : update.getOccurrenceDates()) {
+                    TransactionContentValuesBuilder builder = new TransactionContentValuesBuilder()
+                            .money(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.MONEY)))
+                            .date(DateUtils.getSQLDateTimeString(occurrenceDate))
+                            .description(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.DESCRIPTION)))
+                            .categoryId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.CATEGORY_ID)))
+                            .direction(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.DIRECTION)))
+                            .type(Contract.TransactionType.STANDARD)
+                            .walletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.WALLET_ID)))
+                            .note(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransaction.NOTE)));
+                    if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransaction.PLACE_ID))) {
+                        builder.placeId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.PLACE_ID)));
                     }
-                } catch (InvalidRecurrenceRuleException ignore) {
-                    // do nothing, next occurrence is still null so this recurrence will
-                    // not be processed again in future
+                    if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransaction.EVENT_ID))) {
+                        builder.eventId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransaction.EVENT_ID)));
+                    }
+                    builder.recurrenceId(transactionId)
+                            .confirmed(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.CONFIRMED)) == 1)
+                            .countInTotal(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransaction.COUNT_IN_TOTAL)) == 1);
+                    ContentValues contentValues = builder.build();
+                    getContentResolver().insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
                 }
                 ContentValues contentValues = new ContentValues();
-                contentValues.put(Contract.RecurrentTransaction.LAST_OCCURRENCE, DateUtils.getSQLDateString(DateUtils.getFixedDate(lastOccurrence)));
-                contentValues.put(Contract.RecurrentTransaction.NEXT_OCCURRENCE, nextOccurrence != null ? DateUtils.getSQLDateString(DateUtils.getFixedDate(nextOccurrence)) : null);
+                contentValues.put(Contract.RecurrentTransaction.LAST_OCCURRENCE, DateUtils.getSQLDateString(update.getLastOccurrence()));
+                contentValues.put(Contract.RecurrentTransaction.NEXT_OCCURRENCE, update.getNextOccurrence() != null ? DateUtils.getSQLDateString(update.getNextOccurrence()) : null);
                 Uri contentUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_RECURRENT_TRANSACTIONS, transactionId);
                 getContentResolver().update(contentUri, contentValues, null, null);
             }
@@ -132,52 +110,34 @@ public class RecurrenceHandlerIntentService extends JobIntentService {
                 long recurrenceId = cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.ID));
                 String firstOccurrenceDateString = cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.NEXT_OCCURRENCE));
                 Date firstOccurrenceDate = DateUtils.getDateFromSQLDateString(firstOccurrenceDateString);
-                DateTime currentDateTime = DateUtils.getFixedDateTime(new Date());
-                DateTime startDateTime = DateUtils.getFixedDateTime(firstOccurrenceDate);
-                DateTime lastOccurrence = DateUtils.getFixedDateTime(firstOccurrenceDate);
-                DateTime nextOccurrence = null;
-                RecurrenceRule recurrenceRule;
-                try {
-                    recurrenceRule = new RecurrenceRule(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.RULE)));
-                    RecurrenceRuleIterator iterator = recurrenceRule.iterator(startDateTime);
-                    while (iterator.hasNext()) {
-                        DateTime nextInstance = iterator.nextDateTime();
-                        if (!nextInstance.after(currentDateTime)) {
-                            Date transferDate = DateUtils.getFixedDate(nextInstance);
-                            TransferContentValuesBuilder builder = new TransferContentValuesBuilder()
-                                    .description(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.DESCRIPTION)))
-                                    .date(DateUtils.getSQLDateTimeString(transferDate))
-                                    .fromWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_FROM_ID)))
-                                    .toWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_TO_ID)))
-                                    .taxWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_FROM_ID)))
-                                    .fromMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_FROM)))
-                                    .toMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_TO)))
-                                    .taxMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_TAX)))
-                                    .note(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.NOTE)));
-                            if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransfer.PLACE_ID))) {
-                                builder.placeId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.PLACE_ID)));
-                            }
-                            if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransfer.EVENT_ID))) {
-                                builder.eventId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.EVENT_ID)));
-                            }
-                            builder.recurrenceId(recurrenceId)
-                                    .confirmed(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.CONFIRMED)) == 1)
-                                    .countInTotal(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.COUNT_IN_TOTAL)) == 1);
-                            ContentValues contentValues = builder.build();
-                            getContentResolver().insert(DataContentProvider.CONTENT_TRANSFERS, contentValues);
-                            lastOccurrence = nextInstance;
-                        } else {
-                            nextOccurrence = nextInstance;
-                            break;
-                        }
+                String rule = cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.RULE));
+                RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(rule, firstOccurrenceDate, new Date());
+                for (Date occurrenceDate : update.getOccurrenceDates()) {
+                    TransferContentValuesBuilder builder = new TransferContentValuesBuilder()
+                            .description(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.DESCRIPTION)))
+                            .date(DateUtils.getSQLDateTimeString(occurrenceDate))
+                            .fromWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_FROM_ID)))
+                            .toWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_TO_ID)))
+                            .taxWalletId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.WALLET_FROM_ID)))
+                            .fromMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_FROM)))
+                            .toMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_TO)))
+                            .taxMoney(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.MONEY_TAX)))
+                            .note(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.NOTE)));
+                    if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransfer.PLACE_ID))) {
+                        builder.placeId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.PLACE_ID)));
                     }
-                } catch (InvalidRecurrenceRuleException ignore) {
-                    // do nothing, next occurrence is still null so this recurrence will
-                    // not be processed again in future
+                    if (!cursor.isNull(cursor.getColumnIndex(Contract.RecurrentTransfer.EVENT_ID))) {
+                        builder.eventId(cursor.getLong(cursor.getColumnIndex(Contract.RecurrentTransfer.EVENT_ID)));
+                    }
+                    builder.recurrenceId(recurrenceId)
+                            .confirmed(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.CONFIRMED)) == 1)
+                            .countInTotal(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.COUNT_IN_TOTAL)) == 1);
+                    ContentValues contentValues = builder.build();
+                    getContentResolver().insert(DataContentProvider.CONTENT_TRANSFERS, contentValues);
                 }
                 ContentValues contentValues = new ContentValues();
-                contentValues.put(Contract.RecurrentTransfer.LAST_OCCURRENCE, DateUtils.getSQLDateString(DateUtils.getFixedDate(lastOccurrence)));
-                contentValues.put(Contract.RecurrentTransfer.NEXT_OCCURRENCE, nextOccurrence != null ? DateUtils.getSQLDateString(DateUtils.getFixedDate(nextOccurrence)) : null);
+                contentValues.put(Contract.RecurrentTransfer.LAST_OCCURRENCE, DateUtils.getSQLDateString(update.getLastOccurrence()));
+                contentValues.put(Contract.RecurrentTransfer.NEXT_OCCURRENCE, update.getNextOccurrence() != null ? DateUtils.getSQLDateString(update.getNextOccurrence()) : null);
                 Uri contentUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_RECURRENT_TRANSFERS, recurrenceId);
                 getContentResolver().update(contentUri, contentValues, null, null);
             }

--- a/app/src/test/java/com/oriondev/moneywallet/model/RecurrenceSettingTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/model/RecurrenceSettingTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.model;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.oriondev.moneywallet.utils.DateUtils;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Host-side coverage for the pure occurrence computation extracted from
+ * {@code RecurrenceHandlerIntentService}. {@link RecurrenceSetting#computeOccurrences(String, Date, Date)}
+ * carries the exact rule that decides when a recurring transaction or transfer silently enters the
+ * ledger, so every semantic the service relied on is pinned here: the seed is the inclusive first
+ * instance, the window boundary is {@code !instance.after(now)}, an exhausted or invalid rule yields
+ * a null next occurrence, and month-end rules skip absent days without crashing.
+ */
+public class RecurrenceSettingTest {
+
+    // ---------------------------------------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------------------------------------
+
+    /** Builds a Date at the given calendar day (month is 0-based, as everywhere in this codebase). */
+    private static Date day(int year, int month, int dayOfMonth) {
+        return DateUtils.getDate(year, month, dayOfMonth);
+    }
+
+    /** Asserts a computed Date falls on the expected calendar day, ignoring time-of-day. */
+    private static void assertDay(Date date, int year, int month, int dayOfMonth) {
+        assertNotNull(date);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        assertEquals(year, calendar.get(Calendar.YEAR));
+        assertEquals(month, calendar.get(Calendar.MONTH));
+        assertEquals(dayOfMonth, calendar.get(Calendar.DAY_OF_MONTH));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // instantiability
+    // ---------------------------------------------------------------------------------------------
+
+    /**
+     * The model class carries android.os.Parcelable plumbing, so first prove it loads and works in a
+     * plain JVM test: construct it and exercise the legacy getNextOccurrence the importer depends on.
+     */
+    @Test
+    public void recurrenceSettingIsInstantiableInPlainJvm() {
+        RecurrenceSetting setting = new RecurrenceSetting(day(2020, 0, 1), "FREQ=DAILY");
+        assertNotNull(setting.getRule());
+        Date next = setting.getNextOccurrence(day(2020, 0, 1));
+        assertDay(next, 2020, 0, 2);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // daily / weekly / monthly advancement between a seed and a now
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void dailyAdvancementCollectsEveryDayUpToNow() {
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "FREQ=DAILY", day(2020, 0, 1), day(2020, 0, 5));
+        List<Date> dates = update.getOccurrenceDates();
+        assertEquals(5, dates.size());
+        assertDay(dates.get(0), 2020, 0, 1);
+        assertDay(dates.get(1), 2020, 0, 2);
+        assertDay(dates.get(2), 2020, 0, 3);
+        assertDay(dates.get(3), 2020, 0, 4);
+        assertDay(dates.get(4), 2020, 0, 5);
+        assertDay(update.getLastOccurrence(), 2020, 0, 5);
+        assertDay(update.getNextOccurrence(), 2020, 0, 6);
+    }
+
+    @Test
+    public void weeklyAdvancementSteppsSevenDays() {
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "FREQ=WEEKLY", day(2020, 0, 1), day(2020, 0, 20));
+        List<Date> dates = update.getOccurrenceDates();
+        assertEquals(3, dates.size());
+        assertDay(dates.get(0), 2020, 0, 1);
+        assertDay(dates.get(1), 2020, 0, 8);
+        assertDay(dates.get(2), 2020, 0, 15);
+        assertDay(update.getLastOccurrence(), 2020, 0, 15);
+        assertDay(update.getNextOccurrence(), 2020, 0, 22);
+    }
+
+    @Test
+    public void monthlyAdvancementSteppsOneMonth() {
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "FREQ=MONTHLY", day(2020, 0, 15), day(2020, 3, 20));
+        List<Date> dates = update.getOccurrenceDates();
+        assertEquals(4, dates.size());
+        assertDay(dates.get(0), 2020, 0, 15);
+        assertDay(dates.get(1), 2020, 1, 15);
+        assertDay(dates.get(2), 2020, 2, 15);
+        assertDay(dates.get(3), 2020, 3, 15);
+        assertDay(update.getLastOccurrence(), 2020, 3, 15);
+        assertDay(update.getNextOccurrence(), 2020, 4, 15);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // boundary exactness: an occurrence exactly at "now" is included, the day after is not
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void occurrenceExactlyAtNowIsIncludedNextDayIsNext() {
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "FREQ=DAILY", day(2020, 5, 10), day(2020, 5, 10));
+        List<Date> dates = update.getOccurrenceDates();
+        // seed == now: !instance.after(now) is true, so the seed day is due
+        assertEquals(1, dates.size());
+        assertDay(dates.get(0), 2020, 5, 10);
+        assertDay(update.getLastOccurrence(), 2020, 5, 10);
+        // the first instance strictly after now stops the walk and becomes the next occurrence
+        assertDay(update.getNextOccurrence(), 2020, 5, 11);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // month-end rule advances as rfc5545 dictates without skipping or crashing
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void monthEndRuleSkipsShortMonthsWithoutCrashing() {
+        // BYMONTHDAY=31 has no instance in Feb/Apr/Jun; org.dmfs simply omits those months
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "FREQ=MONTHLY;BYMONTHDAY=31", day(2020, 0, 31), day(2020, 6, 15));
+        List<Date> dates = update.getOccurrenceDates();
+        assertEquals(3, dates.size());
+        assertDay(dates.get(0), 2020, 0, 31); // Jan 31
+        assertDay(dates.get(1), 2020, 2, 31); // Mar 31 (Feb skipped)
+        assertDay(dates.get(2), 2020, 4, 31); // May 31 (Apr skipped)
+        assertDay(update.getLastOccurrence(), 2020, 4, 31);
+        assertDay(update.getNextOccurrence(), 2020, 6, 31); // Jul 31 (Jun skipped)
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // a rule with an end (COUNT / UNTIL) that exhausts inside the window -> null next occurrence
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void countRuleExhaustingInsideWindowLeavesNoNextOccurrence() {
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "FREQ=DAILY;COUNT=3", day(2020, 1, 1), day(2020, 1, 28));
+        List<Date> dates = update.getOccurrenceDates();
+        assertEquals(3, dates.size());
+        assertDay(dates.get(0), 2020, 1, 1);
+        assertDay(dates.get(1), 2020, 1, 2);
+        assertDay(dates.get(2), 2020, 1, 3);
+        assertDay(update.getLastOccurrence(), 2020, 1, 3);
+        assertNull(update.getNextOccurrence());
+    }
+
+    @Test
+    public void untilRuleExhaustingInsideWindowLeavesNoNextOccurrence() {
+        // UNTIL is inclusive per RFC 5545; the Jan 22 instance is kept, then the rule is done
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "FREQ=WEEKLY;UNTIL=20200122", day(2020, 0, 1), day(2020, 11, 31));
+        List<Date> dates = update.getOccurrenceDates();
+        assertEquals(4, dates.size());
+        assertDay(dates.get(0), 2020, 0, 1);
+        assertDay(dates.get(1), 2020, 0, 8);
+        assertDay(dates.get(2), 2020, 0, 15);
+        assertDay(dates.get(3), 2020, 0, 22);
+        assertDay(update.getLastOccurrence(), 2020, 0, 22);
+        assertNull(update.getNextOccurrence());
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // a window with nothing due returns empty and leaves the seed as the (unchanged) next occurrence
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void seedInTheFutureYieldsNoOccurrencesAndKeepsSeedAsNext() {
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "FREQ=MONTHLY", day(2020, 4, 10), day(2020, 4, 1));
+        assertTrue(update.getOccurrenceDates().isEmpty());
+        // nothing was inserted, so last occurrence stays at the seed and next stays at the seed too
+        assertDay(update.getLastOccurrence(), 2020, 4, 10);
+        assertDay(update.getNextOccurrence(), 2020, 4, 10);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // an unparseable rule yields no occurrences and a null next occurrence (no daily fallback)
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    public void invalidRuleYieldsNoOccurrencesAndNullNext() {
+        RecurrenceSetting.OccurrenceUpdate update = RecurrenceSetting.computeOccurrences(
+                "this is not a rule", day(2020, 2, 3), day(2020, 2, 30));
+        assertTrue(update.getOccurrenceDates().isEmpty());
+        assertDay(update.getLastOccurrence(), 2020, 2, 3);
+        assertNull(update.getNextOccurrence());
+    }
+}


### PR DESCRIPTION
## Recurrence occurrences computed once, purely, in the model

Builds on the transaction values PR (#37, branch `consolidate-transaction-values`) and is opened against that branch, not master. Please retarget it to master once #37 merges.

### What and why

The rule for when a recurring transaction or transfer silently enters the ledger lived twice, as two near identical sixty line loops welded to the Cursor inside `RecurrenceHandlerIntentService`. This moves that computation into a pure, Android free method on `RecurrenceSetting` so it can be reasoned about and unit tested on the JVM, and leaves each service handler with only its own entity column copying.

### Mechanism

`RecurrenceSetting.computeOccurrences(rule, seed, now)` walks the rfc5545 rule and returns an `OccurrenceUpdate` holding the due occurrence dates, the value for `LAST_OCCURRENCE`, and the value for `NEXT_OCCURRENCE`. Each service method queries the row, calls the method, inserts one ledger row per returned date through the existing `TransactionContentValuesBuilder` / `TransferContentValuesBuilder`, then writes the two columns back.

### Behavior preserved exactly

- Seeding: the stored `NEXT_OCCURRENCE` seeds the iterator and is itself the inclusive first instance, exactly as the inline loop did.
- Boundary: an instance is due while it is not after now (`!instance.after(now)`); an instance whose day equals now is included, the day after becomes the next occurrence. Comparison stays at day granularity because the same `getFixedDateTime` conversion is used.
- Exhaustion: a COUNT or UNTIL rule that runs out inside the window leaves `NEXT_OCCURRENCE` null so the row is never reprocessed; `LAST_OCCURRENCE` stays at the seed when nothing was due.
- Invalid rule: parsed inside the method, so a bad rule yields no occurrences and a null next occurrence, matching the old inline try/catch rather than the daily fallback the `(Date, String)` constructor applies.
- Column updates: `LAST_OCCURRENCE` and `NEXT_OCCURRENCE` are formatted and written identically to before.

`getNextOccurrence`, used by the legacy importer, is left untouched.

### Blast radius

Three files:

- `model/RecurrenceSetting.java`: new pure `computeOccurrences` method and `OccurrenceUpdate` result class; no change to existing methods.
- `service/RecurrenceHandlerIntentService.java`: both handlers rewritten to call the pure method and keep only their entity column copying.
- `broadcast/RecurrenceBroadcastReceiver.java`: two identical `MIN(next_occurrence)` queries collapsed into one parameterized helper, behavior identical (same projection, selection and cursor handling).

No schema, contract, or public API change.

### Verified

Full gate green: `clean testFlossOsmDebugUnitTest assembleFlossOsmDebug`, BUILD SUCCESSFUL, debug APK produced. Forty unit tests pass, the thirty already on the base branch plus ten new ones covering daily, weekly and monthly advancement, the now boundary, month end (31st) rules, COUNT and UNTIL exhaustion, an empty window, and an invalid rule.
