### PR TITLE
Route service task reporting through one shared helper

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/service/AbstractCurrencyRateDownloadIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/AbstractCurrencyRateDownloadIntentService.java
@@ -24,8 +24,6 @@ import android.app.IntentService;
 import android.content.Intent;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
-import androidx.core.app.NotificationManagerCompat;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.service.openexchangerates.OpenExchangeRatesCurrencyRateDownloadIntentService;
@@ -35,7 +33,6 @@ import com.oriondev.moneywallet.storage.cache.ExchangeRateCache;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.notification.NotificationContract;
 import com.oriondev.moneywallet.utils.CurrencyManager;
-import com.oriondev.moneywallet.utils.Utils;
 
 /**
  * Created by andre on 24/03/2018.
@@ -54,6 +51,7 @@ public abstract class AbstractCurrencyRateDownloadIntentService extends IntentSe
 
     private ExchangeRateCache mCache;
     private NotificationCompat.Builder mBuilder;
+    private TaskReporter mReporter;
 
     public AbstractCurrencyRateDownloadIntentService(String name) {
         super(name);
@@ -62,8 +60,8 @@ public abstract class AbstractCurrencyRateDownloadIntentService extends IntentSe
 
     @Override
     protected void onHandleIntent(@Nullable Intent intent) {
-        mBuilder = new NotificationCompat.Builder(getBaseContext(), NotificationContract.NOTIFICATION_CHANNEL_EXCHANGE_RATE)
-                .setSmallIcon(Utils.isAtLeastLollipop() ? R.drawable.ic_notification : R.mipmap.ic_launcher)
+        mReporter = new TaskReporter(this);
+        mBuilder = mReporter.newNotification(NotificationContract.NOTIFICATION_CHANNEL_EXCHANGE_RATE)
                 .setContentTitle(getString(R.string.notification_title_download_exchange_rates))
                 .setProgress(0, 0, true)
                 .setCategory(NotificationCompat.CATEGORY_PROGRESS);
@@ -86,8 +84,7 @@ public abstract class AbstractCurrencyRateDownloadIntentService extends IntentSe
 
     private void sendBroadcastMessage() {
         PreferenceManager.setLastExchangeRateUpdateTimestamp(System.currentTimeMillis());
-        Intent intent = new Intent(LocalAction.ACTION_EXCHANGE_RATES_UPDATED);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        mReporter.broadcast(LocalAction.ACTION_EXCHANGE_RATES_UPDATED);
     }
 
     protected void storeExchangeRate(CurrencyUnit currency, double rate, long timestamp) {
@@ -101,14 +98,12 @@ public abstract class AbstractCurrencyRateDownloadIntentService extends IntentSe
     }
 
     private void showError(String error) {
-        mBuilder = new NotificationCompat.Builder(getBaseContext(), NotificationContract.NOTIFICATION_CHANNEL_ERROR)
-                .setSmallIcon(Utils.isAtLeastLollipop() ? R.drawable.ic_notification : R.mipmap.ic_launcher)
+        mBuilder = mReporter.newNotification(NotificationContract.NOTIFICATION_CHANNEL_ERROR)
                 .setContentTitle(getString(R.string.notification_title_download_exchange_rates))
                 .setContentText(getString(R.string.notification_content_error_message, error))
                 .setStyle(new NotificationCompat.BigTextStyle().bigText(getString(R.string.notification_content_error_message, error)))
                 .setCategory(NotificationCompat.CATEGORY_ERROR);
-        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
-        notificationManager.notify(NotificationContract.NOTIFICATION_ID_EXCHANGE_RATE_ERROR, mBuilder.build());
+        mReporter.showNotification(NotificationContract.NOTIFICATION_ID_EXCHANGE_RATE_ERROR, mBuilder);
     }
 
     public class MissingApiKey extends Exception {

--- a/app/src/main/java/com/oriondev/moneywallet/service/AttachmentHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/AttachmentHandlerIntentService.java
@@ -25,8 +25,8 @@ import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Bundle;
 import androidx.annotation.Nullable;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.Attachment;
@@ -54,6 +54,8 @@ public class AttachmentHandlerIntentService extends IntentService {
     public static final int ACTION_CREATE = 1;
     public static final int ACTION_DELETE = 2;
 
+    private TaskReporter mReporter;
+
     public AttachmentHandlerIntentService() {
         super("AttachmentHandlerIntentService");
     }
@@ -61,6 +63,7 @@ public class AttachmentHandlerIntentService extends IntentService {
     @Override
     protected void onHandleIntent(@Nullable Intent intent) {
         if (intent != null) {
+            mReporter = new TaskReporter(this);
             int action = intent.getIntExtra(ACTION, 0);
             Attachment attachment = intent.getParcelableExtra(ATTACHMENT);
             notifyOperationStarted(attachment, action);
@@ -125,24 +128,24 @@ public class AttachmentHandlerIntentService extends IntentService {
     }
 
     private void notifyOperationStarted(Attachment attachment, int action) {
-        Intent intent = new Intent(LocalAction.ACTION_ATTACHMENT_OP_STARTED);
-        intent.putExtra(ATTACHMENT, attachment);
-        intent.putExtra(ACTION, action);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putParcelable(ATTACHMENT, attachment);
+        extras.putInt(ACTION, action);
+        mReporter.broadcast(LocalAction.ACTION_ATTACHMENT_OP_STARTED, extras);
     }
 
     private void notifyOperationFinished(Attachment attachment, int action) {
-        Intent intent = new Intent(LocalAction.ACTION_ATTACHMENT_OP_FINISHED);
-        intent.putExtra(ATTACHMENT, attachment);
-        intent.putExtra(ACTION, action);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putParcelable(ATTACHMENT, attachment);
+        extras.putInt(ACTION, action);
+        mReporter.broadcast(LocalAction.ACTION_ATTACHMENT_OP_FINISHED, extras);
     }
 
     private void notifyOperationFailed(Attachment attachment, int action, String error) {
-        Intent intent = new Intent(LocalAction.ACTION_ATTACHMENT_OP_FAILED);
-        intent.putExtra(ATTACHMENT, attachment);
-        intent.putExtra(ACTION, action);
-        intent.putExtra(ERROR, error);
-        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putParcelable(ATTACHMENT, attachment);
+        extras.putInt(ACTION, action);
+        extras.putString(ERROR, error);
+        mReporter.broadcast(LocalAction.ACTION_ATTACHMENT_OP_FAILED, extras);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/service/BackendHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/BackendHandlerIntentService.java
@@ -21,9 +21,9 @@ package com.oriondev.moneywallet.service;
 
 import android.app.IntentService;
 import android.content.Intent;
+import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.oriondev.moneywallet.api.BackendException;
 import com.oriondev.moneywallet.api.BackendServiceFactory;
@@ -52,7 +52,7 @@ public class BackendHandlerIntentService extends IntentService {
 
     private String mBackendId;
 
-    private LocalBroadcastManager mBroadcastManager;
+    private TaskReporter mReporter;
 
     public BackendHandlerIntentService() {
         super("BackendHandlerIntentService");
@@ -61,7 +61,7 @@ public class BackendHandlerIntentService extends IntentService {
     @Override
     protected void onHandleIntent(@Nullable Intent intent) {
         if (intent != null && intent.hasExtra(BACKEND_ID)) {
-            mBroadcastManager = LocalBroadcastManager.getInstance(this);
+            mReporter = new TaskReporter(this);
             mBackendId = intent.getStringExtra(BACKEND_ID);
             switch (intent.getIntExtra(ACTION, ACTION_LIST)) {
                 case ACTION_LIST:
@@ -100,29 +100,29 @@ public class BackendHandlerIntentService extends IntentService {
     }
 
     private void notifyTaskStarted(int action) {
-        Intent intent = new Intent(LocalAction.ACTION_BACKEND_SERVICE_STARTED);
-        intent.putExtra(ACTION, action);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, action);
+        mReporter.broadcast(LocalAction.ACTION_BACKEND_SERVICE_STARTED, extras);
     }
 
     private void notifyListTaskFinished(List<IFile> files) {
-        Intent intent = new Intent(LocalAction.ACTION_BACKEND_SERVICE_FINISHED);
-        intent.putExtra(ACTION, ACTION_LIST);
-        intent.putParcelableArrayListExtra(FOLDER_CONTENT, Utils.wrapAsArrayList(files));
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, ACTION_LIST);
+        extras.putParcelableArrayList(FOLDER_CONTENT, Utils.wrapAsArrayList(files));
+        mReporter.broadcast(LocalAction.ACTION_BACKEND_SERVICE_FINISHED, extras);
     }
 
     private void notifyCreateFolderTaskFinished(IFile file) {
-        Intent intent = new Intent(LocalAction.ACTION_BACKEND_SERVICE_FINISHED);
-        intent.putExtra(ACTION, ACTION_CREATE_FOLDER);
-        intent.putExtra(CREATED_FILE, file);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, ACTION_CREATE_FOLDER);
+        extras.putParcelable(CREATED_FILE, file);
+        mReporter.broadcast(LocalAction.ACTION_BACKEND_SERVICE_FINISHED, extras);
     }
 
     private void notifyTaskFailure(int action, String message) {
-        Intent intent = new Intent(LocalAction.ACTION_BACKEND_SERVICE_FAILED);
-        intent.putExtra(ACTION, action);
-        intent.putExtra(ERROR_MESSAGE, message);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, action);
+        extras.putString(ERROR_MESSAGE, message);
+        mReporter.broadcast(LocalAction.ACTION_BACKEND_SERVICE_FAILED, extras);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
@@ -30,8 +30,6 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
-import androidx.core.app.NotificationManagerCompat;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.text.TextUtils;
 
 import com.oriondev.moneywallet.R;
@@ -115,7 +113,7 @@ public class BackupHandlerIntentService extends IntentService {
     private IBackendServiceAPI mBackendServiceAPI;
 
     private String mCallerId;
-    private LocalBroadcastManager mBroadcastManager;
+    private TaskReporter mReporter;
     private NotificationCompat.Builder mNotificationBuilder;
 
     public static void startInForeground(Context context, Intent intent) {
@@ -146,11 +144,11 @@ public class BackupHandlerIntentService extends IntentService {
             // in the notification if it is required
             Exception exception = null;
             try {
-                // initialize the broadcast manager
-                mBroadcastManager = LocalBroadcastManager.getInstance(this);
+                // initialize the task reporter
+                mReporter = new TaskReporter(this);
                 // if the notification is required, start the service in foreground
                 if (runForeground && (action == ACTION_BACKUP || action == ACTION_RESTORE)) {
-                    mNotificationBuilder = getBaseNotificationBuilder(NotificationContract.NOTIFICATION_CHANNEL_BACKUP)
+                    mNotificationBuilder = mReporter.newNotification(NotificationContract.NOTIFICATION_CHANNEL_BACKUP)
                             .setProgress(0, 0, true)
                             .setCategory(NotificationCompat.CATEGORY_PROGRESS);
                 }
@@ -327,11 +325,6 @@ public class BackupHandlerIntentService extends IntentService {
         return null;
     }
 
-    private NotificationCompat.Builder getBaseNotificationBuilder(String channelId) {
-        return new NotificationCompat.Builder(getBaseContext(), channelId)
-                .setSmallIcon(Utils.isAtLeastLollipop() ? R.drawable.ic_notification : R.mipmap.ic_launcher);
-    }
-
     private String getNotificationContentText(int status) {
         switch (status) {
             case STATUS_BACKUP_CREATION:
@@ -348,10 +341,10 @@ public class BackupHandlerIntentService extends IntentService {
 
     private void notifyTaskStarted(int action) {
         // notify the local broadcast manager
-        Intent intent = new Intent(LocalAction.ACTION_BACKUP_SERVICE_STARTED);
-        intent.putExtra(ACTION, action);
-        intent.putExtra(CALLER_ID, mCallerId);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, action);
+        extras.putString(CALLER_ID, mCallerId);
+        mReporter.broadcast(LocalAction.ACTION_BACKUP_SERVICE_STARTED, extras);
         // update the notification if required
         if (mNotificationBuilder != null) {
             mNotificationBuilder.setContentTitle(getNotificationContentTitle(action, false));
@@ -361,12 +354,12 @@ public class BackupHandlerIntentService extends IntentService {
 
     private void notifyTaskProgress(int action, int status, int progress) {
         // notify the local broadcast manager
-        Intent intent = new Intent(LocalAction.ACTION_BACKUP_SERVICE_RUNNING);
-        intent.putExtra(ACTION, action);
-        intent.putExtra(PROGRESS_STATUS, status);
-        intent.putExtra(PROGRESS_VALUE, progress);
-        intent.putExtra(CALLER_ID, mCallerId);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, action);
+        extras.putInt(PROGRESS_STATUS, status);
+        extras.putInt(PROGRESS_VALUE, progress);
+        extras.putString(CALLER_ID, mCallerId);
+        mReporter.broadcast(LocalAction.ACTION_BACKUP_SERVICE_RUNNING, extras);
         // update the notification if required
         if (mNotificationBuilder != null) {
             mNotificationBuilder.setContentText(getNotificationContentText(status));
@@ -378,86 +371,50 @@ public class BackupHandlerIntentService extends IntentService {
     private void notifyTaskFinished(int action) {
         // notify only the local broadcast manager: it is not required to update
         // the notification because it is removed when everything is gone right
-        Intent intent = new Intent(LocalAction.ACTION_BACKUP_SERVICE_FINISHED);
-        intent.putExtra(ACTION, action);
-        intent.putExtra(CALLER_ID, mCallerId);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, action);
+        extras.putString(CALLER_ID, mCallerId);
+        mReporter.broadcast(LocalAction.ACTION_BACKUP_SERVICE_FINISHED, extras);
     }
 
     private void notifyListTaskFinished(List<IFile> files) {
         // notify only the local broadcast manager: it is not required to update
         // the notification because it is removed when everything is gone right
-        Intent intent = new Intent(LocalAction.ACTION_BACKUP_SERVICE_FINISHED);
-        intent.putExtra(ACTION, ACTION_LIST);
-        intent.putParcelableArrayListExtra(FOLDER_CONTENT, Utils.wrapAsArrayList(files));
-        intent.putExtra(CALLER_ID, mCallerId);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, ACTION_LIST);
+        extras.putParcelableArrayList(FOLDER_CONTENT, Utils.wrapAsArrayList(files));
+        extras.putString(CALLER_ID, mCallerId);
+        mReporter.broadcast(LocalAction.ACTION_BACKUP_SERVICE_FINISHED, extras);
     }
 
     private void notifyUploadTaskFinished(IFile file) {
         // notify only the local broadcast manager: it is not required to update
         // the notification because it is removed when everything is gone right
-        Intent intent = new Intent(LocalAction.ACTION_BACKUP_SERVICE_FINISHED);
-        intent.putExtra(ACTION, ACTION_BACKUP);
-        intent.putExtra(BACKUP_FILE, file);
-        intent.putExtra(CALLER_ID, mCallerId);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, ACTION_BACKUP);
+        extras.putParcelable(BACKUP_FILE, file);
+        extras.putString(CALLER_ID, mCallerId);
+        mReporter.broadcast(LocalAction.ACTION_BACKUP_SERVICE_FINISHED, extras);
     }
 
     private void notifyTaskFailure(Intent baseIntent, Exception exception) {
         // notify the local broadcast manager
         int action = baseIntent.getIntExtra(ACTION, ACTION_NONE);
-        Intent intent = new Intent(LocalAction.ACTION_BACKUP_SERVICE_FAILED);
-        intent.putExtra(ACTION, action);
-        intent.putExtra(EXCEPTION, exception);
-        intent.putExtra(CALLER_ID, mCallerId);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putInt(ACTION, action);
+        extras.putSerializable(EXCEPTION, exception);
+        extras.putString(CALLER_ID, mCallerId);
+        mReporter.broadcast(LocalAction.ACTION_BACKUP_SERVICE_FAILED, extras);
         // update the notification if required
         if (mNotificationBuilder != null || mAutoBackup) {
-            mNotificationBuilder = getBaseNotificationBuilder(NotificationContract.NOTIFICATION_CHANNEL_ERROR)
+            mNotificationBuilder = mReporter.newNotification(NotificationContract.NOTIFICATION_CHANNEL_ERROR)
                     .setContentTitle(getNotificationContentTitle(action, true))
                     .setCategory(NotificationCompat.CATEGORY_ERROR);
             if (exception instanceof WiFiNotConnectedException) {
-                // create a copy of the arguments used in this service
-                Bundle intentArguments = new Bundle();
-                intentArguments.putInt(ACTION, action);
-                intentArguments.putString(BACKEND_ID, baseIntent.getStringExtra(BACKEND_ID));
-                intentArguments.putBoolean(AUTO_BACKUP, baseIntent.getBooleanExtra(AUTO_BACKUP, DEFAULT_AUTO_BACKUP));
-                intentArguments.putBoolean(ONLY_ON_WIFI, baseIntent.getBooleanExtra(ONLY_ON_WIFI, DEFAULT_ONLY_ON_WIFI));
-                intentArguments.putBoolean(RUN_FOREGROUND, baseIntent.getBooleanExtra(RUN_FOREGROUND, DEFAULT_RUN_FOREGROUND));
-                intentArguments.putString(PASSWORD, baseIntent.getStringExtra(PASSWORD));
-                intentArguments.putParcelable(PARENT_FOLDER, baseIntent.getParcelableExtra(PARENT_FOLDER));
-                intentArguments.putParcelable(BACKUP_FILE, baseIntent.getParcelableExtra(BACKUP_FILE));
-                // prepare the pending intent for the notification receiver
-                Intent retryIntent = new Intent(this, NotificationBroadcastReceiver.class);
-                retryIntent.setAction(NotificationBroadcastReceiver.ACTION_RETRY_BACKUP_CREATION);
-                retryIntent.putExtra(NotificationBroadcastReceiver.ACTION_INTENT_ARGUMENTS, intentArguments);
-                PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, retryIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-                // finish to setup the notification body
-                mNotificationBuilder.setContentText(getString(R.string.notification_content_backup_error_wifi_network));
-                mNotificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(getString(R.string.notification_content_backup_error_wifi_network)));
-                mNotificationBuilder.addAction(R.drawable.ic_refresh_black_24dp, getString(R.string.notification_action_retry), pendingIntent);
+                setupRetryNotification(baseIntent, action, R.string.notification_content_backup_error_wifi_network);
             } else if (exception instanceof BackendException) {
                 if (((BackendException) exception).isRecoverable()) {
-                    // create a copy of the arguments used in this service
-                    Bundle intentArguments = new Bundle();
-                    intentArguments.putInt(ACTION, action);
-                    intentArguments.putString(BACKEND_ID, baseIntent.getStringExtra(BACKEND_ID));
-                    intentArguments.putBoolean(AUTO_BACKUP, baseIntent.getBooleanExtra(AUTO_BACKUP, DEFAULT_AUTO_BACKUP));
-                    intentArguments.putBoolean(ONLY_ON_WIFI, baseIntent.getBooleanExtra(ONLY_ON_WIFI, DEFAULT_ONLY_ON_WIFI));
-                    intentArguments.putBoolean(RUN_FOREGROUND, baseIntent.getBooleanExtra(RUN_FOREGROUND, DEFAULT_RUN_FOREGROUND));
-                    intentArguments.putString(PASSWORD, baseIntent.getStringExtra(PASSWORD));
-                    intentArguments.putParcelable(PARENT_FOLDER, baseIntent.getParcelableExtra(PARENT_FOLDER));
-                    intentArguments.putParcelable(BACKUP_FILE, baseIntent.getParcelableExtra(BACKUP_FILE));
-                    // prepare the pending intent for the notification receiver
-                    Intent retryIntent = new Intent(this, NotificationBroadcastReceiver.class);
-                    retryIntent.setAction(NotificationBroadcastReceiver.ACTION_RETRY_BACKUP_CREATION);
-                    retryIntent.putExtra(NotificationBroadcastReceiver.ACTION_INTENT_ARGUMENTS, intentArguments);
-                    PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, retryIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-                    // finish to setup the notification body
-                    mNotificationBuilder.setContentText(getString(R.string.notification_content_backup_error_backend_recoverable));
-                    mNotificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(getString(R.string.notification_content_backup_error_backend_recoverable)));
-                    mNotificationBuilder.addAction(R.drawable.ic_refresh_black_24dp, getString(R.string.notification_action_retry), pendingIntent);
+                    setupRetryNotification(baseIntent, action, R.string.notification_content_backup_error_backend_recoverable);
                 } else {
                     mNotificationBuilder.setContentText(getString(R.string.notification_content_backup_error_backend));
                     mNotificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(getString(R.string.notification_content_backup_error_backend)));
@@ -470,9 +427,37 @@ public class BackupHandlerIntentService extends IntentService {
             // use the notification service instead of the foreground service
             // because when the intent service has finished the notification
             // is removed even if the stopForeground is set to false
-            NotificationManagerCompat notificationManager = NotificationManagerCompat.from(this);
-            notificationManager.notify(NotificationContract.NOTIFICATION_ID_BACKUP_ERROR, mNotificationBuilder.build());
+            mReporter.showNotification(NotificationContract.NOTIFICATION_ID_BACKUP_ERROR, mNotificationBuilder);
         }
+    }
+
+    /**
+     * Build the error notification body for the two recoverable failures that
+     * offer a retry action. Both cases copy the same service arguments into the
+     * retry pending intent and differ only in the content text, so the copy is
+     * done once here and the text resource is passed in.
+     */
+    private void setupRetryNotification(Intent baseIntent, int action, int contentTextRes) {
+        // create a copy of the arguments used in this service
+        Bundle intentArguments = new Bundle();
+        intentArguments.putInt(ACTION, action);
+        intentArguments.putString(BACKEND_ID, baseIntent.getStringExtra(BACKEND_ID));
+        intentArguments.putBoolean(AUTO_BACKUP, baseIntent.getBooleanExtra(AUTO_BACKUP, DEFAULT_AUTO_BACKUP));
+        intentArguments.putBoolean(ONLY_ON_WIFI, baseIntent.getBooleanExtra(ONLY_ON_WIFI, DEFAULT_ONLY_ON_WIFI));
+        intentArguments.putBoolean(RUN_FOREGROUND, baseIntent.getBooleanExtra(RUN_FOREGROUND, DEFAULT_RUN_FOREGROUND));
+        intentArguments.putString(PASSWORD, baseIntent.getStringExtra(PASSWORD));
+        intentArguments.putParcelable(PARENT_FOLDER, baseIntent.getParcelableExtra(PARENT_FOLDER));
+        intentArguments.putParcelable(BACKUP_FILE, baseIntent.getParcelableExtra(BACKUP_FILE));
+        // prepare the pending intent for the notification receiver
+        Intent retryIntent = new Intent(this, NotificationBroadcastReceiver.class);
+        retryIntent.setAction(NotificationBroadcastReceiver.ACTION_RETRY_BACKUP_CREATION);
+        retryIntent.putExtra(NotificationBroadcastReceiver.ACTION_INTENT_ARGUMENTS, intentArguments);
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 0, retryIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+        // finish to setup the notification body
+        String contentText = getString(contentTextRes);
+        mNotificationBuilder.setContentText(contentText);
+        mNotificationBuilder.setStyle(new NotificationCompat.BigTextStyle().bigText(contentText));
+        mNotificationBuilder.addAction(R.drawable.ic_refresh_black_24dp, getString(R.string.notification_action_retry), pendingIntent);
     }
 
     private class WiFiNotConnectedException extends Exception {

--- a/app/src/main/java/com/oriondev/moneywallet/service/ImportExportIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/ImportExportIntentService.java
@@ -5,11 +5,11 @@ import android.content.ContentResolver;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
+import android.os.Bundle;
 import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.FileProvider;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.DataFormat;
@@ -52,7 +52,7 @@ public class ImportExportIntentService extends IntentService {
     public static final int MODE_EXPORT = 0;
     public static final int MODE_IMPORT = 1;
 
-    private LocalBroadcastManager mBroadcastManager;
+    private TaskReporter mReporter;
 
     public ImportExportIntentService() {
         super("ImportExportIntentService");
@@ -61,7 +61,7 @@ public class ImportExportIntentService extends IntentService {
     @Override
     protected void onHandleIntent(@Nullable Intent intent) {
         if (intent != null) {
-            mBroadcastManager = LocalBroadcastManager.getInstance(this);
+            mReporter = new TaskReporter(this);
             int mode = intent.getIntExtra(MODE, MODE_EXPORT);
             switch (mode) {
                 case MODE_EXPORT:
@@ -206,26 +206,24 @@ public class ImportExportIntentService extends IntentService {
     }
 
     private void notifyTaskStarted(String action) {
-        Intent intent = new Intent(action);
-        mBroadcastManager.sendBroadcast(intent);
+        mReporter.broadcast(action);
     }
 
     private void notifyTaskFinished(String action) {
-        Intent intent = new Intent(action);
-        mBroadcastManager.sendBroadcast(intent);
+        mReporter.broadcast(action);
     }
 
     private void notifyTaskFinished(String action, Uri resultUri, String resultType) {
-        Intent intent = new Intent(action);
-        intent.putExtra(RESULT_FILE_URI, resultUri);
-        intent.putExtra(RESULT_FILE_TYPE, resultType);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putParcelable(RESULT_FILE_URI, resultUri);
+        extras.putString(RESULT_FILE_TYPE, resultType);
+        mReporter.broadcast(action, extras);
     }
 
     private void notifyTaskFailed(String action, Exception exception) {
-        Intent intent = new Intent(action);
-        intent.putExtra(EXCEPTION, exception);
-        mBroadcastManager.sendBroadcast(intent);
+        Bundle extras = new Bundle();
+        extras.putSerializable(EXCEPTION, exception);
+        mReporter.broadcast(action, extras);
     }
 
     private AbstractDataImporter getDataImporter(DataFormat dataFormat, File file) throws IOException {

--- a/app/src/main/java/com/oriondev/moneywallet/service/TaskReporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/TaskReporter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.service;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.utils.Utils;
+
+/**
+ * Small helper shared by the intent services to report task state.
+ *
+ * It centralises the two cross-cutting mechanisms that every service used to
+ * re-implement on its own: sending a local broadcast (action plus optional
+ * extras) and creating/posting the progress or error notification. Each service
+ * keeps full ownership of its own task logic, extra keys, notification content
+ * and foreground timing; this class only owns the plumbing that was identical
+ * everywhere.
+ */
+class TaskReporter {
+
+    private final Context mContext;
+    private final LocalBroadcastManager mBroadcastManager;
+
+    TaskReporter(Context context) {
+        mContext = context;
+        mBroadcastManager = LocalBroadcastManager.getInstance(context);
+    }
+
+    /**
+     * Send a local broadcast carrying only the action string.
+     */
+    void broadcast(String action) {
+        mBroadcastManager.sendBroadcast(new Intent(action));
+    }
+
+    /**
+     * Send a local broadcast carrying the action string and the given extras.
+     * The extras are copied verbatim into the intent, so the receivers observe
+     * exactly the keys, types and values the caller put into the bundle.
+     */
+    void broadcast(String action, Bundle extras) {
+        Intent intent = new Intent(action);
+        intent.putExtras(extras);
+        mBroadcastManager.sendBroadcast(intent);
+    }
+
+    /**
+     * Create a notification builder pre-configured with the shared small icon.
+     * The caller sets everything else (title, text, progress, category, style,
+     * actions) so per-service notification differences are preserved.
+     */
+    NotificationCompat.Builder newNotification(String channelId) {
+        return new NotificationCompat.Builder(mContext, channelId)
+                .setSmallIcon(Utils.isAtLeastLollipop() ? R.drawable.ic_notification : R.mipmap.ic_launcher);
+    }
+
+    /**
+     * Post (or update) a notification through the notification manager. Used for
+     * the error notifications that must survive the end of the foreground task.
+     */
+    void showNotification(int id, NotificationCompat.Builder builder) {
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(mContext);
+        notificationManager.notify(id, builder.build());
+    }
+}


### PR DESCRIPTION
## What

The intent services each re-implemented two cross-cutting mechanisms with drift: sending a `LocalBroadcastManager` intent (action plus extras) and building/posting the foreground progress and error notifications (`NotificationCompat` plus `startForeground`). This adds one small plain helper, `service/TaskReporter`, that owns just that plumbing, and routes every service through it.

## Blast radius

Touches only the service layer and its new shared helper:

- `service/TaskReporter.java` (new)
- `service/BackupHandlerIntentService.java`
- `service/BackendHandlerIntentService.java`
- `service/ImportExportIntentService.java`
- `service/AttachmentHandlerIntentService.java`
- `service/AbstractCurrencyRateDownloadIntentService.java`

No receiver, fragment, contract, or resource is modified. `RecurrenceHandlerIntentService` and `UpgradeLegacyEditionIntentService` are left untouched.

## Mechanism

`TaskReporter` holds the `LocalBroadcastManager` and exposes four plain methods:

- `broadcast(action)` and `broadcast(action, Bundle extras)`, which create the intent, copy the extras verbatim, and send it.
- `newNotification(channelId)`, which returns a builder pre-set with the shared small icon (the `getBaseNotificationBuilder` logic that Backup had as a method and the currency service inlined).
- `showNotification(id, builder)`, which posts through `NotificationManagerCompat` for the error notifications that must outlive the foreground task.

Each service keeps its own task logic, its own extra keys and types, its own notification texts, categories, styles and retry actions, and its own `startForeground`/`stopForeground` calls, so foreground timing is unchanged. The helper owns the mechanism, the services own the content.

In `BackupHandlerIntentService` the two near-identical retry blocks inside `notifyTaskFailure` (the WiFi-not-connected case and the recoverable-backend case) were collapsed into one `setupRetryNotification(baseIntent, action, contentTextRes)` method. They copied the same service arguments into the retry pending intent and differed only by the content-text resource, which is now a parameter.

## Zero observable change

Every broadcast keeps its exact action string and exact extra keys, types and values; the extras are moved from per-call `Intent.putExtra` into a `Bundle` that is copied into the intent with `putExtras`, which is behaviorally identical for the receivers (verified: `BackupHandlerFragment` still reads `getParcelableArrayListExtra` and `getSerializableExtra` for the same keys). Every notification keeps its exact id, channel, small icon, texts, priority, category, style, and progress semantics (indeterminate vs determinate), and the same `startForeground`/`stopForeground` timing relative to the work.

## Per-service differences found and preserved

- Backup adds `CALLER_ID` to every broadcast and Backend does not; Backup carries a numeric `ACTION` extra while Import/Export uses the broadcast action string directly with no numeric extra. These stay exactly as they were: the differing keys live in each service's own bundle, not in the helper.
- Only Backup and the currency service post notifications; the other three are broadcast-only. Backup's error notification adds retry actions and a big-text style, the currency service's does not. Preserved.
- `getBaseNotificationBuilder` and the currency service's inline builder created the builder from `getBaseContext()`; `TaskReporter.newNotification` uses the service context. A Service delegates all context operations to its base context, so the builder resolves the identical package and resources. No observable difference.
- The retry helper reads the content-text resource once into a local and uses it for both the content text and the big-text style, where the original called `getString` twice for the same argument-free resource. Same string value.

## Verified

Clean debug build and unit tests pass: `clean testFlossOsmDebugUnitTest assembleFlossOsmDebug` reports `BUILD SUCCESSFUL`, 30 unit tests, 0 failures, and the debug APK is produced.
