### PR TITLE
Show the wallet a screen is scoped to in its toolbar

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
@@ -20,7 +20,15 @@
 package com.oriondev.moneywallet.ui.fragment.base;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
 import android.os.Bundle;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
 import androidx.annotation.IdRes;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.MenuRes;
@@ -37,6 +45,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.preference.CurrentWalletController;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.activity.DrawerController;
 import com.oriondev.moneywallet.ui.activity.ToolbarController;
 import com.oriondev.moneywallet.utils.Utils;
@@ -48,6 +60,8 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
 
     private static final String SAVED_STATE_SECONDARY_PANEL_VISIBLE = "MultiPanelFragment::SecondaryPanelVisible";
 
+    private static final int CURRENT_WALLET_LOADER_ID = 60001;
+
     private Toolbar mPrimaryToolbar;
 
     private ViewGroup mPrimaryPanel;
@@ -56,6 +70,35 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
     private FloatingActionButton mFloatingActionButton;
     private boolean mExtendedLayout;
     private boolean mSecondaryPanelVisible;
+
+    private BroadcastReceiver mCurrentWalletObserver;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        if (showsCurrentWallet()) {
+            // an anonymous listener rather than this class implementing CurrentWalletController,
+            // because a subclass that implements it would override the callback and stop the
+            // toolbar updating
+            mCurrentWalletObserver = PreferenceManager.registerCurrentWalletObserver(context, new CurrentWalletController() {
+
+                @Override
+                public void onCurrentWalletChanged(long walletId) {
+                    showCurrentWalletInToolbar(true);
+                }
+
+            });
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        if (mCurrentWalletObserver != null) {
+            PreferenceManager.unregisterCurrentWalletObserver(getActivity(), mCurrentWalletObserver);
+            mCurrentWalletObserver = null;
+        }
+        super.onDetach();
+    }
 
     @Nullable
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -117,6 +160,7 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
     protected void setupPrimaryToolbar(Toolbar toolbar) {
         // setup toolbar title and menu (if provided)
         toolbar.setTitle(getTitleRes());
+        showCurrentWalletInToolbar(false);
         int menuResId = onInflateMenu();
         if (menuResId > 0) {
             toolbar.inflateMenu(menuResId);
@@ -185,6 +229,84 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
             // unlock the navigation drawer
             setDrawerLocked(false);
         }
+    }
+
+    /**
+     * Override to true on a screen whose content is filtered by the wallet selected in the
+     * drawer. Naming the wallet is what stops such a screen looking empty for the wrong reason.
+     * Leave it false everywhere else: a screen that shows every wallet, or none in particular,
+     * would be claiming a scope it does not have. First read from onAttach, so an override
+     * cannot depend on anything assigned in onCreate or later.
+     */
+    protected boolean showsCurrentWallet() {
+        return false;
+    }
+
+    private final LoaderManager.LoaderCallbacks<Cursor> mCurrentWalletCallbacks = new LoaderManager.LoaderCallbacks<Cursor>() {
+
+        @NonNull
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, @Nullable Bundle args) {
+            Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, PreferenceManager.getCurrentWallet());
+            return new CursorLoader(getActivity(), uri, new String[] {Contract.Wallet.NAME}, null, null, null);
+        }
+
+        @Override
+        public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor data) {
+            if (mPrimaryToolbar != null) {
+                mPrimaryToolbar.setSubtitle(Utils.readWalletName(data));
+            }
+        }
+
+        @Override
+        public void onLoaderReset(@NonNull Loader<Cursor> loader) {
+            // the subtitle holds a copy of the string, not the cursor
+        }
+
+    };
+
+    /**
+     * @param reload true when the selected wallet may have changed, so the loader has to be
+     *               rebuilt against the new id. False on the view creation path, where init
+     *               redelivers the row a retained loader already holds instead of querying
+     *               again on every rotation.
+     */
+    private void showCurrentWalletInToolbar(boolean reload) {
+        if (!showsCurrentWallet() || mPrimaryToolbar == null || !isAdded()) {
+            return;
+        }
+        long walletId = PreferenceManager.getCurrentWallet();
+        if (walletId == PreferenceManager.TOTAL_WALLET_ID) {
+            // synthetic, there is no row to load
+            mPrimaryToolbar.setSubtitle(R.string.total_wallet_name);
+            getLoaderManager().destroyLoader(CURRENT_WALLET_LOADER_ID);
+        } else if (walletId == PreferenceManager.NO_CURRENT_WALLET) {
+            mPrimaryToolbar.setSubtitle(null);
+            getLoaderManager().destroyLoader(CURRENT_WALLET_LOADER_ID);
+        } else if (reload) {
+            // clear first: the load is asynchronous, and until it lands the old name would be
+            // naming the wrong wallet rather than merely being out of date
+            mPrimaryToolbar.setSubtitle(null);
+            // a loader rather than a direct query: resolving a wallet row runs a balance
+            // aggregate over the transactions table, and it redelivers when the row is renamed
+            getLoaderManager().restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+        } else if (isLoaderBuiltForAnotherWallet(walletId)) {
+            // a retained loader outlives this fragment instance, so init would redeliver the row
+            // it already holds, which belongs to a wallet that is no longer the selected one.
+            // No clear needed before the reload, unlike the branch above: this path only runs
+            // while the toolbar is freshly inflated, so there is no old name on it yet
+            getLoaderManager().restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+        } else {
+            getLoaderManager().initLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+        }
+    }
+
+    private boolean isLoaderBuiltForAnotherWallet(long walletId) {
+        Loader<Cursor> loader = getLoaderManager().getLoader(CURRENT_WALLET_LOADER_ID);
+        if (loader instanceof CursorLoader) {
+            return ContentUris.parseId(((CursorLoader) loader).getUri()) != walletId;
+        }
+        return false;
     }
 
     protected Toolbar getPrimaryToolbar() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SinglePanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SinglePanelFragment.java
