### PR TITLE
Export the wallet note in database backups

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabaseExporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabaseExporter.java
@@ -71,6 +71,7 @@ public class SQLDatabaseExporter {
         object.mName = cursor.getString(cursor.getColumnIndex(Schema.Wallet.NAME));
         object.mIcon = cursor.getString(cursor.getColumnIndex(Schema.Wallet.ICON));
         object.mCurrency = cursor.getString(cursor.getColumnIndex(Schema.Wallet.CURRENCY));
+        object.mNote = cursor.getString(cursor.getColumnIndex(Schema.Wallet.NOTE));
         object.mStartMoney = cursor.getLong(cursor.getColumnIndex(Schema.Wallet.START_MONEY));
         object.mCountInTotal = cursor.getInt(cursor.getColumnIndex(Schema.Wallet.COUNT_IN_TOTAL)) == 1;
         object.mArchived = cursor.getInt(cursor.getColumnIndex(Schema.Wallet.ARCHIVED)) == 1;


### PR DESCRIPTION
Fixes #50.

## What is wrong

Wallet notes are silently dropped by the backup exporter, so a restore rebuilds every wallet without its note.

`SQLDatabaseExporter.getWallet(Cursor)` reads the id, name, icon, currency, start money, count in total, archived flag, index, tag, uuid, last edit and deleted flag. It never reads the note. Every other exported entity reads its own note.

## Why the rest of the path is not at fault

The column exists as `Schema.Wallet.NOTE`, the model declares `public String mNote`, `JSONDataOutputFactory` writes it, and `SQLDatabaseImporter` restores it. The value is exported as null and the import faithfully rebuilds the wallet without it. The cursor query uses a null projection so the column is already present and no query change is needed.

## The change

One line in `getWallet`, matching the pattern the other entities already use. No change to the backup format: a null note emits no key either way, so backups written before this simply carry no note.

## Verification

Two sided on an emulator. A wallet was created with a note through the app, then backed up. On the current build the exported JSON has no `note` key at all for that wallet. On this build it reads `"note": "..."`. The stored note was then overwritten and the backup restored through the app, and the note came back, so the round trip works rather than just the export half.