### PR TITLE
Let the bundled translations be chosen per app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,10 @@ android {
         buildConfig true
     }
 
+    androidResources {
+        generateLocaleConfig true
+    }
+
     defaultConfig {
         applicationId "io.github.herrerad85.tallybook"
         minSdk 24

--- a/app/src/main/java/com/oriondev/moneywallet/App.java
+++ b/app/src/main/java/com/oriondev/moneywallet/App.java
@@ -21,7 +21,10 @@ package com.oriondev.moneywallet;
 
 import android.app.Application;
 import android.content.Context;
+import android.content.res.Configuration;
+import android.os.LocaleList;
 
+import androidx.annotation.NonNull;
 import androidx.multidex.MultiDex;
 
 import com.oriondev.moneywallet.broadcast.AutoBackupBroadcastReceiver;
@@ -40,15 +43,31 @@ import me.weishu.reflection.Reflection;
  */
 public class App extends Application {
 
+    private LocaleList mLocales;
+
     @Override
     public void onCreate() {
         super.onCreate();
+        mLocales = getResources().getConfiguration().getLocales();
         PreferenceManager.initialize(this);
         BackendManager.initialize(this);
         ThemeEngine.initialize(this);
         CurrencyManager.initialize(this);
         NotificationContract.initializeNotificationChannels(this);
         initializeScheduledTimers();
+    }
+
+    @Override
+    public void onConfigurationChanged(@NonNull Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        // both sides come from getResources rather than from newConfig, since that is the
+        // configuration the channel names resolve against
+        LocaleList locales = getResources().getConfiguration().getLocales();
+        if (locales.equals(mLocales)) {
+            return;
+        }
+        NotificationContract.initializeNotificationChannels(this);
+        mLocales = locales;
     }
 
     private void initializeScheduledTimers() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/CustomDigitSetupDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/CustomDigitSetupDialog.java
@@ -32,7 +32,6 @@ import android.widget.TextView;
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
-import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.CurrencyManager;
@@ -48,7 +47,6 @@ public class CustomDigitSetupDialog extends DialogFragment {
     private static final String SS_ROUNDING_ENABLED = "CustomDigitSetupDialog::SavedState::RoundingEnabled";
     private static final String SS_SYMBOL_ENABLED = "CustomDigitSetupDialog::SavedState::SymbolEnabled";
 
-    private static final CurrencyUnit DEFAULT_CURRENCY = CurrencyManager.getDefaultCurrency();
     private static final long DEFAULT_MONEY = 1258972L;
 
     private TextView mDisplayTextView;
@@ -152,7 +150,8 @@ public class CustomDigitSetupDialog extends DialogFragment {
     }
 
     private void refreshDisplay() {
-        mFormatter.applyNotTinted(mDisplayTextView, DEFAULT_CURRENCY, DEFAULT_MONEY);
+        // read live, since the currency follows the app language and that can change
+        mFormatter.applyNotTinted(mDisplayTextView, CurrencyManager.getDefaultCurrency(), DEFAULT_MONEY);
     }
 
     private void onSaveChanges() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/MonthView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/MonthView.java
@@ -38,7 +38,8 @@ import java.util.Locale;
 
 public class MonthView extends RecyclerView {
 
-    private static String[] MONTHS = DateFormatSymbols.getInstance().getShortMonths();
+    // per instance so the names follow an app language change, which rebuilds this view
+    private final String[] months = DateFormatSymbols.getInstance().getShortMonths();
 
     private MonthAdapter adapter;
     private LinearLayoutManager layoutManager;
@@ -342,8 +343,8 @@ public class MonthView extends RecyclerView {
             this.year = year;
             this.month = month;
 
-            String text = MONTHS[month];
-            text = text.substring(0, Math.min(text.length(), 3)).toUpperCase(Locale.US);
+            String text = months[month];
+            text = text.substring(0, Math.min(text.length(), 3)).toUpperCase(Locale.getDefault());
             if (yearDigitCount > 0) {
                 text += yearOnNewLine ? "\n" : " ";
                 text += year % (int) Math.pow(10, yearDigitCount);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
@@ -42,7 +42,7 @@ public class TimelineView extends RecyclerView {
 
     private static final String TAG = "TimelineView";
 
-    private static final String[] WEEK_DAYS = DateFormatSymbols.getInstance().getShortWeekdays();
+    private final String[] weekDays = DateFormatSymbols.getInstance().getShortWeekdays();
 
     private final Calendar calendar = Calendar.getInstance(Locale.getDefault());
 
@@ -344,7 +344,7 @@ public class TimelineView extends RecyclerView {
             this.year = year;
             this.month = month;
             this.day = day;
-            lblDay.setText(WEEK_DAYS[dayOfWeek].toUpperCase(Locale.US));
+            lblDay.setText(weekDays[dayOfWeek].toUpperCase(Locale.getDefault()));
             lblDate.setText(String.valueOf(day));
             // lblDate.setBackgroundResource(selected ? R.drawable.mti_bg_lbl_date_selected : (isToday ? R.drawable.mti_bg_lbl_date_today : 0));
             lblDate.setTextColor(selected || isToday ? lblDateSelectedColor : lblDateColor);

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US


### PR DESCRIPTION
Closes #71.

This app ships nineteen translations and a user could only reach any of them by changing the language of their whole device, because it declared no locale config and Android will not list an app in the per app language picker without one.

`androidResources.generateLocaleConfig` builds the list from the locale qualifiers on the resource folders at compile time, so a translation added later is picked up without anyone remembering to. `resources.properties` supplies the one thing it cannot infer, which locale the unqualified `values` folder holds, and the build fails outright if it is missing.

**The picker itself is Android 13 and up.** The AppCompat backport arrived in appcompat 1.6.0, and this project declares 1.0.0 and resolves to 1.2.0, so on API 24 through 32 nobody gains a way to choose a language.

## The part that is not a build file

Four places settled something locale derived once per process and never revisited it:

* `CustomDigitSetupDialog` held the default currency
* `MonthView` held the short month names
* `TimelineView` held the short weekday names
* `App` created the notification channels in `onCreate` only

**None of this is new, and I first wrote this change believing it was.** The assumption was that changing the device language restarts the app. It does not. Measured on an emulator with the app running and its calendar open: removing English from the system language list, so German became the device language, left the process on the same pid throughout. These have been stale able for as long as the code has existed. What this change does is make them easy to hit.

The calendar is the visible one. With the statics left in place, switching to German gives a screen titled Kalender with a month strip still reading MAY and OCT.

The first three now read per instance or per draw, which is enough because the activity, and so the view, is rebuilt; no activity in this app declares `configChanges` covering locale. The channels are re created from `onConfigurationChanged`, which is safe to repeat because creating a channel that already exists renames it without resetting the sound, the importance or anything else the user has changed. That is guarded on the locale list, since the callback fires for every configuration change and behind it are four binder calls on the main thread.

`MonthView` also upper cased its month name with `Locale.US`, which is wrong for Turkish: `Nis` and `Eki` need a dotted capital I and were getting a dotless one. Across the twenty shipped locales that is the only difference the change makes. `TimelineView` got the same edit for symmetry and it is inert, because no Turkish abbreviated weekday contains an i.

## Verification

On an Android 16 emulator. The generated file lists twenty locales; the merged manifest carries `android:localeConfig` on the proprietary flavour as well as floss and on release as well as debug; the per app language screen opens and lists them where it refused to open before.

Switching the running app between languages kept the same pid and moved the digits preview between a dollar and a euro amount, the calendar strip between MAY and MAI, and the four notification channel names between English and German and back. The calendar stayed English with the statics restored, and the Turkish October column renders with a dotted capital where it rendered a dotless one before.

## On the ordering against #69

No path tested through the picker produced a region free locale, so it cannot reach the crash fixed in #73. A language with several regions makes you pick one; Malayalam, which has a single region, still set `ml-IN`; and Spanish, the only language here with both a bare and a regioned resource folder, set `es-ES`. That is one observation on one Android version rather than a guarantee, and it matters because the generated config really does carry a bare `es` alongside `es-ES`. The guarantee lives in the code instead: `CurrencyManager.currencyOf` catches the `IllegalArgumentException`.

## Two things to decide, neither of them new

**The default currency follows the app language.** `getDefaultCurrency` reads the preferred locale list, so choosing German to read the app in German on a device set to the United States pre selects EUR for the next new wallet. That was always the rule; it used to require changing the whole device.

**Nine of the nineteen translations cover a fifth or less** of the six hundred and thirty four translatable base strings, so a user picking one of those gets a mostly English app from a list carrying this app's name. The other ten sit between eighty six and ninety seven percent. Trimming the list is a separate decision, and `localeFilters` would also strip those resources from users who reach them through the device language, who have them today.

## Filed while working on this

* #74, system category names are frozen into the database in whatever language the app was installed in. Reproduced live.
* #75, the calendar strips truncate labels by character count, which collapses the Chinese weekday row to the same character seven times.