@@ -20,7 +20,15 @@
 package com.oriondev.moneywallet.ui.fragment.base;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.ContentUris;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
 import android.os.Bundle;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -35,6 +43,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.preference.CurrentWalletController;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.activity.ToolbarController;
 import com.oriondev.moneywallet.utils.Utils;
 
@@ -43,7 +55,38 @@ import com.oriondev.moneywallet.utils.Utils;
  */
 public abstract class SinglePanelFragment extends Fragment implements Toolbar.OnMenuItemClickListener {
 
+    private static final int CURRENT_WALLET_LOADER_ID = 60002;
+
     private Toolbar mToolbar;
+
+    private BroadcastReceiver mCurrentWalletObserver;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        if (showsCurrentWallet()) {
+            // an anonymous listener rather than this class implementing CurrentWalletController,
+            // because a subclass that implements it would override the callback and stop the
+            // toolbar updating
+            mCurrentWalletObserver = PreferenceManager.registerCurrentWalletObserver(context, new CurrentWalletController() {
+
+                @Override
+                public void onCurrentWalletChanged(long walletId) {
+                    showCurrentWalletInToolbar(true);
+                }
+
+            });
+        }
+    }
+
+    @Override
+    public void onDetach() {
+        if (mCurrentWalletObserver != null) {
+            PreferenceManager.unregisterCurrentWalletObserver(getActivity(), mCurrentWalletObserver);
+            mCurrentWalletObserver = null;
+        }
+        super.onDetach();
+    }
 
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
@@ -87,6 +130,7 @@ public abstract class SinglePanelFragment extends Fragment implements Toolbar.On
     protected void setupPrimaryToolbar(Toolbar toolbar) {
         // setup toolbar title and menu (if provided)
         toolbar.setTitle(getTitleRes());
+        showCurrentWalletInToolbar(false);
         int menuResId = onInflateMenu();
         if (menuResId > 0) {
             toolbar.inflateMenu(menuResId);
@@ -108,6 +152,84 @@ public abstract class SinglePanelFragment extends Fragment implements Toolbar.On
         if (mToolbar != null) {
             mToolbar.setSubtitle(subtitle);
         }
+    }
+
+    /**
+     * Override to true on a screen whose content is filtered by the wallet selected in the
+     * drawer. Naming the wallet is what stops such a screen looking empty for the wrong reason.
+     * Leave it false everywhere else: a screen that shows every wallet, or none in particular,
+     * would be claiming a scope it does not have. First read from onAttach, so an override
+     * cannot depend on anything assigned in onCreate or later.
+     */
+    protected boolean showsCurrentWallet() {
+        return false;
+    }
+
+    private final LoaderManager.LoaderCallbacks<Cursor> mCurrentWalletCallbacks = new LoaderManager.LoaderCallbacks<Cursor>() {
+
+        @NonNull
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, @Nullable Bundle args) {
+            Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, PreferenceManager.getCurrentWallet());
+            return new CursorLoader(getActivity(), uri, new String[] {Contract.Wallet.NAME}, null, null, null);
+        }
+
+        @Override
+        public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor data) {
+            if (mToolbar != null) {
+                mToolbar.setSubtitle(Utils.readWalletName(data));
+            }
+        }
+
+        @Override
+        public void onLoaderReset(@NonNull Loader<Cursor> loader) {
+            // the subtitle holds a copy of the string, not the cursor
+        }
+
+    };
+
+    /**
+     * @param reload true when the selected wallet may have changed, so the loader has to be
+     *               rebuilt against the new id. False on the view creation path, where init
+     *               redelivers the row a retained loader already holds instead of querying
+     *               again on every rotation.
+     */
+    private void showCurrentWalletInToolbar(boolean reload) {
+        if (!showsCurrentWallet() || mToolbar == null || !isAdded()) {
+            return;
+        }
+        long walletId = PreferenceManager.getCurrentWallet();
+        if (walletId == PreferenceManager.TOTAL_WALLET_ID) {
+            // synthetic, there is no row to load
+            mToolbar.setSubtitle(R.string.total_wallet_name);
+            getLoaderManager().destroyLoader(CURRENT_WALLET_LOADER_ID);
+        } else if (walletId == PreferenceManager.NO_CURRENT_WALLET) {
+            mToolbar.setSubtitle(null);
+            getLoaderManager().destroyLoader(CURRENT_WALLET_LOADER_ID);
+        } else if (reload) {
+            // clear first: the load is asynchronous, and until it lands the old name would be
+            // naming the wrong wallet rather than merely being out of date
+            mToolbar.setSubtitle(null);
+            // a loader rather than a direct query: resolving a wallet row runs a balance
+            // aggregate over the transactions table, and it redelivers when the row is renamed
+            getLoaderManager().restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+        } else if (isLoaderBuiltForAnotherWallet(walletId)) {
+            // a retained loader outlives this fragment instance, so init would redeliver the row
+            // it already holds, which belongs to a wallet that is no longer the selected one.
+            // No clear needed before the reload, unlike the branch above: this path only runs
+            // while the toolbar is freshly inflated, so there is no old name on it yet
+            getLoaderManager().restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+        } else {
+            getLoaderManager().initLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+        }
+    }
+
+    private boolean isLoaderBuiltForAnotherWallet(long walletId) {
+        Loader<Cursor> loader = getLoaderManager().getLoader(CURRENT_WALLET_LOADER_ID);
+        if (loader instanceof CursorLoader) {
+            return ContentUris.parseId(((CursorLoader) loader).getUri()) != walletId;
+        }
+        return false;
     }
 
     @MenuRes

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/BudgetMultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/BudgetMultiPanelViewPagerFragment.java
@@ -58,6 +58,11 @@ public class BudgetMultiPanelViewPagerFragment extends MultiPanelViewPagerItemFr
     }
 
     @Override
