### PR TITLE
Let the map tile server be chosen

### DIFF
--- a/app/src/gmap/java/com/oriondev/moneywallet/view/MapViewWrapper.java
+++ b/app/src/gmap/java/com/oriondev/moneywallet/view/MapViewWrapper.java
@@ -42,6 +42,14 @@ import java.util.Map;
 
 public class MapViewWrapper implements OnMapReadyCallback, GoogleMap.OnInfoWindowClickListener {
 
+    /**
+     * @return whether this map implementation can be pointed at a different tile server. The
+     *          Google Maps one cannot, so the setting is hidden in that flavor.
+     */
+    public static boolean supportsCustomTileServer() {
+        return false;
+    }
+
     private static final float DEFAULT_ZOOM_LEVEL = 14;
     private static final float GLOBAL_ZOOM_LEVEL = 8;
 

--- a/app/src/main/java/com/oriondev/moneywallet/api/webdav/WebDAVBackendService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/webdav/WebDAVBackendService.java
@@ -33,11 +33,11 @@ import androidx.annotation.StringRes;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.oriondev.moneywallet.BuildConfig;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.AbstractBackendServiceDelegate;
 import com.oriondev.moneywallet.api.BackendServiceFactory;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+import com.oriondev.moneywallet.utils.Urls;
 
 /**
  * Setup is a plain dialog rather than an activity result flow, because a self hosted server needs
@@ -153,7 +153,7 @@ public class WebDAVBackendService extends AbstractBackendServiceDelegate {
                     urlField.setError(activity.getString(R.string.hint_webdav_url));
                     return;
                 }
-                if (!isAcceptableUrl(typedUrl)) {
+                if (!Urls.isAcceptableUrl(typedUrl)) {
                     urlField.setError(activity.getString(R.string.message_webdav_url_scheme));
                     return;
                 }
@@ -162,22 +162,6 @@ public class WebDAVBackendService extends AbstractBackendServiceDelegate {
         });
 
         dialog.show();
-    }
-
-    /**
-     * Rejects cleartext up front rather than letting the user save an address that the platform
-     * will then refuse to open. Since Android 9 cleartext is blocked by default, so an http://
-     * server would fail at connect time with an error that says nothing about the real cause, and
-     * the address carries a password either way.
-     *
-     * Debug builds allow it so the backend can be tested against a throwaway server without TLS;
-     * they ship a matching network security config.
-     */
-    static boolean isAcceptableUrl(String url) {
-        if (url.startsWith("https://")) {
-            return true;
-        }
-        return BuildConfig.DEBUG && url.startsWith("http://");
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
@@ -65,6 +65,8 @@ public class PreferenceManager {
     private static final String CONVERTER_LAST_CURRENCY_1 = "converter_currency_iso_1";
     private static final String CONVERTER_LAST_CURRENCY_2 = "converter_currency_iso_2";
 
+    private static final String MAP_TILE_SERVER = "map_tile_server";
+
     private static final String LAST_DATA_CHANGE_TIME = "last_data_change_time";
 
     public static final int LOCK_MODE_NONE = 0;
@@ -107,6 +109,23 @@ public class PreferenceManager {
 
     public static Context getApplicationContext() {
         return mApplicationContext;
+    }
+
+    /**
+     * @return the address the user chose for tiles, either a base address or a full template,
+     *          or null to use the map library's own default. Not a promise that tiles come from
+     *          there: the map re checks it and falls back if it no longer passes.
+     */
+    public static String getMapTileServer() {
+        return mPreferences.getString(MAP_TILE_SERVER, null);
+    }
+
+    public static void setMapTileServer(String url) {
+        if (TextUtils.isEmpty(url)) {
+            mPreferences.edit().remove(MAP_TILE_SERVER).apply();
+        } else {
+            mPreferences.edit().putString(MAP_TILE_SERVER, url).apply();
+        }
     }
 
     public static void setCurrentWallet(Context context, long walletId) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UtilitySettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UtilitySettingFragment.java
@@ -31,6 +31,7 @@ import androidx.annotation.Nullable;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.biometric.BiometricManager;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.recyclerview.widget.RecyclerView;
 import android.text.InputType;
@@ -49,6 +50,8 @@ import com.oriondev.moneywallet.ui.activity.LockActivity;
 import com.oriondev.moneywallet.ui.preference.ThemedInputPreference;
 import com.oriondev.moneywallet.ui.preference.ThemedListPreference;
 import com.oriondev.moneywallet.utils.DateFormatter;
+import com.oriondev.moneywallet.utils.Urls;
+import com.oriondev.moneywallet.view.MapViewWrapper;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -70,6 +73,7 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
     private Preference mSecurityModeChangeKeyPreference;
     private ThemedListPreference mExchangeRateServiceListPreference;
     private ThemedInputPreference mExchangeRateCustomApiKey;
+    private ThemedInputPreference mMapTileServerPreference;
     private Preference mExchangeRateUpdatePreference;
     private Preference mCurrencyManagementPreference;
 
@@ -103,6 +107,14 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
         mExchangeRateCustomApiKey = (ThemedInputPreference) findPreference("exchange_rate_api_key");
         mExchangeRateUpdatePreference = findPreference("exchange_rate_update");
         mCurrencyManagementPreference = findPreference("currency_management");
+        mMapTileServerPreference = (ThemedInputPreference) findPreference("map_tile_server");
+        if (!MapViewWrapper.supportsCustomTileServer()) {
+            PreferenceCategory mapCategory = (PreferenceCategory) findPreference("map_category");
+            if (mapCategory != null) {
+                getPreferenceScreen().removePreference(mapCategory);
+            }
+            mMapTileServerPreference = null;
+        }
     }
 
     @Override
@@ -146,6 +158,7 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
         // setup current (or default) values
         setupCurrentDailyReminder();
         setupCurrentLockMode();
+        setupCurrentMapTileServer();
         setupCurrentExchangeRateService();
         setupCurrentExchangeRateCustomApiKey();
         setupCurrentExchangeRateUpdate();
@@ -227,6 +240,31 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
             }
 
         });
