### PR TITLE
Sort a debt that is paid off in full with the finished ones

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/wrapper/DebtHeaderCursor.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/wrapper/DebtHeaderCursor.java
@@ -44,6 +44,27 @@ public class DebtHeaderCursor extends AbstractHeaderCursor<DebtHeaderCursor.Head
     public static final int HEADER_CURRENT = 0;
     public static final int HEADER_ARCHIVED = 1;
 
+    /**
+     * A debt counts as finished once it has been archived by hand or paid off in full. Archiving
+     * was the only thing the app treated as finished, which left a debt you had finished paying
+     * sitting in the group that still needs attention.
+     * <p>
+     * The query selects this expression under {@link #COLUMN_IS_SETTLED} and orders by it, and the
+     * grouping below reads that same column back rather than recomputing the rule. Recomputing it
+     * in Java would be a second copy that could drift, and this class throws when the grouping
+     * disagrees with the order, so the drift would surface as a crash rather than a mis-sort.
+     * <p>
+     * A debt for no money is not finished, it is unfinished data entry. The amount is not required
+     * when saving, so one can be created by accident, and filing it away as finished is how it
+     * would be lost.
+     */
+    public static final String SQL_IS_SETTLED = "(CASE WHEN " + Contract.Debt.ARCHIVED + " = 1 OR "
+            + "(" + Contract.Debt.MONEY + " <> 0 AND "
+            + "ABS(COALESCE(" + Contract.Debt.PROGRESS + ", 0)) >= ABS(" + Contract.Debt.MONEY + "))"
+            + " THEN 1 ELSE 0 END)";
+
+    public static final String COLUMN_IS_SETTLED = "debt_is_settled";
+
     private final int mIndexDebtType;
     private final Contract.DebtType mDebtType;
 
@@ -59,34 +80,36 @@ public class DebtHeaderCursor extends AbstractHeaderCursor<DebtHeaderCursor.Head
         int indexDebtCurrency = cursor.getColumnIndex(Contract.Debt.WALLET_CURRENCY);
         int indexDebtMoney = cursor.getColumnIndex(Contract.Debt.MONEY);
         int indexDebtProgress = cursor.getColumnIndex(Contract.Debt.PROGRESS);
