### PR TITLE
Prepare 1.1.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,8 +31,8 @@ android {
         applicationId "io.github.herrerad85.tallybook"
         minSdk 24
         targetSdk 35
-        versionCode 78
-        versionName "1.0.2"
+        versionCode 79
+        versionName "1.1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         multiDexEnabled true

--- a/fastlane/metadata/android/en-US/changelogs/79.txt
+++ b/fastlane/metadata/android/en-US/changelogs/79.txt
@@ -1,0 +1,3 @@
+Backups can now go to your own WebDAV server, such as Nextcloud, ownCloud or a NAS, with no third party account and nothing sent to anyone else. Tested against four different server implementations.
+
+Also a large internal cleanup: money and recurrence calculations, backup destination handling and data export were each consolidated into one place, and unit test coverage nearly doubled.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -17,11 +17,13 @@ Features:
 * Calendar view of your activity
 * Transaction templates and scheduled events
 * Local backup and restore, with a local-folder option you can sync using your own tools
+* Backup to your own WebDAV server, such as Nextcloud, ownCloud or a NAS, with no third party account
 * Export to CSV, Excel, and PDF, plus CSV import
 * Optional place attachments using OpenStreetMap, with no proprietary services
 
 Privacy and offline first:
 
+* Optional app lock with a PIN, a pattern, or your fingerprint
 * No account, no sign-up, and no ads
 * Your data stays on your device unless you choose to back it up or export it
 * The open-source build uses OpenStreetMap and no Google services


### PR DESCRIPTION
Bumps to versionCode 79 / versionName 1.1.0 for the WebDAV release (#45).

Adds `changelogs/79.txt` and updates the store description. F-Droid pulls fastlane metadata from the latest release tag, not from master, so listing copy has to travel with a version bump or it does not ship at all.

The description gains two things:
- The WebDAV backup destination, which is the headline of this release.
- The optional PIN, pattern and fingerprint lock. That has been in the app since the fork but was never mentioned anywhere a user would look.

No code change. Build green, 67 tests passing.