+    protected boolean showsCurrentWallet() {
+        return true;
+    }
+
+    @Override
     protected void onFloatingActionButtonClick() {
         Intent intent = new Intent(getActivity(), NewEditBudgetActivity.class);
         intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.NEW_ITEM);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
@@ -20,6 +20,8 @@
 package com.oriondev.moneywallet.ui.fragment.multipanel;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -37,6 +39,7 @@ import android.view.ViewGroup;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.preference.CurrentWalletController;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.adapter.recycler.AbstractCursorAdapter;
 import com.oriondev.moneywallet.ui.adapter.recycler.TransactionCursorAdapter;
@@ -55,7 +58,7 @@ import java.util.Date;
 /**
  * Created by andrea on 06/04/18.
  */
-public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment implements MonthView.OnMonthSelectedListener, OnDateSelectedListener, SwipeRefreshLayout.OnRefreshListener, TransactionCursorAdapter.ActionListener, LoaderManager.LoaderCallbacks<Cursor> {
+public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment implements MonthView.OnMonthSelectedListener, OnDateSelectedListener, SwipeRefreshLayout.OnRefreshListener, TransactionCursorAdapter.ActionListener, LoaderManager.LoaderCallbacks<Cursor>, CurrentWalletController {
 
     private static final String SECONDARY_PANEL_FRAGMENT_TAG = "CalendarMultiPanelFragment::Tag::TransactionItemFragment";
 
@@ -64,6 +67,8 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
     private static final String ARG_SELECTED_DAY = "CalendarMultiPanelFragment::Arguments::Day";
 
     private static final int DEFAULT_LOADER_ID = 4834;
+
+    private BroadcastReceiver mCurrentWalletObserver;
 
     private MonthView mMonthView;
     private TimelineView mTimelineView;
@@ -118,6 +123,11 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
     @Override
     protected int getTitleRes() {
         return R.string.title_activity_calendar;
+    }
+
+    @Override
+    protected boolean showsCurrentWallet() {
+        return true;
     }
 
     @Override
@@ -200,6 +210,32 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
                 mTimelineView.getSelectedDay()
         );
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.REFRESHING);
+    }
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        mCurrentWalletObserver = PreferenceManager.registerCurrentWalletObserver(context, this);
+    }
+
+    @Override
+    public void onDetach() {
+        PreferenceManager.unregisterCurrentWalletObserver(getActivity(), mCurrentWalletObserver);
+        super.onDetach();
+    }
+
+    @Override
+    public void onCurrentWalletChanged(long walletId) {
+        if (mTimelineView == null) {
+            return;
+        }
+        // this screen names the wallet in its toolbar, so the day list has to follow it
+        loadTransactions(
+                mTimelineView.getSelectedYear(),
+                mTimelineView.getSelectedMonth(),
+                mTimelineView.getSelectedDay()
+        );
+        mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
     }
 
     private void loadTransactions(int year, int month, int day) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/DebtMultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/DebtMultiPanelViewPagerFragment.java
