### PR TITLE
Follow the device 12 or 24 hour setting for times

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/picker/DateTimePicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/DateTimePicker.java
@@ -28,6 +28,7 @@ import androidx.fragment.app.FragmentManager;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+import com.oriondev.moneywallet.utils.DateFormatter;
 import com.philliphsu.bottomsheetpickers.date.DatePickerDialog;
 import com.philliphsu.bottomsheetpickers.time.BottomSheetTimePickerDialog;
 import com.philliphsu.bottomsheetpickers.time.numberpad.NumberPadTimePickerDialog;
@@ -152,7 +153,9 @@ public class DateTimePicker extends Fragment implements DatePickerDialog.OnDateS
     }
 
     public void showTimePicker() {
-        ThemedDialog.buildNumberPadTimePickerDialog(this, true)
+        // must match how the time is rendered next to this picker, which follows the device
+        // setting rather than a preference of this app
+        ThemedDialog.buildNumberPadTimePickerDialog(this, DateFormatter.is24HourFormat())
                 .build()
                 .show(getChildFragmentManager(), getTimePickerTag());
     }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
@@ -98,9 +98,15 @@ public class PreferenceManager {
     private static final int DEFAULT_COLOR_EXPENSE = Color.RED;
 
     private static SharedPreferences mPreferences;
+    private static Context mApplicationContext;
 
     public static void initialize(Context context) {
+        mApplicationContext = context.getApplicationContext();
         mPreferences = context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE);
+    }
+
+    public static Context getApplicationContext() {
+        return mApplicationContext;
     }
 
     public static void setCurrentWallet(Context context, long walletId) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UserInterfaceSettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UserInterfaceSettingFragment.java
@@ -19,7 +19,11 @@
 
 package com.oriondev.moneywallet.ui.fragment.secondary;
 
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
 import android.os.Bundle;
+import android.provider.Settings;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentManager;
@@ -39,6 +43,7 @@ import com.oriondev.moneywallet.ui.preference.ColorPreference;
 import com.oriondev.moneywallet.ui.preference.ThemedListPreference;
 import com.oriondev.moneywallet.ui.view.theme.ITheme;
 import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
+import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.DateFormatter;
 
 import java.text.DateFormatSymbols;
@@ -65,6 +70,7 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
     private ColorPreference mColorExpensePreference;
     private Preference mCustomDigitsSetupPreference;
     private ThemedListPreference mDateFormatPreference;
+    private Preference mTimeFormatPreference;
     private ThemedListPreference mFirstDayWeekPreference;
     private ThemedListPreference mFirstDayMonthPreference;
     private ThemedListPreference mGroupTypePreference;
@@ -86,6 +92,7 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
         mColorExpensePreference = (ColorPreference) findPreference("expense_color");
         mCustomDigitsSetupPreference = findPreference("custom_digits");
         mDateFormatPreference = (ThemedListPreference) findPreference("date_format");
+        mTimeFormatPreference = findPreference("time_format");
         mFirstDayWeekPreference = (ThemedListPreference) findPreference("first_day_week");
         mFirstDayMonthPreference = (ThemedListPreference) findPreference("first_day_month");
         mGroupTypePreference = (ThemedListPreference) findPreference("group_type");
@@ -120,18 +127,7 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
         // setup date format preference: we use a dynamic version that render the current
         // datetime of the device using all the available datetime patterns to help the
         // user to decide which is better for him
-        Date now = Calendar.getInstance().getTime();
-        mDateFormatPreference.setEntries(new String[] {
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_0),
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_1),
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_2),
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_3),
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_4),
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_5),
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_6),
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_7),
-                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_8)
-        });
+        setupDateFormatEntries();
         mDateFormatPreference.setEntryValues(new String[] {
                 String.valueOf(PreferenceManager.DATE_FORMAT_TYPE_0),
                 String.valueOf(PreferenceManager.DATE_FORMAT_TYPE_1),
@@ -193,6 +189,7 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
         mThemeTypePreference.setEntryValues(new String[] {THEME_TYPE_LIGHT, THEME_TYPE_DARK, THEME_TYPE_DEEP_DARK});
         // setup current values
         setupCurrentDateFormat();
+        setupCurrentTimeFormat();
         setupCurrentFirstDayOfWeek();
         setupCurrentFirstDayOfMonth();
         setupCurrentGroupType();
@@ -214,6 +211,26 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
                 int index = Integer.parseInt((String) newValue);
                 PreferenceManager.setCurrentDateFormatIndex(index);
                 setupCurrentDateFormat();
+                return false;
+            }
+
+        });
+        mTimeFormatPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                try {
+                    startActivity(new Intent(Settings.ACTION_DATE_SETTINGS));
+                } catch (ActivityNotFoundException e) {
+                    Activity activity = getActivity();
+                    if (activity != null) {
+                        ThemedDialog.buildMaterialDialog(activity)
+                                .title(R.string.title_error)
+                                .content(R.string.message_error_activity_not_found)
+                                .positiveText(android.R.string.ok)
+                                .show();
+                    }
+                }
                 return false;
             }
 
