### PR TITLE
Give each weekday its own letter, and size the strip to fit

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
@@ -24,8 +24,11 @@ import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import android.text.Layout;
+import android.text.TextPaint;
 import android.text.format.DateUtils;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -33,7 +36,7 @@ import android.widget.TextView;
 
 import com.oriondev.moneywallet.R;
 
-import java.text.DateFormatSymbols;
+import android.icu.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +45,9 @@ public class TimelineView extends RecyclerView {
 
     private static final String TAG = "TimelineView";
 
-    private final String[] weekDays = DateFormatSymbols.getInstance().getShortWeekdays();
+    private final String[] weekDays = narrowWeekdays();
+
+    private float dayLabelSize = 0f;
 
     private final Calendar calendar = Calendar.getInstance(Locale.getDefault());
 
@@ -74,6 +79,74 @@ public class TimelineView extends RecyclerView {
     public TimelineView(Context context, @Nullable AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         init();
+    }
+
+    /**
+     * The narrow weekday headers, indexed by the {@link Calendar#SUNDAY} to
+     * {@link Calendar#SATURDAY} values.
+     *
+     * These come from the locale rather than from cutting a longer name to a fixed
+     * number of characters. Cutting assumes every language distinguishes its days in
+     * the first character, and of the twenty locales bundled here only Persian does:
+     * the Chinese short names all begin 周 and the Catalan ones all begin d, so the
+     * whole week rendered as one repeated glyph. CLDR already publishes a narrow name
+     * per weekday for exactly this position, so the shortening is a lookup rather than
+     * a rule this app invents.
+     *
+     * A narrow name is not one char, which is what maxLength counted. CLDR gives Catalan
+     * dg, dl, dt, dc, dj, dv and ds, and gives Malayalam names wider still, so the labels
+     * are sized to fit rather than assumed to fit. The uppercasing below is this app's.
+     */
+    private static String[] narrowWeekdays() {
+        return new DateFormatSymbols(Locale.getDefault()).getWeekdays(
+                DateFormatSymbols.STANDALONE, DateFormatSymbols.NARROW);
+    }
+
+    private String dayLabel(int dayOfWeek) {
+        return weekDays[dayOfWeek].toUpperCase(Locale.getDefault());
+    }
+
+    /**
+     * One text size for all seven weekday labels, small enough that each of them measures
+     * within a cell. Returns the size unchanged if the cell has no fixed width to fit to,
+     * and for most locales it returns it unchanged anyway.
+     *
+     * Of the locales bundled here only Malayalam grows wide enough to need this, and only
+     * at accessibility font scales. The label comes from the system locale rather than
+     * from those translations, so the check is not limited to that set. Overflow is sized
+     * away rather than cut because cutting is the defect this class just removed, and one
+     * size is derived for the whole strip so that neighbouring letters match, where a size
+     * per cell would let adjacent letters differ.
+     */
+    private float dayLabelSize(TextView sample, View cell) {
+        if (dayLabelSize > 0f) {
+            return dayLabelSize;
+        }
+        dayLabelSize = sample.getTextSize();
+        int available = cell.getLayoutParams().width - cell.getPaddingLeft() - cell.getPaddingRight();
+        if (available <= 0) {
+            return dayLabelSize;
+        }
+        // Step down and measure again until every label fits, rather than deriving a ratio and
+        // trusting it. Measuring every label rather than only the one that came out widest
+        // at the starting size costs nothing here and removes the question of whether that
+        // ranking holds at every size.
+        TextPaint paint = new TextPaint(sample.getPaint());
+        while (dayLabelSize > 1f && !labelsFit(paint, available)) {
+            dayLabelSize -= 0.5f;
+            paint.setTextSize(dayLabelSize);
+        }
+        return dayLabelSize;
+    }
+
+    private boolean labelsFit(TextPaint paint, int available) {
+        for (int dayOfWeek = Calendar.SUNDAY; dayOfWeek <= Calendar.SATURDAY; dayOfWeek++) {
+            // Rounded up, which is what a TextView does with the width it asks for.
+            if (Math.ceil(Layout.getDesiredWidth(dayLabel(dayOfWeek), paint)) > available) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private void init() {
@@ -327,6 +400,7 @@ public class TimelineView extends RecyclerView {
             lblDate = root.findViewById(R.id.mti_timeline_lbl_date);
 
             lblDay.setTextColor(lblDayColor);
+            lblDay.setTextSize(TypedValue.COMPLEX_UNIT_PX, dayLabelSize(lblDay, root));
             lblDate.setTextColor(lblDateColor);
 
             root.setOnClickListener(new OnClickListener() {
@@ -344,7 +418,7 @@ public class TimelineView extends RecyclerView {
             this.year = year;
             this.month = month;
             this.day = day;
-            lblDay.setText(weekDays[dayOfWeek].toUpperCase(Locale.getDefault()));
+            lblDay.setText(dayLabel(dayOfWeek));
             lblDate.setText(String.valueOf(day));
             // lblDate.setBackgroundResource(selected ? R.drawable.mti_bg_lbl_date_selected : (isToday ? R.drawable.mti_bg_lbl_date_today : 0));
             lblDate.setTextColor(selected || isToday ? lblDateSelectedColor : lblDateColor);

--- a/app/src/main/res/layout/view_mti_item_day.xml
+++ b/app/src/main/res/layout/view_mti_item_day.xml
@@ -34,9 +34,7 @@
         android:id="@+id/mti_timeline_lbl_day"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:maxLength="1"
         android:maxLines="1"
-        android:singleLine="true"
         android:textSize="@dimen/view_mti_timeline_lbl_day_text"
         tools:text="T"/>
 


### PR DESCRIPTION
The calendar day strip built its weekday header by taking `DateFormatSymbols.getShortWeekdays()` and cutting it to one character with `android:maxLength="1"`. That rule assumes every language distinguishes its days in the first character. Read back from the running app in all twenty bundled locales, only Persian does. Chinese rendered the whole week as the single repeated character 周, and Catalan as a repeated D.

Part of #75. This is the weekday strip half only; the month strip has the same defect and that half stays open.

## The fix

CLDR already publishes a narrow weekday name for exactly this position, so the labels now come from `android.icu.text.DateFormatSymbols` with `STANDALONE` and `NARROW`, and the `maxLength` is gone from the day label. That class is available at the project `minSdk` of 24, so no desugaring and no new dependency.

Six locales change and fourteen do not. Catalan goes from one repeated letter to seven distinct labels and Chinese from one repeated character to seven. Malayalam and both Spanish variants go from six distinct labels to seven, Spanish because Wednesday is X rather than a second M. Hungarian changes to SZ and CS but still repeats SZ, so it stays at six. The fourteen that do not move are correct rather than a shortfall: German really is S M D M D F S, and English really does repeat T and S.

That alone fixes the reported defect, because the old cut was unconditional rather than a response to overflow.

## Why the sizing is in here too

Removing the cut leaves a label that is no longer guaranteed to be one character. CLDR gives Catalan dg through ds, and gives Malayalam names wider still. So the strip derives one shared text size and steps it down, measuring again at each step, until every label fits inside a cell.

Two decisions worth reviewing:

* **One size for all seven, not a size per cell.** A size per cell would let adjacent letters differ, which reads as a rendering bug even when every label fits.
* **It measures at each step rather than deriving a ratio.** Text width is not exactly proportional to text size, so a computed ratio cannot be trusted, and neither can a ranking of which label is widest taken once at the starting size.

Of the bundled translations only Malayalam reaches that path, and only at accessibility font scales. The locale comes from `Locale.getDefault()` rather than from the bundled set, so the check is not bounded by which translations ship.

## Why `android:singleLine` is removed

It is not a synonym for the `maxLines="1"` beside it. Measured both ways on one build with the sizing disabled: Malayalam at font scale 2.0 renders two cells completely empty with `singleLine` present, and renders every cell, merely cut short, without it. A blank weekday is worse than a cut one. The mechanism behind the blanking was not traced and is not asserted here.

## Verification

Built and driven on an Android 16 emulator against a build of the parent commit, same screen and same date.

* All twenty locales were read back from both builds at the default font size. That covers the label source, since the parent cannot overflow a cell and so cannot exercise the sizing at all.
* The sizing was covered separately against the sizing disabled build described above, with Malayalam at font scale 2.0 drawing all seven labels whole.
* At font scale 2.0, Catalan, Hungarian, Chinese and Malayalam all render seven labels with nothing clipped and the date row below still drawing. English and Persian report label bounds identical to the control, so nothing is scaled that does not need it.
* A probe with the scaling disabled settled what the clamp is for: without it nothing goes blank, but the wide Malayalam labels clip at the cell edge and ചൊ renders as ചെ, a different valid syllable. The probe was reverted.

`clean testFlossOsmDebugUnitTest assembleFlossOsmDebug` is green, 95 unit tests, no failures and none skipped.

## Not in this change

`MonthView` cuts `getShortMonths()` with `substring(0, 3)`, which is the same defect one row up, and `view_mti_item_month.xml` carries a `maxLength="8"` that is inert today and becomes live the moment that substring goes. Removing it is not a one line change, because the strip height starts depending on which month laid out first and a month scrolled in later can lose its year. That half is tracked on #75.
