### PR TITLE
Fix pie chart percentage labels: enable toggle, init line color, round percentages, center text

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/chart/PieChart.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/chart/PieChart.java
@@ -110,6 +110,7 @@ public class PieChart extends View {
         mRectangle = new RectF();
         mSlicePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
         mLinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        mLinePaint.setTextAlign(Paint.Align.CENTER);
         // obtain attributes
         TypedArray a = context.getTheme().obtainStyledAttributes(attrs, R.styleable.PieChart, defStyleAttr, defStyleRes);
         try {
@@ -118,7 +119,8 @@ public class PieChart extends View {
             mPercentageEnabled = a.getBoolean(R.styleable.PieChart_pie_chartPercentageEnabled, DEFAULT_PERCENTAGE_ENABLED);
             mShadowColor = a.getColor(R.styleable.PieChart_pie_chartShadowColor, DEFAULT_SHADOW_COLOR);
             mHoleColor = a.getColor(R.styleable.PieChart_pie_chartHoleColor, DEFAULT_HOLE_COLOR);
-            mLinePaint.setColor(a.getColor(R.styleable.PieChart_pie_chartLineColor, DEFAULT_LINE_COLOR));
+            mLineColor = a.getColor(R.styleable.PieChart_pie_chartLineColor, DEFAULT_LINE_COLOR);
+            mLinePaint.setColor(mLineColor);
             mLinePaint.setStrokeWidth(a.getFloat(R.styleable.PieChart_pie_chartLineSize, DEFAULT_LINE_SIZE));
         } catch (Exception e) {
             // initialize variables at default state
@@ -338,9 +340,9 @@ public class PieChart extends View {
             // draw percentage
             if (mPercentageEnabled) {
                 // calculate center text coordinates
-                float textX = ((float) (Math.cos(Math.toRadians(iconAngle)) * textDistance)) + centerX - (textSize / 4 * 3);
+                float textX = ((float) (Math.cos(Math.toRadians(iconAngle)) * textDistance)) + centerX;
                 float textY = ((float) (Math.sin(Math.toRadians(iconAngle)) * textDistance)) + centerY + (textSize / 2);
-                int percentage = (int) (sweepAngle * 100 / 360f);
+                int percentage = Math.round(sweepAngle * 100 / 360f);
                 c.drawText(String.valueOf(percentage) + "%", textX, textY, mLinePaint);
             }
         }

--- a/app/src/main/res/layout/adapter_pie_chart_item.xml
+++ b/app/src/main/res/layout/adapter_pie_chart_item.xml
@@ -20,6 +20,8 @@
 
 <com.oriondev.moneywallet.ui.view.theme.ThemedPieChart
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/pie_chart_view"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent"
+    app:pie_chartPercentageEnabled="true" />


### PR DESCRIPTION
## Summary

Four fixes for the pie chart percentage labels and connector lines (issue #53).

## Changes

1. **adapter_pie_chart_item.xml**: Add `xmlns:app` namespace and set `app:pie_chartPercentageEnabled="true"` to enable the percentage draw path.

2. **PieChart.java — mLineColor initialization**: `mLineColor` was never assigned from the styleable in the try block (only in the catch branch or via `setLineColor`). `onDraw()` then calls `mLinePaint.setColor(mLineColor)` on every frame, overwriting the paint with the default int value 0. Fixed by assigning `mLineColor` from the styleable before using it.

3. **PieChart.java — percentage rounding**: Changed `(int) (sweepAngle * 100 / 360f)` to `Math.round(sweepAngle * 100 / 360f)` so percentages round to the nearest integer instead of truncating.

4. **PieChart.java — text centering**: Added `mLinePaint.setTextAlign(Paint.Align.CENTER)` in `initialize()` and removed the fixed `-(textSize / 4 * 3)` left nudge from `textX`. Labels now center on their computed position instead of always pushing left.

## Known issues not addressed

- The chart never receives a theme, so labels use default grey and the centre hole stays white in dark themes.
- Label text size is a raw pixel constant; it varies ~3x across screen densities and the bottom label can fall outside view bounds on lower-density screens.