@@ -286,6 +303,37 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
         String summary = DateFormatter.getFormattedDateTime(Calendar.getInstance().getTime(), index);
         mDateFormatPreference.setValue(String.valueOf(index));
         mDateFormatPreference.setSummary(summary);
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // the 12 or 24 hour choice lives in the system settings, which the Time format row links
+        // to, so everything that renders a time can be stale on the way back: the two summaries
+        // and the nine dated examples inside the date format dialog
+        setupCurrentTimeFormat();
+        setupCurrentDateFormat();
+        setupDateFormatEntries();
+    }
+
+    private void setupDateFormatEntries() {
+        Date now = Calendar.getInstance().getTime();
+        mDateFormatPreference.setEntries(new String[] {
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_0),
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_1),
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_2),
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_3),
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_4),
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_5),
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_6),
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_7),
+                DateFormatter.getFormattedDateTime(now, PreferenceManager.DATE_FORMAT_TYPE_8)
+        });
+    }
+
+    private void setupCurrentTimeFormat() {
+        String example = DateFormatter.getFormattedTime(Calendar.getInstance().getTime());
+        mTimeFormatPreference.setSummary(getString(R.string.setting_summary_ui_time_format, example));
     }
 
     private void setupCurrentFirstDayOfWeek() {

--- a/app/src/main/java/com/oriondev/moneywallet/utils/DateFormatter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/DateFormatter.java
@@ -47,17 +47,20 @@ public class DateFormatter {
     public static final String DATE_PATTERN_7 = "MM/dd/yyyy";
     public static final String DATE_PATTERN_8 = "EEE MM/dd/yyyy";
 
-    private static final String[][] DATE_FORMATS = new String[][] {
-            new String[] {"EEEE dd MMMM yyyy", "HH:mm", "EEEE dd MMMM yyyy, HH:mm"},
-            new String[] {"EEEE dd MMM yyyy", "HH:mm", "EEEE dd MMM yyyy, HH:mm"},
-            new String[] {"EEE dd MMM yyyy", "HH:mm", "EEE dd MMM yyyy, HH:mm"},
-            new String[] {"dd MMM yyyy", "HH:mm", "dd MMM yyyy, HH:mm"},
-            new String[] {"EEE dd/MM/yyyy", "HH:mm", "EEE dd/MM/yyyy, HH:mm"},
-            new String[] {"dd/MM/yyyy", "HH:mm", "dd/MM/yyyy, HH:mm"},
-            new String[] {"yyyy/MM/dd", "HH:mm", "yyyy/MM/dd, HH:mm"},
-            new String[] {"MM/dd/yyyy", "HH:mm", "MM/dd/yyyy, HH:mm"},
-            new String[] {"EEE MM/dd/yyyy", "HH:mm", "EEE MM/dd/yyyy, HH:mm"}
+    private static final String[] DATE_FORMATS = new String[] {
+            DATE_PATTERN_0,
+            DATE_PATTERN_1,
+            DATE_PATTERN_2,
+            DATE_PATTERN_3,
+            DATE_PATTERN_4,
+            DATE_PATTERN_5,
+            DATE_PATTERN_6,
+            DATE_PATTERN_7,
+            DATE_PATTERN_8
     };
+
+    private static final String TIME_SKELETON_24_HOUR = "Hm";
+    private static final String TIME_SKELETON_12_HOUR = "hm";
 
     public static void applyDate(TextView textView, Date date) {
         textView.setText(getFormattedDate(date));
@@ -93,11 +96,7 @@ public class DateFormatter {
     }
 
     public static String getFormattedTime(Date date) {
-        return getFormattedTime(date, PreferenceManager.getCurrentDateFormatIndex());
-    }
-
-    public static String getFormattedTime(Date date, int index) {
-        return getUserTimeFormat(index).format(date);
+        return new SimpleDateFormat(getTimePattern(), Locale.getDefault()).format(date);
     }
 
     public static String getFormattedDateTime(Date date) {
@@ -132,27 +131,36 @@ public class DateFormatter {
         textView.setText(getTimeRange(context, start, end));
     }
 
-    private static DateFormat getUserDateFormat(int index) {
-        int safeIndex = 0;
-        if (index >= 0 && index < DATE_FORMATS.length) {
-            safeIndex = index;
-        }
-        return new SimpleDateFormat(DATE_FORMATS[safeIndex][0], Locale.getDefault());
+    /**
+     * The time pattern follows the device wide 12 or 24 hour setting rather than a preference of
+     * this app, so that times here read the same way as times everywhere else on the device. The
+     * Time format row in the interface settings says so and links to the system screen.
+     * <p>
+     * The pattern comes from the locale rather than being written out here, because the position
+     * of the AM and PM marker is not the same in every language: Chinese puts it before the time.
+     */
+    public static String getTimePattern() {
+        String skeleton = is24HourFormat() ? TIME_SKELETON_24_HOUR : TIME_SKELETON_12_HOUR;
+        return android.text.format.DateFormat.getBestDateTimePattern(Locale.getDefault(), skeleton);
     }
 
-    private static DateFormat getUserTimeFormat(int index) {
+    public static boolean is24HourFormat() {
+        return android.text.format.DateFormat.is24HourFormat(PreferenceManager.getApplicationContext());
+    }
+
+    private static String getDatePattern(int index) {
         int safeIndex = 0;
         if (index >= 0 && index < DATE_FORMATS.length) {
             safeIndex = index;
         }
-        return new SimpleDateFormat(DATE_FORMATS[safeIndex][1], Locale.getDefault());
+        return DATE_FORMATS[safeIndex];
+    }
+
+    private static DateFormat getUserDateFormat(int index) {
+        return new SimpleDateFormat(getDatePattern(index), Locale.getDefault());
     }
 
     private static DateFormat getUserDateTimeFormat(int index) {
-        int safeIndex = 0;
-        if (index >= 0 && index < DATE_FORMATS.length) {
-            safeIndex = index;
-        }
-        return new SimpleDateFormat(DATE_FORMATS[safeIndex][2], Locale.getDefault());
+        return new SimpleDateFormat(getDatePattern(index) + ", " + getTimePattern(), Locale.getDefault());
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,8 @@
     <string name="setting_title_ui_custom_digits">"Display style of digits"</string>
     <string name="setting_summary_ui_custom_digits">"Personalize the display style of digits"</string>
     <string name="setting_title_ui_date_format">"Date format"</string>
+    <string name="setting_title_ui_time_format">"Time format"</string>
+    <string name="setting_summary_ui_time_format">"%1$s, set in your device settings"</string>
     <string name="setting_title_ui_first_day_week">"First day of week"</string>
     <string name="setting_title_ui_first_day_month">"First day of month"</string>
     <string name="setting_title_ui_group_type">"Grouping"</string>

--- a/app/src/main/res/xml/settings_user_interface.xml
+++ b/app/src/main/res/xml/settings_user_interface.xml
@@ -42,6 +42,11 @@
             android:title="@string/setting_title_ui_date_format"
             android:persistent="false" />
 
+        <com.oriondev.moneywallet.ui.preference.ThemedPreference
+            android:key="time_format"
+            android:title="@string/setting_title_ui_time_format"
+            android:persistent="false" />
+
         <com.oriondev.moneywallet.ui.preference.ThemedListPreference
             android:key="first_day_week"
             android:title="@string/setting_title_ui_first_day_week"


### PR DESCRIPTION
Fixes #54.

## What is wrong

Times were always rendered in 24 hour form. The pattern was hardcoded in every row of the date format table, so a device set to 12 hour still saw 18:54 here while every other app on it showed 6:54 PM.

## The change

The pattern comes from `getBestDateTimePattern` for the current locale, with the skeleton chosen by `is24HourFormat`. Asking the locale rather than writing the pattern out matters because the AM and PM marker does not go in the same place in every language: Chinese puts it first.

The date format table loses its time and its date with time columns, since both are now derived, and one unused overload goes with them, so the file is shorter than before. `PreferenceManager` keeps the application context it is already handed at startup.

The time picker followed the same hardcoded 24 hour choice. It agreed with the field before this change and would have disagreed after it, so it now reads the same setting and opens the matching keypad.

## Making the setting visible

A setting that lives somewhere else is invisible, so the interface settings gain a Time format row under Date format. It shows a live example with the reason, "7:13 PM, set in your device settings", and opens the system date and time screen when tapped, guarded the way every other implicit intent in this app already is.

Everything on that screen that renders a time is rebuilt in `onResume`, including the nine examples inside the date format dialog, because the value can change while the user is away on exactly that trip.

## Two things worth stating plainly

Taking the pattern from the locale means the 24 hour rendering is unchanged only where the locale pattern is `HH:mm`, which covers English. A few locales use `H:mm` or a dot separator, so their times shift slightly. That is the locale being respected rather than a regression.

The number pad the picker opens labels its AM and PM keys in English when the localized markers are longer than two characters. That is a limitation of the picker library and was unreachable while the mode was pinned to 24 hour.

## No in app override

Deliberately not included. If enough people ask for one it can be added later without undoing any of this.

## Verification

On an emulator, both directions. On a 12 hour device the field reads 7:11 PM and the picker offers AM and PM; on a 24 hour device the same field reads 19:12 and the picker offers :00 and :30. Flipping the system setting with the app backgrounded updates the row, the summary and all nine dialog entries on return, with no restart.