### PR TITLE
Prepare 1.2.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
         applicationId "io.github.herrerad85.tallybook"
         minSdk 24
         targetSdk 35
-        versionCode 79
-        versionName "1.1.0"
+        versionCode 80
+        versionName "1.2.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         multiDexEnabled true

--- a/fastlane/metadata/android/en-US/changelogs/80.txt
+++ b/fastlane/metadata/android/en-US/changelogs/80.txt
@@ -1,0 +1,3 @@
+You can now set the app's language on its own, separately from the device, through Android's per app language setting.
+
+Fixes: the app no longer crashes when the chosen language carries no country. Debts paid off in full group with the finished ones and no longer inflate the amount still to pay. Wallet notes are kept in backups. Times follow the device 12 or 24 hour setting. Recurring transfers open the right record. Chart theming and the category screen were corrected too.


### PR DESCRIPTION
Bumps to versionCode 80 / versionName 1.2.0 and adds the changelog for 80.

Ten commits have landed on master since the v1.1.0 tag and none of them have reached a user, because F-Droid builds from a tag rather than from the branch. This is the commit that lets them ship.

What is in it, from the merged work: per app language selection, a crash fix for languages that carry no country, debts paid off in full grouping with the finished ones and no longer inflating the amount still to pay, wallet notes kept in backups, times following the device 12 or 24 hour setting, recurring transfers opening the right record, and chart theming plus the category screen.

The store description is deliberately unchanged. Per app language is the headline change, but the system category names and the calendar labels both still have open language bugs, so the listing copy waits until those land. The changelog still leads with the feature, since that describes what changed in this version rather than making a standing claim about the app.

The changelog file is 479 bytes, under the 500 limit.