### PR TITLE
Load a recurring transfer from the recurring transfers table

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditRecurrentTransferActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditRecurrentTransferActivity.java
@@ -272,7 +272,7 @@ public class NewEditRecurrentTransferActivity extends NewEditItemActivity implem
         if (savedInstanceState == null) {
             ContentResolver contentResolver = getContentResolver();
             if (getMode() == Mode.EDIT_ITEM) {
-                Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSFER_MODELS, getItemId());
+                Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_RECURRENT_TRANSFERS, getItemId());
                 String[] projection = new String[] {
                         Contract.RecurrentTransfer.DESCRIPTION,
                         Contract.RecurrentTransfer.WALLET_FROM_ID,


### PR DESCRIPTION
Closes #58.

One line. The EDIT_ITEM branch of `NewEditRecurrentTransferActivity` built its uri from `CONTENT_TRANSFER_MODELS`, so the load went to the transfer models query.

## Why it throws

The projection immediately below that line lists twenty nine entries, twenty eight distinct, since `WALLET_TO_ID` is written twice. Thirteen of the twenty eight are base table columns of `recurrent_transfers`, and `getTransferModels` never emits them, so SQLite answers `no such column: recurrent_transfer_description`, the first of the thirteen in projection order.

The other fifteen do resolve, which is the part that makes this look smaller than it is: `Contract.RecurrentTransfer` and `Contract.TransferModel` use byte identical alias strings for every joined wallet, event and place column, so those fifteen are the same name in both queries.

`DataContentProvider` has no `catch` anywhere in the file, and the query runs from `onViewCreated` on the main thread, so it is a process kill rather than a caught error.

Even with a matching projection the uri was wrong. It would have loaded whichever unrelated transfer model happened to share the numeric id, or come up blank when none did.

## What this touches

The one uri. Nothing else in the file, and no other screen. The sibling `NewEditRecurrentTransactionActivity` already loads from `CONTENT_RECURRENT_TRANSACTIONS`, and the insert and update further down this same file already use `CONTENT_RECURRENT_TRANSFERS`. Only this load did not, and it has been that way since the initial commit.

Every one of the twenty eight columns the projection asks for was compared against the aliases `getRecurrentTransfers` actually emits. All present, so the projection needed no change.

## How it was checked

Nothing reaches this branch today. The only launch site always passes `NEW_ITEM`, and both recurrence panels serve a delete only menu. So the activity was launched with an explicit `EDIT_ITEM` intent against a seeded recurring transfer, on an Android 16 emulator, with the uri put back and taken out again:

* old uri: the process dies with that `SQLiteException` before the activity is drawn
* new uri: the screen opens with the description, both wallets, the amount and the rule filled in from the right row

## One limitation

This does not make the screen usable on its own. `SQLDatabase.updateRecurrentTransfer` returns 0 for anything that is not an occurrence bump, so a save from here is discarded while the screen closes as though it worked, and `updateRecurrentTransaction` is the same. That is the unfinished half already described in #51. This fixes the load so that work has something correct to build on.