+        if (mMapTileServerPreference != null) {
+            mMapTileServerPreference.setInput(R.string.setting_hint_map_tile_server, true, InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_URI);
+            mMapTileServerPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    String url = newValue != null ? ((String) newValue).trim() : null;
+                    if (!TextUtils.isEmpty(url) && !Urls.isUsableTileAddress(url)) {
+                        // rejected here because at map load a bad address is simply ignored, so
+                        // the map quietly keeps using the default and the setting looks applied
+                        mMapTileServerPreference.setSummary(R.string.setting_summary_map_tile_server_invalid);
+                        // the widget keeps whatever was typed, and that value is both the
+                        // dialog's prefill and how it decides something changed. Put the stored one
+                        // back, or retyping the same bad address is silently a no op
+                        mMapTileServerPreference.setCurrentValue(PreferenceManager.getMapTileServer());
+                        return false;
+                    }
+                    PreferenceManager.setMapTileServer(url);
+                    setupCurrentMapTileServer();
+                    return false;
+                }
+
+            });
+            setupCurrentMapTileServer();
+        }
         mExchangeRateUpdatePreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
 
             @Override
@@ -370,6 +408,22 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
         } else {
             mExchangeRateCustomApiKey.setVisible(true);
         }
+    }
+
+    private void setupCurrentMapTileServer() {
+        if (mMapTileServerPreference == null) {
+            return;
+        }
+        String url = PreferenceManager.getMapTileServer();
+        if (TextUtils.isEmpty(url)) {
+            mMapTileServerPreference.setSummary(R.string.setting_summary_map_tile_server_default);
+        } else {
+            mMapTileServerPreference.setSummary(getString(R.string.setting_summary_map_tile_server, url));
+        }
+        // without this the dialog opens empty even when a server is configured, so an existing
+        // address has to be retyped rather than corrected, and pressing ok on the untouched field
+        // clears it
+        mMapTileServerPreference.setCurrentValue(url);
     }
 
     private void setupCurrentExchangeRateCustomApiKey() {

--- a/app/src/main/java/com/oriondev/moneywallet/utils/Urls.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/Urls.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.utils;
+
+import com.oriondev.moneywallet.BuildConfig;
+
+import java.util.Locale;
+
+import okhttp3.HttpUrl;
+
+/**
+ * Address rules for the two places a user types a server address: the backup backend and the map
+ * tile server. Free of any android framework class so it can be unit tested, which the neighbouring
+ * Utils class cannot be, its static initializer needing a real framework.
+ */
+public class Urls {
+
+    private static final String HTTPS = "https://";
+    private static final String HTTP = "http://";
+
+    private static final String TILE_Z = "{z}";
+    private static final String TILE_X = "{x}";
+    private static final String TILE_Y = "{y}";
+
+    private static final String PLACEHOLDER_START = "{";
+    private static final String PLACEHOLDER_START_ENCODED = "%7b";
+    private static final char QUERY = '?';
+    private static final char FRAGMENT = '#';
+
+    private static final String TILE_SUFFIX = TILE_Z + "/" + TILE_X + "/" + TILE_Y + ".png";
+
+    /**
+     * Https, naming a server, matched case insensitively. Release builds ship no cleartext policy
+     * so the platform would refuse http anyway; debug builds ship one, so they allow it and can be
+     * pointed at a throwaway local server.
+     *
+     * This also gates the WebDAV server address, which carries a password. Relaxing the scheme
+     * rule for the map would relax it for that too.
+     */
+    public static boolean isAcceptableUrl(String url) {
+        if (url == null) {
+            return false;
+        }
+        String lower = url.toLowerCase(Locale.ENGLISH);
+        if (lower.startsWith(HTTPS)) {
+            return namesAServer(url, HTTPS);
+        }
+        return BuildConfig.DEBUG && lower.startsWith(HTTP) && namesAServer(url, HTTP);
+    }
+
+    /**
+     * Whether the part between the scheme and the path names a server.
+     *
+     * Handed to a parser rather than scanned by hand. Three hand rolled versions of this each
+     * looked complete and each let a different hostless shape through, the last being anything that
+     * put a character in front of the empty host.
+     *
+     * OkHttp's parser rather than java.net.URI, because URI implements the RFC 2396 hostname
+     * grammar and refuses an underscore or a non ascii name. Both are ordinary on a home network,
+     * which is the audience for this, and both are accepted by the clients that do the fetching.
+     * A validator stricter than the fetcher refuses addresses that would have worked.
+     *
+     * Only the authority is parsed, not the whole address, because a template carries braces and
+     * every parser rejects those. Userinfo is refused outright: neither client turns it into an
+     * auth header, so it cannot work, and it would sit in plain view on the settings screen.
+     */
+    private static boolean namesAServer(String url, String scheme) {
+        int start = scheme.length();
+        int end = url.length();
+        for (int i = start; i < end; i++) {
+            char c = url.charAt(i);
+            if (c == '/' || c == QUERY || c == FRAGMENT) {
+                end = i;
+                break;
+            }
+        }
+        String authority = url.substring(start, end);
+        if (authority.contains(PLACEHOLDER_START)
+                || authority.toLowerCase(Locale.ENGLISH).contains(PLACEHOLDER_START_ENCODED)) {
+            return false;
+        }
+        if (authority.endsWith(":")) {
+            // a port separator with nothing after it, which parses as a bare host, so pasting an
+            // address twice over gives the plausible looking host "https"
+            return false;
+        }
+        HttpUrl parsed = HttpUrl.parse(HTTPS + authority + "/");
+        return parsed != null && parsed.username().isEmpty() && parsed.password().isEmpty();
+    }
+
+    /**
+     * A tile address is a bare base address, which asTileTemplate completes, or a template with
+     * all three placeholders. Also refused: any other placeholder, including capitals and the
+     * percent encoded spelling; a fragment, in either shape; and a query in a base address.
+     *
+     * The rules have tests in TileAddressTest, most of them naming the address that motivated the
+     * rule and what it would have done. That is the place to read why, and it fails if the answer
+     * changes.
+     */
+    public static boolean isUsableTileAddress(String url) {
+        if (!isAcceptableUrl(url)) {
+            return false;
+        }
+        // before the count: a stray placeholder is as fatal in a base address as in a template
+        String stripped = stripKnownPlaceholders(url);
+        if (stripped.contains(PLACEHOLDER_START)
+                || stripped.toLowerCase(Locale.ENGLISH).contains(PLACEHOLDER_START_ENCODED)) {
+            return false;
+        }
+        if (url.indexOf(FRAGMENT) >= 0 || containsWhitespace(url)) {
+            return false;
+        }
+        int found = (url.contains(TILE_Z) ? 1 : 0)
+                + (url.contains(TILE_X) ? 1 : 0)
+                + (url.contains(TILE_Y) ? 1 : 0);
+        if (found != 0 && found != 3) {
+            return false;
+        }
+        return found == 3 || url.indexOf(QUERY) < 0;
+    }
+
+    /**
+     * Anywhere, not just in the host. The field is trimmed at the ends only, so an interior space
+     * or a tab pasted into the path survives into the request.
+     */
+    private static boolean containsWhitespace(String url) {
+        for (int i = 0; i < url.length(); i++) {
+            if (Character.isWhitespace(url.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String stripKnownPlaceholders(String url) {
+        return url.replace(TILE_Z, "").replace(TILE_X, "").replace(TILE_Y, "");
+    }
+
+    /**
+     * @return the address of one tile. Kept here rather than in the map wrapper so the string that
+     *          becomes a network request is reachable from an ordinary unit test.
+     */
+    public static String tileUrl(String template, int zoom, int x, int y) {
+        return template
+                .replace(TILE_Z, String.valueOf(zoom))
+                .replace(TILE_X, String.valueOf(x))
+                .replace(TILE_Y, String.valueOf(y));
+    }
+
+    /**
+     * @return the address as a template. A bare base address is completed, so the common case is
+     *          just the server's own address and nobody has to know the convention. Assumes the
+     *          address already passed isUsableTileAddress.
+     */
+    public static String asTileTemplate(String url) {
+        if (url.contains(TILE_Z)) {
+            return url;
+        }
+        return url.endsWith("/") ? url + TILE_SUFFIX : url + "/" + TILE_SUFFIX;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -398,7 +398,7 @@
     <string name="message_backup_service_storage_access_framework_disconnect">"Are you sure you want to disconnect the current folder? No files will be deleted."</string>
     <string name="message_backup_service_webdav_disconnect">"Are you sure you want to disconnect this server? The saved address and password will be removed from this device. No files will be deleted from the server."</string>
     <string name="message_webdav_app_password">"If your server supports app passwords, such as Nextcloud, create one for Tallybook instead of using your account password."</string>
-    <string name="message_webdav_url_scheme">"The address must start with https://. A plain http address is refused because it would send your password unencrypted, and Android blocks it."</string>
+    <string name="message_webdav_url_scheme">"The address must start with https:// and name a server. A plain http address is refused because it would send your password unencrypted, and Android blocks it."</string>
     <string name="message_backup_service_google_drive_disconnect">"Are you sure you want to disconnect your Google Drive account?"</string>
     <string name="message_action_archive_wallet">"Are you sure you want to archive this wallet? It will not be visible in the menu anymore."</string>
     <string name="message_action_unarchive_wallet">"Are you sure you want to unarchive this wallet? It will be visible in the menu again."</string>
@@ -491,6 +491,12 @@
 
     <string name="setting_category_utility_notification">"Notification"</string>
     <string name="setting_category_utility_security">"Security"</string>
+    <string name="setting_category_utility_map">"Map"</string>
+    <string name="setting_title_map_tile_server">"Tile server"</string>
+    <string name="setting_hint_map_tile_server" translatable="false">"https://tiles.example.org/{z}/{x}/{y}.png"</string>
+    <string name="setting_summary_map_tile_server_default">"Using the default OpenStreetMap servers. Enter another https address, with {z}, {x} and {y} or with none of them."</string>
+    <string name="setting_summary_map_tile_server">"Loading tiles from %1$s"</string>
+    <string name="setting_summary_map_tile_server_invalid">"Not a usable address. Needs https, a server name, and {z}, {x} and {y} or none of them."</string>
     <string name="setting_category_utility_exchange_rates">"Exchange rates"</string>
     <string name="setting_title_daily_reminder">"Daily reminder"</string>
     <string name="setting_summary_daily_reminder">"Every day at: %1$s"</string>

--- a/app/src/main/res/xml/settings_utility.xml
+++ b/app/src/main/res/xml/settings_utility.xml
@@ -45,6 +45,16 @@
     </com.oriondev.moneywallet.ui.preference.ThemedPreferenceCategory>
 
     <com.oriondev.moneywallet.ui.preference.ThemedPreferenceCategory
+        android:key="map_category"
+        android:title="@string/setting_category_utility_map" >
+
+        <com.oriondev.moneywallet.ui.preference.ThemedInputPreference
+            android:key="map_tile_server"
+            android:title="@string/setting_title_map_tile_server"/>
+
+    </com.oriondev.moneywallet.ui.preference.ThemedPreferenceCategory>
+
+    <com.oriondev.moneywallet.ui.preference.ThemedPreferenceCategory
         android:title="@string/setting_category_utility_exchange_rates" >
 
         <com.oriondev.moneywallet.ui.preference.ThemedListPreference

--- a/app/src/osm/java/com/oriondev/moneywallet/view/MapViewWrapper.java
+++ b/app/src/osm/java/com/oriondev/moneywallet/view/MapViewWrapper.java
@@ -23,16 +23,22 @@ import android.content.Context;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.view.MotionEvent;
 import android.view.View;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Coordinates;
 import com.oriondev.moneywallet.model.Place;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.utils.Urls;
 
 import org.osmdroid.api.IGeoPoint;
 import org.osmdroid.config.Configuration;
 import org.osmdroid.config.IConfigurationProvider;
+import org.osmdroid.tileprovider.tilesource.OnlineTileSourceBase;
+import org.osmdroid.tileprovider.tilesource.TileSourcePolicy;
+import org.osmdroid.util.MapTileIndex;
 import org.osmdroid.util.GeoPoint;
 import org.osmdroid.views.MapView;
 import org.osmdroid.views.overlay.CopyrightOverlay;
@@ -52,6 +58,31 @@ import java.util.List;
 public class MapViewWrapper {
 
     private static final String TILE_CACHE_FOLDER = "osm_tiles";
+
+    private static final String OSM_COPYRIGHT = "© OpenStreetMap contributors";
+
+    /**
+     * Bit identical to the policy the library's own default carries. Two of these limit us: at
+     * most two requests in flight, and no speculative fetching of surrounding tiles. The no
+     * argument policy has neither, so leaving it would make this app ask more of somebody's self
+     * hosted server, and ask it more concurrently, than it asks of OpenStreetMap's.
+     *
+     * FLAG_NO_BULK is neither: it gates CacheManager, which this app never constructs, so it is
+     * inert here and present only to stay identical to the default.
+     *
+     * MEANINGFUL is neither a limit nor inert, it is a gate: with it set the downloader refuses to
+     * fetch anything at all unless a real user agent was configured, which setupConfiguration does
+     * below. Removing the configured agent would silently stop every tile. NORMALIZED only makes
+     * the downloader prefer a normalized agent where one exists, and refuses nothing.
+     */
+    private static final TileSourcePolicy TILE_POLICY = new TileSourcePolicy(2,
+            TileSourcePolicy.FLAG_NO_BULK
+                    | TileSourcePolicy.FLAG_NO_PREVENTIVE
+                    | TileSourcePolicy.FLAG_USER_AGENT_MEANINGFUL
+                    | TileSourcePolicy.FLAG_USER_AGENT_NORMALIZED);
+
+    private static final int TILE_SIZE_PIXELS = 256;
+    private static final int TILE_MAX_ZOOM = 19;
 
     private static final double DEFAULT_MIN_ZOOM_LEVEL = 4d;
     private static final double DEFAULT_ZOOM_LEVEL = 14d;
@@ -85,6 +116,65 @@ public class MapViewWrapper {
                 configuration.setOsmdroidTileCache(tileCache);
             }
         }
+        setupTileSource();
+    }
+
+    /**
+     * Point the map at whatever server the user chose, so that replacing the default one does not
+     * need a change to this app. Doing nothing leaves the library's own default in place.
+     *
+     * The address is re checked here rather than trusted from storage. A rejected one leaves the
+     * library's default in place, which shows a working map rather than an empty one, at the cost
+     * of saying nothing about why the chosen server was not used.
+     *
+     * The source is named after the address, because osmdroid keys its tile cache on that name and
+     * a fixed one would serve the previous server's tiles after a change. Note the name also
+     * reaches BitmapTileSourceBase.pathBase, which the assets and zip archive providers use as a
+     * path; both simply miss and fall through, so a url is tolerated there rather than intended.
+     *
+     * The attribution is the OpenStreetMap one because that is what this setting is documented for
+     * and that data carries a licence requiring the notice. Passing nothing makes CopyrightOverlay
+     * draw none at all, which is the worse failure for the case this exists to serve. Pointed at a
+     * server carrying something other than OpenStreetMap data the notice is wrong, and there is no
+     * way to change it.
+     */
+    private void setupTileSource() {
+        String url = PreferenceManager.getMapTileServer();
+        if (TextUtils.isEmpty(url) || !Urls.isUsableTileAddress(url)) {
+            return;
+        }
+        mMapView.setTileSource(new TemplateTileSource(Urls.asTileTemplate(url)));
+    }
+
+    /**
+     * osmdroid's own XYTileSource builds the address by concatenation, which fixes the path shape
+     * and the image extension. Overriding the one method that produces the address is what lets a
+     * user paste the {z}/{x}/{y} form that nearly every tile provider documents.
+     */
+    private static class TemplateTileSource extends OnlineTileSourceBase {
+
+        private final String mTemplate;
+
+        private TemplateTileSource(String template) {
+            super(template, 0, TILE_MAX_ZOOM, TILE_SIZE_PIXELS, "", new String[] {template},
+                    OSM_COPYRIGHT, TILE_POLICY);
+            mTemplate = template;
+        }
+
+        @Override
+        public String getTileURLString(long pMapTileIndex) {
+            return Urls.tileUrl(mTemplate,
+                    MapTileIndex.getZoom(pMapTileIndex),
+                    MapTileIndex.getX(pMapTileIndex),
+                    MapTileIndex.getY(pMapTileIndex));
+        }
+    }
+
+    /**
+     * @return whether this map implementation can be pointed at a different tile server.
+     */
+    public static boolean supportsCustomTileServer() {
+        return true;
     }
 
     private void setupCopyrightOverlay() {

--- a/app/src/test/java/com/oriondev/moneywallet/utils/TileAddressTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/TileAddressTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.utils;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TileAddressTest {
+
+    @Test
+    public void aBaseAddressIsUsable() {
+        assertTrue(Urls.isUsableTileAddress("https://tiles.example.org/"));
+        assertTrue(Urls.isUsableTileAddress("https://tiles.example.org/osm"));
+    }
+
+    @Test
+    public void aCompleteTemplateIsUsable() {
+        assertTrue(Urls.isUsableTileAddress("https://tiles.example.org/{z}/{x}/{y}.jpg"));
+        assertTrue(Urls.isUsableTileAddress("https://tiles.example.org/{z}/{x}/{y}.png?key=abc"));
+    }
+
+    @Test
+    public void aHalfTemplateIsRejected() {
+        // the first would have a second tile path appended; the other two would be used as they
+        // stand, with the missing coordinate no longer varying, so a whole zoom level or a whole
+        // column draws one repeated image
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/{x}/{y}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/{z}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/{z}/{x}.png"));
+    }
+
+    @Test
+    public void aTemplateCarryingAPlaceholderWeDoNotSubstituteIsRejected() {
+        // the first is the form nearly every provider publishes, and leaving {s} in place means
+        // the host never resolves; the second puts an unsupported placeholder in the path instead
+        assertFalse(Urls.isUsableTileAddress("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/{z}/{x}/{y}{r}.png"));
+    }
+
+    @Test
+    public void aFragmentIsRejectedInATemplateToo() {
+        // the base address case is covered below. Nothing after a fragment is ever sent, so every
+        // tile would resolve to whatever precedes it
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/#{z}/{x}/{y}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://map.example.org/#{z}/{x}/{y}?key=abc"));
+    }
+
+    @Test
+    public void percentEncodedPlaceholdersAreRejected() {
+        // a browser address bar encodes braces, so a copy paste arrives in this shape. With none
+        // of the three counted it would otherwise be taken for a base address, have a tile path
+        // appended, and reach the server with the encoded braces still in it
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/%7Bz%7D/%7Bx%7D/%7By%7D.png"));
+        assertFalse(Urls.isUsableTileAddress("https://%7Bs%7D.tile.openstreetmap.org/"));
+    }
+
+    @Test
+    public void aRepeatedPlaceholderSubstitutesConsistently() {
+        assertEquals("https://tiles.example.org/14/8189/8188/14.png",
+                Urls.tileUrl("https://tiles.example.org/{z}/{x}/{y}/{z}.png", 14, 8189, 8188));
+    }
+
+    @Test
+    public void aBaseAddressCarryingAnUnknownPlaceholderIsRejectedToo() {
+        // the same fatal address reached through the other door: with no known placeholders to
+        // count, an earlier version treated these as base addresses and completed them
+        assertFalse(Urls.isUsableTileAddress("https://{s}.tile.openstreetmap.org/"));
+        assertFalse(Urls.isUsableTileAddress("https://{s}.tiles.example.org"));
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/{style}"));
+    }
+
+    @Test
+    public void placeholdersSpelledInCapitalsAreRejectedRatherThanTakenAsABaseAddress() {
+        // nothing lowercases these, so counted as zero they would be taken for a base address and
+        // have a tile path appended after them
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/{Z}/{X}/{Y}.png"));
+    }
+
+    @Test
+    public void anInvertedYTemplateIsRejected() {
+        // TMS numbers y from the bottom. This code neither inverts nor substitutes {-y}, so it is
+        // refused as an unsupported placeholder rather than left to reach the server literally
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/{z}/{x}/{-y}.png"));
+    }
+
+    @Test
+    public void aBaseAddressWithAQueryOrFragmentIsRejected() {
+        // the appended tile path would land inside the query value rather than in the path
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/?key=abc"));
+        // and after a fragment it would never be sent at all
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/#section"));
+    }
+
+    @Test
+    public void anAddressWithNoHostIsRejected() {
+        // none of these names a server, by one route or another: an empty host, a host that is
+        // only userinfo, a port with no host, an unparseable port, or an address pasted twice.
+        // Three hand rolled versions of the check each let a different one of them through
+        assertFalse(Urls.isUsableTileAddress("https:///"));
+        assertFalse(Urls.isUsableTileAddress("https:///tiles/{z}/{x}/{y}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://:8080/tiles"));
+        assertFalse(Urls.isUsableTileAddress("https://user@/tiles"));
+        assertFalse(Urls.isUsableTileAddress("https://user:pass@/{z}/{x}/{y}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://user@:8080/tiles"));
+        assertFalse(Urls.isUsableTileAddress("https://https://tiles.example.org/"));
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org:abc/"));
+    }
+
+    @Test
+    public void credentialsInTheAddressAreRejected() {
+        // no http client here turns userinfo into an auth header, so it cannot work, and it would
+        // sit in plain view in the settings row
+        assertFalse(Urls.isUsableTileAddress("https://user:secret@tiles.example.org/{z}/{x}/{y}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://user@tiles.example.org/"));
+    }
+
+    @Test
+    public void whitespaceOtherThanASpaceIsRejectedInTheHostToo() {
+        assertFalse(Urls.isUsableTileAddress("https://tiles\texample.org/"));
+        assertFalse(Urls.isUsableTileAddress("https://tiles\nexample.org/"));
+    }
+
+    @Test
+    public void anIpv6LiteralIsAccepted() {
+        // bracketed literals are the shape most likely to break an authority check on the next edit
+        assertTrue(Urls.isUsableTileAddress("https://[2001:db8::1]/{z}/{x}/{y}.png"));
+        assertTrue(Urls.isUsableTileAddress("https://[::1]:8080/"));
+    }
+
+    @Test
+    public void aPlaceholderInTheHostIsRejected() {
+        // substituting here gives a host that changes as the user pans, which is the subdomain
+        // sharding mistake wearing a placeholder this code does substitute
+        assertFalse(Urls.isUsableTileAddress("https://{z}.tiles.example.org/{x}/{y}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://%7Bz%7D.tiles.example.org/{x}/{y}.png"));
+    }
+
+    @Test
+    public void whitespaceAnywhereIsRejected() {
+        // trimming the field only strips the ends, so anything interior survives to the request
+        assertFalse(Urls.isUsableTileAddress("https://tiles example.org/"));
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/my tiles/{z}/{x}/{y}.png"));
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/a	b/{z}/{x}/{y}.png"));
+    }
+
+    @Test
+    public void aHostnameTheFetcherWouldAcceptIsNotRefused() {
+        // an underscore and a non ascii name are both ordinary on a home network and both accepted
+        // by the clients that do the fetching. A stricter validator refuses a working address
+        assertTrue(Urls.isUsableTileAddress("https://tile_server.lan/{z}/{x}/{y}.png"));
+        assertTrue(Urls.isUsableTileAddress("https://münchen.example.org/"));
+        // odd, but the userinfo is empty and the host is real, so this fetches. Refusing it would
+        // be the same over strictness in a different spelling
+        assertTrue(Urls.isUsableTileAddress("https://@tiles.example.org/"));
+    }
+
+    @Test
+    public void aPortAndAnIpLiteralAreStillAccepted() {
+        // the shape a self hoster actually types, and the reason the authority check cannot simply
+        // refuse a colon
+        assertTrue(Urls.isUsableTileAddress("https://192.168.1.10:8080/{z}/{x}/{y}.png"));
+        assertTrue(Urls.isUsableTileAddress("https://tiles.example.org:8443/"));
+    }
+
+    @Test
+    public void anEncodedBraceIsMatchedWhicheverCaseItIsWrittenIn() {
+        // percent encoding is case insensitive, so a lowercase %7b has to be caught as well
+        assertFalse(Urls.isUsableTileAddress("https://tiles.example.org/%7bz%7d/%7bx%7d/%7by%7d.png"));
+    }
+
+    @Test
+    public void aTileAddressIsBuiltFromTheTemplate() {
+        assertEquals("https://tiles.example.org/14/8189/8188.png",
+                Urls.tileUrl("https://tiles.example.org/{z}/{x}/{y}.png", 14, 8189, 8188));
+        assertEquals("https://tiles.example.org/tile/3/1/2@2x.jpg?key=abc",
+                Urls.tileUrl("https://tiles.example.org/tile/{z}/{x}/{y}@2x.jpg?key=abc", 3, 1, 2));
+    }
+
+    @Test
+    public void aCompletedBaseAddressBuildsTheUsualTilePath() {
+        String template = Urls.asTileTemplate("https://tiles.example.org/basecase");
+        assertEquals("https://tiles.example.org/basecase/14/8189/8188.png",
+                Urls.tileUrl(template, 14, 8189, 8188));
+    }
+
+    @Test
+    public void anUnknownSchemeAndAMissingSchemeAreBothRejected() {
+        // deliberately not asserting the http branch, which differs by build variant, so this
+        // suite says the same thing whichever variant runs it
+        assertFalse(Urls.isUsableTileAddress("ftp://tiles.example.org/"));
+        assertFalse(Urls.isUsableTileAddress("tiles.example.org"));
+    }
+
+    @Test
+    public void aSchemeWithNothingAfterItIsRejected() {
+        // not an address, and it would otherwise be completed and produce a blank map
+        assertFalse(Urls.isUsableTileAddress("https://"));
+        assertFalse(Urls.isAcceptableUrl("https://"));
+    }
+
+    @Test
+    public void theSchemeIsMatchedWithoutRegardToCase() {
+        // a keyboard that capitalises the first letter of a field produces this, and the scheme is
+        // case insensitive per RFC 3986
+        assertTrue(Urls.isAcceptableUrl("HTTPS://tiles.example.org/"));
+        assertTrue(Urls.isAcceptableUrl("Https://tiles.example.org/"));
+    }
+
+    @Test
+    public void aNullAddressIsRejectedRatherThanThrowing() {
+        // the stored value is null whenever the user has never set one. Every caller happens to
+        // check emptiness first, so this is the guard staying true rather than a reachable path
+        assertFalse(Urls.isAcceptableUrl(null));
+        assertFalse(Urls.isUsableTileAddress(null));
+    }
+
+    @Test
+    public void aBaseAddressIsCompletedIntoATemplate() {
+        assertEquals("https://tiles.example.org/{z}/{x}/{y}.png",
+                Urls.asTileTemplate("https://tiles.example.org/"));
+        assertEquals("https://tiles.example.org/{z}/{x}/{y}.png",
+                Urls.asTileTemplate("https://tiles.example.org"));
+        assertEquals("https://tiles.example.org/osm/{z}/{x}/{y}.png",
+                Urls.asTileTemplate("https://tiles.example.org/osm"));
+    }
+
+    @Test
+    public void aCompleteTemplateIsLeftExactlyAsItIs() {
+        String template = "https://tiles.example.org/tile/{z}/{x}/{y}@2x.jpg?key=abc";
+        assertEquals(template, Urls.asTileTemplate(template));
+    }
+}


### PR DESCRIPTION
Addresses half of #48.

## Why

`MapViewWrapper.setupConfiguration` sets a user agent and a cache folder and never calls `setTileSource`, so osmdroid falls back to its default and the place picker loads from the OpenStreetMap servers with no way for anyone to point it elsewhere. Replacing that service therefore needs a change to this app rather than a change to a setting, which is what F-Droid's `TetheredNet` describes.

Their documented criterion is a simple configuration option allowing an alternative self hostable server. Organic Maps had the same flag removed in July after adding an override while keeping their default, so this is the shape that has worked.

Note this does not remove the flag on its own. That lives in the fdroiddata metadata and needs a separate merge request citing this commit.

## What it does

A tile server address can be set under Settings, Utilities. It takes either:

- a bare base address, which is completed with `{z}/{x}/{y}.png`, so the common case is just the server's own address and nobody has to know the convention, or
- a template carrying `{z}`, `{x}` and `{y}`, which is what allows a different path shape, a different image format, or a key in the query.

Empty keeps the current default. The setting is hidden in the Google Maps flavor, whose base map cannot be repointed.

## The address check

Checked before it is stored rather than at map load, because a rejected address there is simply ignored: the map quietly keeps using the default while the setting reads as applied.

Refused: a scheme other than https (http is allowed in debug builds, which ship a cleartext config, matching what the WebDAV backend already does); an address that names no server; only some of the three placeholders; any placeholder this code does not substitute, including the widely published `{s}` subdomain form, capitals, and the percent encoded spelling; whitespace anywhere; and a fragment.

The host is parsed with OkHttp rather than `java.net.URI`, because URI implements the RFC 2396 hostname grammar and refuses an underscore or a non ascii name. Both are ordinary on a home network, which is the audience here, and both are accepted by the clients that actually do the fetching. A validator stricter than the fetcher refuses addresses that would have worked.

That rule was previously duplicated in `WebDAVBackendService`; it is now one helper both call.

## Two things that are easy to miss

The custom source carries the same attribution as the default. The 6 argument `XYTileSource` constructor passes a null copyright, and `CopyrightOverlay` then draws nothing at all, so a self hosted OpenStreetMap mirror would have lost the notice its licence requires.

It also carries the same `TileSourcePolicy` as the default, bit identical: at most two requests in flight and no speculative prefetch. The no argument policy has neither, so without it this app would ask more of somebody's self hosted server, and ask it more concurrently, than it asks of OpenStreetMap's.

## Verified

28 unit tests on the address rules, and on an emulator against a local server that logs the paths it is asked for:

- a base address `http://10.0.2.2:8099/basecase` produced `/basecase/14/8189/8188.png`
- a template produced `/p4/14/x8189/y8193.png`, with the coordinates labelled so a swapped x and y could not hide
- the `{s}` form is refused as a template and as a bare base address, and a previously stored good address survives a rejection untouched
- clearing the field reverts the log to `Using tile source: Mapnik`
- the Map section is absent in the Google Maps flavor

## Known limits

Zoom is capped at 19 and tiles are assumed 256px, both copied from the library default, so a style serving beyond that is capped with no setting for it. And a plain http server on a LAN cannot be used in a release build, since the app ships no cleartext policy.