@@ -59,6 +59,11 @@ public class DebtMultiPanelViewPagerFragment extends MultiPanelViewPagerItemFrag
     }
 
     @Override
+    protected boolean showsCurrentWallet() {
+        return true;
+    }
+
+    @Override
     protected void onFloatingActionButtonClick() {
         Intent intent = new Intent(getActivity(), NewEditDebtActivity.class);
         intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.NEW_ITEM);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/ModelMultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/ModelMultiPanelViewPagerFragment.java
@@ -68,6 +68,11 @@ public class ModelMultiPanelViewPagerFragment extends MultiPanelViewPagerMultiIt
     }
 
     @Override
+    protected boolean showsCurrentWallet() {
+        return true;
+    }
+
+    @Override
     protected SecondaryPanelFragment onCreateSecondaryPanel(int type) {
         switch (type) {
             case TYPE_TRANSACTION_MODEL:

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/RecurrenceMultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/RecurrenceMultiPanelViewPagerFragment.java
@@ -97,6 +97,11 @@ public class RecurrenceMultiPanelViewPagerFragment extends MultiPanelViewPagerMu
     }
 
     @Override
+    protected boolean showsCurrentWallet() {
+        return true;
+    }
+
+    @Override
     public void onAttach(Context context) {
         super.onAttach(context);
         IntentFilter filter = new IntentFilter(LocalAction.ACTION_ITEM_CLICK);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/SavingMultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/SavingMultiPanelViewPagerFragment.java
@@ -58,6 +58,11 @@ public class SavingMultiPanelViewPagerFragment extends MultiPanelViewPagerItemFr
     }
 
     @Override
+    protected boolean showsCurrentWallet() {
+        return true;
+    }
+
+    @Override
     protected void onFloatingActionButtonClick() {
         Intent intent = new Intent(getActivity(), NewEditSavingActivity.class);
         intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.NEW_ITEM);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/TransactionMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/TransactionMultiPanelFragment.java
@@ -184,6 +184,11 @@ public class TransactionMultiPanelFragment extends MultiPanelCursorListItemFragm
     }
 
     @Override
