### PR TITLE
Close the cursor in the recurrence alarm receiver

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/broadcast/RecurrenceBroadcastReceiver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/broadcast/RecurrenceBroadcastReceiver.java
@@ -67,13 +67,16 @@ public class RecurrenceBroadcastReceiver extends BroadcastReceiver {
         String selection = nextOccurrenceColumn + " IS NOT NULL";
         Cursor cursor = contentResolver.query(uri, projection, selection, null, null);
         if (cursor != null) {
-            if (cursor.moveToFirst()) {
-                String nextOccurrenceString = cursor.getString(0);
-                if (!TextUtils.isEmpty(nextOccurrenceString)) {
-                    return DateUtils.getDateFromSQLDateString(nextOccurrenceString);
+            try {
+                if (cursor.moveToFirst()) {
+                    String nextOccurrenceString = cursor.getString(0);
+                    if (!TextUtils.isEmpty(nextOccurrenceString)) {
+                        return DateUtils.getDateFromSQLDateString(nextOccurrenceString);
+                    }
                 }
+            } finally {
+                cursor.close();
             }
-            cursor.close();
         }
         return null;
     }


### PR DESCRIPTION
## Summary

Fixes a cursor leak in `RecurrenceBroadcastReceiver.getMinNextOccurrence`.

The method returned `DateUtils.getDateFromSQLDateString(...)` from inside the `moveToFirst()` block, which is before the `cursor.close()` call. So whenever a next occurrence exists, and that is the common case, the method returned without closing the cursor and leaked it. The cursor was only closed on the empty/null paths.

The read is now wrapped in a `try/finally` so the cursor is closed on every path, including the early return. The query projection, selection, and returned values are all unchanged; this is purely a resource-cleanup fix.

## Stacking

This PR is stacked on the recurrence occurrences PR (#39, branch `recurrence-occurrences`), because that PR is where `getMinNextOccurrence` was consolidated into its current shape. It is targeted at `recurrence-occurrences` for now. Once that PR merges to master, please retarget this one to master (the change applies cleanly either way).

## Verification

Floss build gate (JDK 17): `clean testFlossOsmDebugUnitTest assembleFlossOsmDebug` -> BUILD SUCCESSFUL, 40 unit tests, 0 failures, 0 errors (the base branch's full suite).
