### PR TITLE
Render the daily reminder hour the way the rest of the app does

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UtilitySettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UtilitySettingFragment.java
@@ -25,6 +25,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.text.format.DateUtils;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -49,7 +50,11 @@ import com.oriondev.moneywallet.ui.preference.ThemedInputPreference;
 import com.oriondev.moneywallet.ui.preference.ThemedListPreference;
 import com.oriondev.moneywallet.utils.DateFormatter;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * Created by andrea on 07/03/18.
@@ -57,6 +62,8 @@ import java.util.Date;
 public class UtilitySettingFragment extends PreferenceFragmentCompat {
 
     private static final int REQUEST_CODE_LOCK_ACTIVITY = 8239;
+
+    private static final int HOURS_IN_DAY = 24;
 
     private ThemedListPreference mDailyReminderPreference;
     private ThemedListPreference mSecurityModeListPreference;
@@ -102,18 +109,9 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
         // setup preference logic
-        mDailyReminderPreference.setEntries(new String[] {
-                getString(R.string.setting_item_security_none),
-                "00:00", "01:00", "02:00", "03:00", "04:00", "05:00",
-                "06:00", "07:00", "08:00", "09:00", "10:00", "11:00",
-                "12:00", "13:00", "14:00", "15:00", "16:00", "17:00",
-                "18:00", "19:00", "20:00", "21:00", "22:00", "23:00"
-        });
-        mDailyReminderPreference.setEntryValues(new String[] {
-                String.valueOf(PreferenceManager.DAILY_REMINDER_DISABLED),
-                "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11",
-                "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "23"
-        });
+        // must precede setupCurrentDailyReminder below: setting the value looks it up in the
+        // entry values, and onResume is too late because it runs after this
+        setupDailyReminderEntries();
         if (isFingerprintAuthSupported(getActivity())) {
             mSecurityModeListPreference.setEntries(new String[] {
                     getString(R.string.setting_item_security_none),
@@ -274,13 +272,61 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
                 || status == BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED;
     }
 
+    @Override
+    public void onResume() {
+        super.onResume();
+        // the 12 or 24 hour choice lives in the system settings and changing it is not a
+        // configuration change, so nothing recreates this screen on the way back
+        setupDailyReminderEntries();
+        setupCurrentDailyReminder();
+        // this row renders a time too, from the same place, so leaving it out would have the two
+        // rows on one screen disagreeing about the format
+        setupCurrentExchangeRateUpdate();
+    }
+
+    /**
+     * The hours were written out as fixed 24 hour strings, which read wrong on a device set to 12
+     * hour and in Persian, which does not use Latin digits. The pattern comes from DateFormatter so
+     * this row follows the same decision as every other time in the app rather than deriving it
+     * again from the platform.
+     */
+    private void setupDailyReminderEntries() {
+        String[] entries = new String[HOURS_IN_DAY + 1];
+        String[] values = new String[HOURS_IN_DAY + 1];
+        entries[0] = getString(R.string.setting_item_daily_reminder_none);
+        values[0] = String.valueOf(PreferenceManager.DAILY_REMINDER_DISABLED);
+        DateFormat format = hourOfDayFormat();
+        for (int hour = 0; hour < HOURS_IN_DAY; hour++) {
+            entries[hour + 1] = formatHourOfDay(format, hour);
+            values[hour + 1] = String.valueOf(hour);
+        }
+        mDailyReminderPreference.setEntries(entries);
+        mDailyReminderPreference.setEntryValues(values);
+    }
+
+    /**
+     * Formatted in UTC deliberately. These are hours of a day rather than moments in time, and
+     * putting an hour into a local calendar means asking for a wall time that does not exist on the
+     * morning the clocks go forward. Which hour depends on the zone: where the shift is at 02:00,
+     * that hour vanishes from the list and 03:00 appears twice, once a year.
+     */
+    private static DateFormat hourOfDayFormat() {
+        SimpleDateFormat format = new SimpleDateFormat(DateFormatter.getTimePattern(), Locale.getDefault());
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format;
+    }
+
+    private static String formatHourOfDay(DateFormat format, int hour) {
+        return format.format(new Date(hour * DateUtils.HOUR_IN_MILLIS));
+    }
+
     private void setupCurrentDailyReminder() {
         int hour = PreferenceManager.getCurrentDailyReminder();
         mDailyReminderPreference.setValue(String.valueOf(hour));
         if (hour == PreferenceManager.DAILY_REMINDER_DISABLED) {
             mDailyReminderPreference.setSummary(R.string.setting_item_daily_reminder_none);
         } else {
-            String summary = getString(R.string.setting_summary_daily_reminder, hour);
+            String summary = getString(R.string.setting_summary_daily_reminder, formatHourOfDay(hourOfDayFormat(), hour));
             mDailyReminderPreference.setSummary(summary);
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -521,7 +521,7 @@
     <string name="setting_summary_exchange_rate_api_key_missing">API-Schlüssel fehlt</string>
     <string name="setting_summary_exchange_rate_api_key">API-Schlüssel: %s</string>
     <string name="setting_summary_database_backup_services">Datenbank erstellen und wiederherstellen</string>
-    <string name="setting_summary_daily_reminder">Täglich um %02d:00</string>
+    <string name="setting_summary_daily_reminder">Täglich um %1$s</string>
     <string name="setting_summary_currency_management">Benutzerdefinierte Währung hinzufügen</string>
     <string name="setting_subtitle_utility">Konfiguration</string>
     <string name="setting_subtitle_user_interface">Personalisiere</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -474,7 +474,7 @@
     <string name="setting_category_utility_security">"Ασφάλεια"</string>
     <string name="setting_category_utility_exchange_rates">"Ισοτιμίες συναλλάγματος"</string>
     <string name="setting_title_daily_reminder">"Καθημερινή υπενθύμιση"</string>
-    <string name="setting_summary_daily_reminder">"Κάθε μέρα στις: %02d:00"</string>
+    <string name="setting_summary_daily_reminder">"Κάθε μέρα στις: %1$s"</string>
     <string name="setting_title_security">"Προστασία πρόσβασης"</string>
     <string name="setting_title_security_change_pin">"Άλλαξε τον αριθμό PIN"</string>
     <string name="setting_title_security_change_sequence">"Άλλαξε την ακολουθία ξεκλειδώματος"</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -433,7 +433,7 @@
     <string name="setting_category_utility_security">"امنیت"</string>
     <string name="setting_category_utility_exchange_rates">"نرخ‌های تبدیل"</string>
     <string name="setting_title_daily_reminder">"یادآوری روزانه"</string>
-    <string name="setting_summary_daily_reminder">"هر روز در: %02d:00"</string>
+    <string name="setting_summary_daily_reminder">"هر روز در: %1$s"</string>
     <string name="setting_title_security">"حفاظت از دسترسی"</string>
     <string name="setting_title_security_change_pin">"تغییر کد پین"</string>
     <string name="setting_title_security_change_sequence">"تغییر توالی باز کردن"</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -473,7 +473,7 @@
     <string name="setting_category_utility_security">"Sécurité"</string>
     <string name="setting_category_utility_exchange_rates">"Taux de change"</string>
     <string name="setting_title_daily_reminder">"Rappel quotidien"</string>
-    <string name="setting_summary_daily_reminder">"Chaque jour à : %02d:00"</string>
+    <string name="setting_summary_daily_reminder">"Chaque jour à : %1$s"</string>
     <string name="setting_title_security">"Protection"</string>
     <string name="setting_title_security_change_pin">"Changer le code PIN"</string>
     <string name="setting_title_security_change_sequence">"Changer le schéma"</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -480,7 +480,7 @@
     <string name="setting_subtitle_user_interface">Személyre szabás</string>
     <string name="setting_subtitle_utility">Elérhető eszközök telepítése</string>
     <string name="setting_summary_currency_management">Saját valuták hozzáadása</string>
-    <string name="setting_summary_daily_reminder">Minden nap %02d:00 időpontban</string>
+    <string name="setting_summary_daily_reminder">Minden nap %1$s időpontban</string>
     <string name="setting_summary_database_backup_services">Adatbázis készítése és visszaállítása</string>
     <string name="setting_summary_exchange_rate_api_key">API kulcs: %s</string>
     <string name="setting_summary_exchange_rate_api_key_missing">API kulcs hiányzik</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -473,7 +473,7 @@
     <string name="setting_category_utility_security">"Sicurezza"</string>
     <string name="setting_category_utility_exchange_rates">"Tassi di cambio"</string>
     <string name="setting_title_daily_reminder">"Promemoria giornaliero"</string>
-    <string name="setting_summary_daily_reminder">"Ogni giorno alle: %02d:00"</string>
+    <string name="setting_summary_daily_reminder">"Ogni giorno alle: %1$s"</string>
     <string name="setting_title_security">"Protezione accesso"</string>
     <string name="setting_title_security_change_pin">"Cambia codice pin"</string>
     <string name="setting_title_security_change_sequence">"Cambia sequenza di sblocco"</string>

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -460,7 +460,7 @@
     <string name="setting_category_utility_security">"സുരക്ഷ"</string>
     <string name="setting_category_utility_exchange_rates">"വിനിമയ നിരക്ക്"</string>
     <string name="setting_title_daily_reminder">"പ്രതിദിന ഓർമ്മപ്പെടുത്തൽ"</string>
-    <string name="setting_summary_daily_reminder">"എല്ലാ ദിവസവും: d: 00"</string>
+    <string name="setting_summary_daily_reminder">"എല്ലാ ദിവസവും: %1$s"</string>
     <string name="setting_title_security">"ആക്സസ് പരിരക്ഷണം"</string>
     <string name="setting_title_security_change_pin">"പിൻ കോഡ് മാറ്റുക"</string>
     <string name="setting_title_security_change_sequence">"അൺലോക്ക് സീക്വൻസ് മാറ്റുക"</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -476,7 +476,7 @@
     <string name="setting_category_utility_security">"Bezpieczeństwo"</string>
     <string name="setting_category_utility_exchange_rates">"Kurs wymiany"</string>
     <string name="setting_title_daily_reminder">"Codzienne przypomnienie"</string>
-    <string name="setting_summary_daily_reminder">"Codziennie o godz: %02d:00"</string>
+    <string name="setting_summary_daily_reminder">"Codziennie o godz: %1$s"</string>
     <string name="setting_title_security">"Ochrona dostępu"</string>
     <string name="setting_title_security_change_pin">"Zmień kod PIN"</string>
     <string name="setting_title_security_change_sequence">"Zmień sekwencję odblokowania"</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -475,7 +475,7 @@
     <string name="setting_category_utility_security">"Segurança"</string>
     <string name="setting_category_utility_exchange_rates">"Taxas de câmbio"</string>
     <string name="setting_title_daily_reminder">"Aviso diário"</string>
-    <string name="setting_summary_daily_reminder">"Todo dia as: %02d:00"</string>
+    <string name="setting_summary_daily_reminder">"Todo dia as: %1$s"</string>
     <string name="setting_title_security">"Proteção de acesso"</string>
     <string name="setting_title_security_change_pin">"Mudar código pin"</string>
     <string name="setting_title_security_change_sequence">"Mudar sequencia de desbloqueio"</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -461,7 +461,7 @@
     <string name="setting_category_utility_security"> "Güvenlik" </string>
     <string name="setting_category_utility_exchange_rates"> "Döviz kurları" </string>
     <string name="setting_title_daily_reminder"> "Günlük hatırlatma" </string>
-    <string name="setting_summary_daily_reminder"> "Her gün:% 02d: 00" </string>
+    <string name="setting_summary_daily_reminder"> "Her gün: %1$s" </string>
     <string name="setting_title_security"> "Erişim koruması" </string>
     <string name="setting_title_security_change_pin"> "PIN kodunu değiştir" </string>
     <string name="setting_title_security_change_sequence"> "Kilit açma sırasını değiştir" </string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -493,7 +493,7 @@
     <string name="setting_category_utility_security">"Security"</string>
     <string name="setting_category_utility_exchange_rates">"Exchange rates"</string>
     <string name="setting_title_daily_reminder">"Daily reminder"</string>
-    <string name="setting_summary_daily_reminder">"Every day at: %02d:00"</string>
+    <string name="setting_summary_daily_reminder">"Every day at: %1$s"</string>
     <string name="setting_title_security">"Access protection"</string>
     <string name="setting_title_security_change_pin">"Change pin code"</string>
     <string name="setting_title_security_change_sequence">"Change unlock sequence"</string>


### PR DESCRIPTION
Fixes #60.

## What is wrong

The reminder setting wrote its hours out as fixed 24 hour strings, both in the list of hours to choose from and in the summary underneath the row. That reads wrong on a device set to 12 hour.

It also read wrong in Persian, which this app ships a translation for and which does not use Latin digits. The picker was Latin throughout. The summary rendered its hour in Persian digits, because the resource formatter localises a numeric placeholder, while the `:00` the string carried as literal text stayed Latin.

## The change

Both now format through `DateFormatter`, so this row follows the same decision as every other time in the app rather than working the device setting out again for itself.

Formatted in UTC deliberately. These are hours of a day rather than moments in time, and putting an hour into a local calendar asks for a wall time that does not exist on the morning the clocks go forward. In a zone that observes it one hour vanishes from the list and the next appears twice, once a year, with the two rows storing different values and looking identical. Which hour depends on the zone. The alarm itself keeps using a local calendar, where normalising forward is the behaviour you want.

The hour list and its stored values are built together in one loop, since they have to stay the same length and in the same order. Both were written out by hand before; generating only the labels would have left 24 literals sitting opposite a loop.

The disabled row now uses the same string as the summary that describes that state, rather than borrowing the one from the security section. The two are identical in every locale, so nothing changes on screen.

## Refreshing

Both are rebuilt in `onResume`, because the device setting can change while the user is away and that is not a configuration change, so nothing else would refresh this screen. The exchange rate row is rebuilt with them: it renders a time from the same source, and refreshing only the reminder would leave two rows on one screen disagreeing about the format.

## Translations

The summary keeps its existing string name and every translation of it now takes a formatted time, rather than adding a second string and leaving ten locales on an English fallback. Two of them were already wrong: the Malayalam one had lost its placeholder entirely and never showed a time at all, and the Turkish one had stray spaces that rendered it as "7: 00". Both are corrected in the same pass.

## Verification

On an emulator. With the device on 12 hour the row reads "Every day at: 7:00 AM" and the picker lists 12 hour times. Opened the screen on 24 hour, went into a sub screen, flipped the device while there, and came back: both the reminder and the exchange rate rows follow. Set back to 24 hour, everything reads as before.