-        int indexDebtArchived = cursor.getColumnIndex(Contract.Debt.ARCHIVED);
+        int indexIsSettled = cursor.getColumnIndex(COLUMN_IS_SETTLED);
         if (cursor.moveToFirst()) {
             Header header = null;
             do {
-                int archived = cursor.getInt(indexDebtArchived);
+                boolean settled = cursor.getInt(indexIsSettled) == 1;
                 if (header != null) {
                     // check the header state
-                    if (archived == 0 && header.mType == 1) {
+                    if (!settled && header.mType == 1) {
                         throw new IllegalStateException("SQL query has failed to sort the items.");
                     }
-                    if (header.mType == 0 && archived == 1) {
+                    if (header.mType == 0 && settled) {
                         // we can store the previous header and create a new one
                         header = new Header(HEADER_ARCHIVED);
                         addHeader(header);
                     }
                 } else {
                     // initialize the header based on current item
-                    header = new Header(archived == 0 ? HEADER_CURRENT : HEADER_ARCHIVED);
+                    header = new Header(!settled ? HEADER_CURRENT : HEADER_ARCHIVED);
                     addHeader(header);
                 }
                 addItem(cursor.getPosition());
                 // if current header than sum the remaining money
-                if (archived == 0) {
+                if (!settled) {
                     String currency = cursor.getString(indexDebtCurrency);
                     long money = cursor.getLong(indexDebtMoney);
                     long progress = cursor.getLong(indexDebtProgress);
-                    long modulus = Math.abs(money) - Math.abs(progress);
-                    // TODO if modulus is < 0 than set it to 0?
+                    // clamped, not merely expected to be positive: a debt saved for no money is
+                    // treated as unsettled and can still have payments against it, and paying more
+                    // than is owed must not subtract from what is owed on everything else
+                    long modulus = Math.max(0, Math.abs(money) - Math.abs(progress));
                     header.addMoney(currency, modulus);
                 }
             } while (cursor.moveToNext());

--- a/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/DebtCursorAdapter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/DebtCursorAdapter.java
@@ -121,7 +121,10 @@ public class DebtCursorAdapter extends AbstractCursorAdapter {
                 }
                 break;
             case DebtHeaderCursor.HEADER_ARCHIVED:
-                holder.mLeftTextView.setText(R.string.header_debts_archived);
+                // the group holds debts archived by hand, which may still have money outstanding,
+                // and debts simply paid off in full. Neither Archived nor Completed is true of
+                // both, so it is named for what they share: no longer needing attention.
+                holder.mLeftTextView.setText(R.string.header_debts_finished);
                 holder.mRightTextView.setText(null);
                 break;
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/DebtListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/DebtListFragment.java
@@ -93,7 +93,8 @@ public class DebtListFragment extends CursorListFragment implements DebtCursorAd
                     Contract.Debt.EXPIRATION_DATE,
                     Contract.Debt.ARCHIVED,
                     Contract.Debt.PLACE_ID,
-                    Contract.Debt.PLACE_NAME
+                    Contract.Debt.PLACE_NAME,
+                    DebtHeaderCursor.SQL_IS_SETTLED + " AS " + DebtHeaderCursor.COLUMN_IS_SETTLED
             };
             String selection;
             String[] selectionArgs;
@@ -106,7 +107,10 @@ public class DebtListFragment extends CursorListFragment implements DebtCursorAd
                 selectionArgs = new String[] {String.valueOf(currentWallet)};
             }
             selection += " AND " + Contract.Debt.TYPE + " = " + String.valueOf(debtType.getValue());
-            String sortOrder = Contract.Debt.ARCHIVED + " ASC, " + Contract.Debt.DATE + " DESC";
+            // a debt that has been paid off in full is finished whether or not anyone remembered to
+            // archive it, so it belongs below the ones that still need attention. The grouping
+            // reads the same value back out of the projection, so the two cannot drift apart.
+            String sortOrder = DebtHeaderCursor.COLUMN_IS_SETTLED + " ASC, " + Contract.Debt.DATE + " DESC";
             return new WrappedCursorLoader(activity, uri, projection, selection, selectionArgs, sortOrder, debtType);
         }
         return null;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -326,6 +326,7 @@
     <string name="header_debts_to_pay">"To pay:"</string>
     <string name="header_debts_to_receive">"To receive:"</string>
     <string name="header_debts_archived">"Archived"</string>
+    <string name="header_debts_finished">"Finished"</string>
 
     <string name="message_no_currency_found">"No currency found"</string>
     <string name="message_no_wallet_found">"No wallet found"</string>


### PR DESCRIPTION
Fixes #56. Also fixes #61.

## What is wrong

Archiving was the only thing this app treated as finished, and it is a manual action. Paying a debt off in full set nothing, so the finished debt stayed in the group that still needs attention, and because the second sort key is newest first the one you had just finished paying tended to sit at the very top, above the ones you still owe. The row itself already read "This debt has been completed" while sitting there.

## The change

The list sorts and groups on settled, meaning archived by hand or paid off in full. The query selects that as a column and orders by it, and the header cursor reads the same column back rather than working the rule out again in Java.

That matters. `DebtHeaderCursor.generateHeaders` throws when the grouping disagrees with the sort, so a second copy of the rule would eventually surface as a crash of the debt list rather than a mis sort. One rule, one place, and the guard stays structurally unfailable.

A debt for no money is deliberately excluded. The amount is not required when saving one, so a debt of zero is unfinished data entry rather than a finished debt, and filing it under Finished is how it would get lost.

## A wrong total, corrected

The To pay heading summed money owed minus money paid for every row it considered current, and that term went negative whenever a debt had more paid against it than it was worth. So overpaying one debt quietly reduced the stated total for all of them.

With two debts of 100 each, one of them paid 120, the heading read `To pay: 80.00` while 100 was genuinely outstanding. Reproduced on a device before and after.

The term is now clamped at zero, which is what the TODO that sat on that line was asking about. Clamped rather than merely expected to be positive, because a debt saved for no money is treated as unsettled here and can still have payments recorded against it.

One follow on effect worth stating: in a wallet holding more than one currency, dropping settled rows can remove a currency from the heading entirely. That removes a line reading zero, and where only one currency is left the remaining amount renders in the short form rather than being labelled with its currency code.

## Naming

The group heading changes from Archived, since it now holds debts nobody archived. It is named Finished rather than Completed because an archived debt may still have money outstanding, so neither Archived nor Completed is true of every member. Added as a new string rather than by editing the old one, so no existing translation silently changes meaning.

## Nothing is written to the database

A debt is not archived by this, only sorted and grouped, so the change is reversible and the two states stay distinct.

## Verification

On an emulator with five debts: pending, paid off exactly, overpaid, archived with money outstanding, and one saved for zero with a payment against it. Before, the two paid ones sat above the pending one and the heading read 80.00. With the clamp removed and everything else in place it read 50.00. Complete, it reads 100.00, which is what is actually outstanding.