+    protected boolean showsCurrentWallet() {
+        return true;
+    }
+
+    @Override
     protected boolean isFloatingActionButtonEnabled() {
         return false;
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/TransactionMultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/TransactionMultiPanelViewPagerFragment.java
@@ -66,6 +66,11 @@ public class TransactionMultiPanelViewPagerFragment extends MultiPanelViewPagerM
         return R.string.menu_transaction;
     }
 
+    @Override
+    protected boolean showsCurrentWallet() {
+        return true;
+    }
+
     @MenuRes
     protected int onInflateMenu() {
         return R.menu.menu_transaction_multipanel_fragment;

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/singlepanel/OverviewSinglePanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/singlepanel/OverviewSinglePanelFragment.java
@@ -99,6 +99,11 @@ public class OverviewSinglePanelFragment extends SinglePanelFragment implements 
         return R.string.menu_overview;
     }
 
+    @Override
+    protected boolean showsCurrentWallet() {
+        return true;
+    }
+
     @MenuRes
     protected int onInflateMenu() {
         return R.menu.menu_overview_fragment;

--- a/app/src/main/java/com/oriondev/moneywallet/utils/Utils.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/Utils.java
@@ -20,6 +20,7 @@
 package com.oriondev.moneywallet.utils;
 
 import android.app.Activity;
+import android.database.Cursor;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -29,6 +30,7 @@ import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.IFile;
+import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.backup.BackupManager;
 
 import java.text.DecimalFormat;
@@ -143,6 +145,18 @@ public class Utils {
             if (view != null) {
                 return view;
             }
+        }
+        return null;
+    }
+
+    /**
+     * @param cursor a wallet row cursor whose projection includes the name. Moved to its first
+     *               row, but not closed: the caller, or its loader, still owns it.
+     * @return the wallet name, or null when the cursor is null or holds no row.
+     */
+    public static String readWalletName(Cursor cursor) {
+        if (cursor != null && cursor.moveToFirst()) {
+            return cursor.getString(cursor.getColumnIndexOrThrow(Contract.Wallet.NAME));
         }
         return null;
     }


### PR DESCRIPTION
## What this fixes

Fourteen call sites filter what a screen shows by the wallet selected in the drawer, and none of those screens names it. The drawer account header does, but it is invisible until the drawer is pulled open, and three of the host activities have no drawer to pull. So a list can render empty because the money is in another wallet, with nothing on screen to say why.

Filed separately as #82.

## What the change does

A screen whose content is filtered by the current wallet now carries the wallet name as its toolbar subtitle. No layout files were touched: both fragment bases already resolve the same `primary_toolbar` id.

The default is off and each scoped screen opts in through `showsCurrentWallet()`. Nine do.

## Why opt in and not opt out

The opt out version was built first and was wrong. The wallet list screen shows every wallet and would have been subtitled with one of them. Naming a wallet on a screen that is not scoped to it claims something false, which is worse than the silence it replaces.

## Why a loader

Resolving one wallet row is not a cheap read. `getWallets` left joins a derived table that sums over the whole transactions table and groups by wallet, and the projection is applied outside that derived table, so asking for only the name does not remove the aggregate. That would have run on the main thread inside `onCreateView`.

The loader also redelivers when the row is updated, so renaming the selected wallet updates the toolbar rather than leaving a stale name.

View creation inits the loader instead of restarting it, so a rotation redelivers the row already held. Only a wallet switch restarts it, and the subtitle is cleared first so the toolbar never names the wallet it is moving away from.

## One cost this does not avoid

Every wallet cursor the provider hands out is registered for notifications on the transaction and transfer collections. So the name reloads whenever a transaction is written. That is background work now rather than main thread work, but it is not free.

## Verification

Driven on an Android 16 emulator, not only built.

| Check | Result |
|---|---|
| scoped screens (transactions, overview) | wallet named |
| unscoped screens (people, settings, manage wallets) | no subtitle, as intended |
| rename the selected wallet from the wallet list, return | toolbar follows, fragment never recreated |
| switch to the total wallet, rotate, switch back | correct label at each step |
| font scale 2.0 on the two screens whose toolbar height is fixed | title and subtitle both render in full |

The font scale check matters because the item transaction list and the calendar sit in layouts that pin the toolbar height, unlike the other seven.

## Known and deliberately out of scope

Deleting the currently selected wallet never resets the preference, so every scoped screen filters on a dead id and the subtitle goes blank. That predates this change and is filed as #85.
