### PR TITLE
Skip preferred locales that imply no currency instead of throwing

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/CurrencyConverterActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/CurrencyConverterActivity.java
@@ -219,7 +219,7 @@ public class CurrencyConverterActivity extends SinglePanelActivity implements Vi
     private CurrencyUnit getDefaultCurrencyUnit(boolean primary) {
         CurrencyUnit currencyUnit = CurrencyManager.getDefaultCurrency();
         if (!primary) {
-            return currencyUnit.getIso().equals(EUR) ?
+            return currencyUnit != null && EUR.equals(currencyUnit.getIso()) ?
                     CurrencyManager.getCurrency(USD) : CurrencyManager.getCurrency(EUR);
         }
         return currencyUnit;
@@ -270,6 +270,19 @@ public class CurrencyConverterActivity extends SinglePanelActivity implements Vi
 
     @Override
     public void onCurrencyChanged(String tag, CurrencyUnit currency) {
+        if (currency == null) {
+            // nothing is selected, which CurrencyPicker allows and this screen did not
+            if (TAG_CURRENCY_FROM_PICKER.equals(tag)) {
+                clearCurrencyRow(mImageCurrencyFrom, mTextCurrencyFrom);
+            } else if (TAG_CURRENCY_TO_PICKER.equals(tag)) {
+                clearCurrencyRow(mImageCurrencyTo, mTextCurrencyTo);
+            }
+            // either side missing makes the result unconvertible, so say so for both
+            mTextMoneyTo.setText(R.string.hint_unknown);
+            // the last used preference is deliberately left pointing at the last real choice,
+            // so reopening the screen offers that rather than nothing
+            return;
+        }
         switch (tag) {
             case TAG_CURRENCY_FROM_PICKER:
                 loadCurrencyFlag(mImageCurrencyFrom, currency.getIso());
@@ -287,6 +300,17 @@ public class CurrencyConverterActivity extends SinglePanelActivity implements Vi
         }
     }
 
+    /**
+     * Empty one of the two currency rows. Both calls are needed: clear cancels a flag load that
+     * has not landed yet, and only loadCurrencyFlag's Glide branch tags a request for it to find,
+     * while the branch for a currency with no flag drawable leaves the drawable set by hand.
+     */
+    private void clearCurrencyRow(ImageView imageView, TextView textView) {
+        Glide.with(this).clear(imageView);
+        imageView.setImageDrawable(null);
+        textView.setText(null);
+    }
+
     private void loadCurrencyFlag(ImageView imageView, String iso) {
         int flag = CurrencyUnit.getCurrencyFlag(this, iso);
         if (flag > 0) {
@@ -295,6 +319,8 @@ public class CurrencyConverterActivity extends SinglePanelActivity implements Vi
                     .load(flag)
                     .into(imageView);
         } else {
+            // into() cancels a pending load for us on the branch above, this branch has to ask
+            Glide.with(this).clear(imageView);
             imageView.setImageDrawable(CurrencyUnit.getCurrencyDrawable(iso));
         }
     }

--- a/app/src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java
@@ -23,6 +23,7 @@ import android.content.ContentResolver;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.os.LocaleList;
 
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.ExchangeRate;
@@ -169,20 +170,57 @@ public class CurrencyManager {
         }
     }
 
