### PR TITLE
Open the category screen and the launcher on the common action

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelViewPagerFragment.java
@@ -56,6 +56,19 @@ public abstract class MultiPanelViewPagerFragment extends MultiPanelAppBarFragme
         mViewPager.setAdapter(onCreatePagerAdapter(getChildFragmentManager()));
         mViewPager.addOnPageChangeListener(this);
         mTabLayout.setupWithViewPager(mViewPager);
+        if (savedInstanceState == null) {
+            mViewPager.setCurrentItem(getDefaultViewPagerPosition(), false);
+        }
+    }
+
+    /**
+     * Which tab this screen opens on. Overridden where the leftmost tab is not the one people
+     * reach for. The tab is preserved across a configuration change or a restore from process
+     * death, but not across leaving the screen and coming back: the navigation drawer replaces
+     * fragments without a back stack, so returning builds a new one and lands here again.
+     */
+    protected int getDefaultViewPagerPosition() {
+        return 0;
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CategoryMultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CategoryMultiPanelViewPagerFragment.java
@@ -57,6 +57,14 @@ public class CategoryMultiPanelViewPagerFragment extends MultiPanelViewPagerItem
     }
 
     @Override
+    protected int getDefaultViewPagerPosition() {
+        // most people record far more expenses than income, so open on the expense tab. The
+        // category picker reached from a new transaction already does this; this is the standalone
+        // Categories screen catching up rather than a new idea.
+        return 1;
+    }
+
+    @Override
     protected int getTitleRes() {
         return R.string.menu_category;
     }

--- a/app/src/main/res/xml-v25/shortcuts.xml
+++ b/app/src/main/res/xml-v25/shortcuts.xml
@@ -1,17 +1,8 @@
 <shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <shortcut
-        android:icon="@drawable/ic_transfer_24dp"
-        android:shortcutId="fast_transfer"
-        android:shortcutLongLabel="@string/title_activity_new_transfer"
-        android:shortcutShortLabel="@string/title_activity_new_transfer">
-
-        <intent
-            android:action="android.intent.action.VIEW"
-            android:targetClass="com.oriondev.moneywallet.ui.activity.NewEditTransferActivity"
-            android:targetPackage="io.github.herrerad85.tallybook" />
-
-    </shortcut>
+    <!-- The launcher ranks these by document order, lowest first, so the most common action goes
+         first. Recording a transaction is what people open this app to do; a transfer between
+         their own wallets is the rarer of the two. -->
 
     <shortcut
         android:icon="@drawable/ic_add_24dp"
@@ -22,6 +13,19 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity"
+            android:targetPackage="io.github.herrerad85.tallybook" />
+
+    </shortcut>
+
+    <shortcut
+        android:icon="@drawable/ic_transfer_24dp"
+        android:shortcutId="fast_transfer"
+        android:shortcutLongLabel="@string/title_activity_new_transfer"
+        android:shortcutShortLabel="@string/title_activity_new_transfer">
+
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:targetClass="com.oriondev.moneywallet.ui.activity.NewEditTransferActivity"
             android:targetPackage="io.github.herrerad85.tallybook" />
 
     </shortcut>


### PR DESCRIPTION
Fixes #52.

## What is wrong

Most people record far more expenses than income, but the Categories screen opened on the income tab, and the launcher shortcut list led with New transfer, which is the rarest of the three things you can record.

Reported on the original upstream tracker in 2019 and again here in 2026.

## Why the tabs are not reordered

Several switches in that screen map tab position to `Contract.CategoryType`, including the add button. Reordering the tabs would have quietly inverted them, so the add button would create income categories while sitting on the expenses tab.

Only the tab shown first changes. The order is untouched.

The category picker reached from a new transaction already opens on expenses, so this is the standalone screen catching up rather than a new idea, and it is done the same way.

## Where the default lives

On the view pager base class rather than in the category screen alone, so any other screen keeps opening on its first tab and this one overrides it. The chosen tab survives a rotation and a restore from process death. It does not survive leaving the screen, because the navigation drawer replaces fragments without a back stack, so coming back builds a new one and applies the default again.

## Verification

On an emulator. The Categories screen opens on Expenses with the expense list showing, the tabs still read Incomes, Expenses, System in that order, and the add button still creates an expense category, which is the switch that would have broken had the tabs been reordered instead.

The launcher now ranks New transaction first, read back from the shortcut manager rather than from the file. Rank is all that was checked. Launching them was not, because both shortcuts hardcode the release application id while the debug build carries a suffix, so on a debug device they do not point at themselves. That is older than this change and is tracked on #62. Replacing the literal with a string resource does not work: the shortcut parser stores the reference unresolved and the component comes out with the raw resource id as its package, which is worse than the hardcoded value.