+    /**
+     * @return the rate between the two currencies, or null if either is absent or no rate is
+     *         known for the pair.
+     */
     public static ExchangeRate getExchangeRate(CurrencyUnit currency1, CurrencyUnit currency2) {
+        if (currency1 == null || currency2 == null) {
+            return null;
+        }
         return mInstance.mExchangeRateCache.getExchangeRate(currency1.getIso(), currency2.getIso());
     }
 
     /**
-     * Obtain the currency of the current locale used by the application.
-     * If for example the user is using the Italian locale, the EUR currency will be returned.
-     * @return the current currency.
+     * Obtain the currency the user's language settings imply.
+     * If for example the user is using the it-IT locale, the EUR currency will be returned.
+     * A locale that carries no country implies no currency at all, so those are skipped and
+     * the first preferred locale that does imply one decides. Whether this installation still
+     * has that currency is a separate question, and a deleted one still answers null rather
+     * than moving on to the next locale.
+     * @return the current currency, or null if no preferred locale implies one, or the user
+     *         has deleted the one it implies.
      */
     public static CurrencyUnit getDefaultCurrency() {
         synchronized (CACHE_MUTEX) {
-            Locale locale = Locale.getDefault();
-            Currency currency = Currency.getInstance(locale);
-            return getCurrency(currency.getCurrencyCode());
+            LocaleList preferredLocales = LocaleList.getAdjustedDefault();
+            for (int index = 0; index < preferredLocales.size(); index++) {
+                Currency currency = currencyOf(preferredLocales.get(index));
+                if (currency != null) {
+                    CurrencyUnit currencyUnit = getCurrency(currency.getCurrencyCode());
+                    if (currencyUnit == null) {
+                        System.out.println("[CurrencyManager] The locale implies "
+                                + currency.getCurrencyCode() + ", which is not installed");
+                    }
+                    return currencyUnit;
+                }
+            }
+            System.out.println("[CurrencyManager] No preferred locale implies a currency: "
+                    + preferredLocales.toLanguageTags());
+            return null;
+        }
+    }
+
+    /**
+     * @return the currency the locale implies, or null if it implies none. getInstance throws
+     *         when the locale has no ISO 3166 country and returns null for a territory that has
+     *         no currency of its own, and here those mean the same thing.
+     */
+    private static Currency currencyOf(Locale locale) {
+        try {
+            return Currency.getInstance(locale);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
Closes #69.

Three process kills, only one of which has anything to do with language. Two files.

## The reported one

Opening Settings killed the app on any app locale with no region. `SettingMultiPanelFragment` builds `UserInterfaceSettingFragment` as soon as the screen opens, which loads `CustomDigitSetupDialog`, whose static field calls `CurrencyManager.getDefaultCurrency`. `Currency.getInstance(Locale)` throws rather than returning null when the locale has no ISO 3166 country. It also returns null, rather than throwing, for a territory with no currency of its own, which the old code would then have dereferenced.

`getDefaultCurrency` now walks the preferred locale list, skips the entries that imply nothing, and the first one that does imply a currency decides. The list comes from `LocaleList.getAdjustedDefault` rather than `getDefault`, because only the former guarantees `Locale.getDefault` is at the top, which makes the first iteration exactly the lookup this method used to do on its own.

**It still returns null when the locale implies a currency the user has deleted, deliberately.** That is what master did, and it is the right answer: `NewEditWalletActivity` is where this value becomes stored money data, and there a null leaves the field blank and the validator refuses the save, so the user has to choose. Filling it in with a different language's currency would create a wallet denominated in something nobody picked. So the only behaviour that changes is that a locale implying nothing is skipped rather than fatal.

## The two underneath, which are on master today

Delete EUR while no wallet uses it, which the currency editor allows, and `getDefaultCurrencyUnit` returns null with no locale involved at all. Both converter pickers reach it on a first open, since the last used currency preferences start null. That null reaches three dereferences:

* `getDefaultCurrencyUnit` compared it against EUR
* `onCurrencyChanged` read its iso when the picker announced itself, so **the converter dies on open**
* `makeConversion` passed it to `getExchangeRate`, so with only the first two fixed **it dies on the first keypad tap instead**

The third is the one that matters: only two of the six `makeConversion` call sites are gated on both pickers being selected. The keypad, the backspace, the long press clear and the swap button are not. The guard went into `getExchangeRate` rather than `makeConversion`, since that accessor has two other callers and every one of them already treats a null rate as unknown. Anyone tempted to push the tolerance one level further down should know `ExchangeRateCache` compares the two iso codes with `TextUtils.equals`, which answers true for two nulls, so it would report a one to one rate between two missing currencies.

`onCurrencyChanged` clears the row rather than just returning, because the swap button can move an empty picker into a field already showing a flag and a code. That needs both `Glide.clear` and `setImageDrawable`, since `clear` only reaches a view with a Glide request tagged on it, and `loadCurrencyFlag` sets the drawable by hand for any currency with no flag resource. `BYN` is exactly one such currency, the only code in `currencies.json` with no `ic_flag` drawable, since only the pre 2016 `ic_flag_byr` ships.

## What this touches

`CurrencyManager.getDefaultCurrency` and `getExchangeRate`, and three places in `CurrencyConverterActivity`. Every other caller of `getDefaultCurrency` was traced and already tolerates null: `MoneyFormatter` has an explicit null currency branch, `NewEditWalletActivity` blanks its field, and the pickers just carry it.

## Verification

On an Android 16 emulator, device locale `en-US`, reading the currency the digits preview renders:

| app locale | result |
|---|---|
| none | USD, unchanged |
| `fa` | USD. A process kill before this change |
| `de-DE` | EUR, the chosen language still beats the device |
| `de-DE` with EUR deleted | no symbol, which is what master does |

On the converter, **each guard was taken back out one at a time** to confirm it is load bearing. With EUR deleted: without the `onCurrencyChanged` guard the screen dies on open; without the `getExchangeRate` guard it opens and dies on the first keypad tap; with both it opens, accepts digits, shows Unknown, and comes out of the swap with one populated row and one empty one. With BYN on one side and the other empty: without `setImageDrawable` the orange BYN tile is stranded in the emptied row beside a blank code, with it the row is blank.

## One correction to the issue

The issue says the per app language picker is how a user reaches this. That is wrong and I wrote it. The shipped build declares no `android:localeConfig`, so it is not in that picker at all (#71). And against a control build that does declare one, no path through the picker produced a bare tag either: a language with several regions makes you choose one, and Malayalam, which has a single region, still set `ml-IN` rather than `ml`. The route that reaches it is `LocaleManager.setApplicationLocales` handed a bare language tag, which is what `cmd locale set-app-locales` does.