### PR TITLE
Open a person's transactions when you tap them

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/PersonCursorAdapter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/PersonCursorAdapter.java
@@ -20,8 +20,14 @@
 package com.oriondev.moneywallet.ui.adapter.recycler;
 
 import android.database.Cursor;
+import android.os.Bundle;
+import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.core.view.AccessibilityDelegateCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.recyclerview.widget.RecyclerViewAccessibilityDelegate;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -67,10 +73,56 @@ public class PersonCursorAdapter extends AbstractCursorAdapter<PersonCursorAdapt
     public PersonCursorAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
         View itemView = inflater.inflate(R.layout.adapter_person_item, parent, false);
+        if (parent instanceof RecyclerView) {
+            RecyclerViewAccessibilityDelegate parentDelegate =
+                    ((RecyclerView) parent).getCompatAccessibilityDelegate();
+            if (parentDelegate != null) {
+                ViewCompat.setAccessibilityDelegate(itemView,
+                        new PersonItemDelegate(parentDelegate.getItemDelegate()));
+            } else {
+                // Only reachable if something cleared the RecyclerView's own delegate. The row
+                // still works, it just loses the named long press, so leave a trace rather than
+                // dropping the label in silence.
+                Log.w("PersonCursorAdapter", "no RecyclerView accessibility delegate, long press stays unlabelled");
+            }
+        }
         return new ViewHolder(itemView);
     }
 
-    /*package-local*/ class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+    /**
+     * A person row needs two things announced that cannot both come from one delegate. Its
+     * position in the list is supplied only by the RecyclerView's own item delegate, and the long
+     * press is otherwise announced with no destination. Setting any delegate on a row makes
+     * RecyclerView skip attaching its own, so this forwards to that one rather than replacing it.
+     */
+    private static class PersonItemDelegate extends AccessibilityDelegateCompat {
+
+        private final AccessibilityDelegateCompat mItemDelegate;
+
+        private PersonItemDelegate(AccessibilityDelegateCompat itemDelegate) {
+            mItemDelegate = itemDelegate;
+        }
+
+        @Override
+        public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+            mItemDelegate.onInitializeAccessibilityNodeInfo(host, info);
+            info.addAction(new AccessibilityNodeInfoCompat.AccessibilityActionCompat(
+                    AccessibilityNodeInfoCompat.ACTION_LONG_CLICK,
+                    host.getContext().getString(R.string.action_open_person_details)
+            ));
+        }
+
+        @Override
+        public boolean performAccessibilityAction(View host, int action, Bundle args) {
+            // Nothing this forward reaches is implemented on the recyclerview this project
+            // resolves, so it changes no behaviour today. It is here so that wrapping the item
+            // delegate stays a complete wrap rather than a partial one.
+            return mItemDelegate.performAccessibilityAction(host, action, args);
+        }
+
+    }
+
+    /*package-local*/ class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener, View.OnLongClickListener {
 
         private ImageView mAvatarImageView;
         private TextView mNameTextView;
@@ -80,6 +132,9 @@ public class PersonCursorAdapter extends AbstractCursorAdapter<PersonCursorAdapt
             mAvatarImageView = itemView.findViewById(R.id.avatar_image_view);
             mNameTextView = itemView.findViewById(R.id.primary_text_view);
             itemView.setOnClickListener(this);
+            // Named for screen readers by PersonItemDelegate above, which is set in
+            // onCreateViewHolder because it needs the RecyclerView to forward to.
+            itemView.setOnLongClickListener(this);
         }
 
         @Override
@@ -91,10 +146,27 @@ public class PersonCursorAdapter extends AbstractCursorAdapter<PersonCursorAdapt
                 }
             }
         }
+
+        @Override
+        public boolean onLongClick(View v) {
+            if (mActionListener == null) {
+                return false;
+            }
+            Cursor cursor = getSafeCursor(getAdapterPosition());
+            if (cursor != null) {
+                mActionListener.onPersonLongClick(cursor.getLong(mIndexId));
+            }
+            // Consumed whenever there is a listener to consume it. Declining it would let the
+            // release that follows run performClick instead, so a long press that lost its row
+            // would open the transaction list rather than the panel the user was reaching for.
+            return true;
+        }
     }
 
     public interface ActionListener {
 
         void onPersonClick(long id);
+
+        void onPersonLongClick(long id);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/PersonMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/PersonMultiPanelFragment.java
@@ -33,6 +33,7 @@ import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
 import com.oriondev.moneywallet.ui.activity.NewEditPersonActivity;
+import com.oriondev.moneywallet.ui.activity.TransactionListActivity;
 import com.oriondev.moneywallet.ui.adapter.recycler.AbstractCursorAdapter;
 import com.oriondev.moneywallet.ui.adapter.recycler.PersonCursorAdapter;
 import com.oriondev.moneywallet.ui.fragment.base.MultiPanelCursorListItemFragment;
@@ -89,8 +90,36 @@ public class PersonMultiPanelFragment extends MultiPanelCursorListItemFragment i
         return R.string.menu_people;
     }
 
+    /**
+     * A tap opens the person's transactions. The detail panel renders their icon, their name
+     * and their note and carries no other data, so the transaction list is the only thing on
+     * it worth navigating to.
+     *
+     * On a layout wide enough to show both panels at once the panel is permanently on screen
+     * and showing it is a no op, so there a tap has to keep feeding it instead. Otherwise it
+     * would sit beside the list holding the empty state, or a person chosen earlier.
+     */
     @Override
     public void onPersonClick(long id) {
+        if (isExtendedLayout()) {
+            showPersonPanel(id);
+        } else {
+            Intent intent = new Intent(getActivity(), TransactionListActivity.class);
+            intent.putExtra(TransactionListActivity.PERSON_ID, id);
+            startActivity(intent);
+        }
+    }
+
+    /**
+     * Long press reaches the detail panel, which is the only place in the app that can edit or
+     * delete a person.
+     */
+    @Override
+    public void onPersonLongClick(long id) {
+        showPersonPanel(id);
+    }
+
+    private void showPersonPanel(long id) {
         showItemId(id);
         showSecondaryPanel();
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PersonItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PersonItemFragment.java
@@ -174,12 +174,8 @@ public class PersonItemFragment extends SecondaryPanelFragment implements Loader
             IconLoader.loadInto(icon, mAvatarImageView);
             mNameTextView.setText(cursor.getString(cursor.getColumnIndex(Contract.Person.NAME)));
             String note = cursor.getString(cursor.getColumnIndex(Contract.Person.NOTE));
-            if (!TextUtils.isEmpty(note)) {
-                mNoteTextView.setText(note);
-                mNoteTextView.setVisibility(View.VISIBLE);
-            } else {
-                mNoteTextView.setVisibility(View.INVISIBLE);
-            }
+            mNoteTextView.setText(note);
+            mNoteTextView.setVisibility(TextUtils.isEmpty(note) ? View.GONE : View.VISIBLE);
         } else {
             showItemId(0L);
         }

--- a/app/src/main/res/drawable/ic_receipt_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_receipt_black_24dp.xml
@@ -24,5 +24,5 @@
         android:viewportHeight="24.0">
     <path
         android:fillColor="#FF000000"
-        android:pathData="M3,13h2v-2L3,11v2zM3,17h2v-2L3,15v2zM3,9h2L5,7L3,7v2zM7,13h14v-2L7,11v2zM7,17h14v-2L7,15v2zM7,7v2h14L21,7L7,7z"/>
+        android:pathData="M18 17H6v-2h12v2zm0-4H6v-2h12v2zm0-4H6V7h12v2zM3 22l1.5-1.5L6 22l1.5-1.5L9 22l1.5-1.5L12 22l1.5-1.5L15 22l1.5-1.5L18 22l1.5-1.5L21 22V2l-1.5 1.5L18 2l-1.5 1.5L15 2l-1.5 1.5L12 2l-1.5 1.5L9 2 7.5 3.5 6 2 4.5 3.5 3 2v20z"/>
 </vector>

--- a/app/src/main/res/menu/menu_list_archive_edit_delete_item.xml
+++ b/app/src/main/res/menu/menu_list_archive_edit_delete_item.xml
@@ -24,7 +24,7 @@
 
     <item
         android:id="@+id/action_show_transaction_list"
-        android:icon="@drawable/ic_list_black_24dp"
+        android:icon="@drawable/ic_receipt_black_24dp"
         android:title="@string/menu_action_show_transaction_list"
         app:showAsAction="ifRoom" />
 

--- a/app/src/main/res/menu/menu_list_edit_delete_item.xml
+++ b/app/src/main/res/menu/menu_list_edit_delete_item.xml
@@ -24,7 +24,7 @@
 
     <item
         android:id="@+id/action_show_transaction_list"
-        android:icon="@drawable/ic_list_black_24dp"
+        android:icon="@drawable/ic_receipt_black_24dp"
         android:title="@string/menu_action_show_transaction_list"
         app:showAsAction="ifRoom" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,8 @@
     <string name="title_fragment_item_place">"Place"</string>
     <string name="title_fragment_item_person">"Person"</string>
 
+    <string name="action_open_person_details">"Open person details"</string>
+
     <string name="menu_action_attach_file">"Attach file"</string>
     <string name="menu_action_save_changes">"Save changes"</string>
     <string name="menu_refresh_currency_rate">"Refresh currency rate"</string>


### PR DESCRIPTION
## What this does

Tapping a person opens that person's transactions. A long press opens the detail panel, which is the only place in the app that can edit or delete a person, so nothing the panel offered becomes unreachable.

Two supporting changes ride along: the toolbar action that opens an item's transaction list gets a receipt glyph instead of a bulleted list glyph, and the person panel's note view is cleared rather than hidden with the previous person's text still inside it.

## Why

The reporter called the control they used a "three line menu" and asked for the name itself to open the history. On master that control is the only route to the list, and its glyph is three bars with small squares beside them, which is a plausible reason it read as a menu. That reading is offered here, not stated by the reporter.

Person is the right screen to single out. Counting the content views in each detail panel body, descending into containers rather than counting direct children only: person 1, place 3, event 3, category 4, budget 5, saving 5, debt 7. The person panel's one view is the note, and it is blank for a person with no note. The other panels carry something; this one does not. No motive is attributed to the reporter for choosing People, because they did not give one.

## Accessibility

The long press is named for screen readers, and keeping the row's position announced at the same time takes a forwarding delegate.

The recyclerview this project resolves, 1.0.0, attaches its own item delegate only to a row that does not already carry one, and that item delegate is what supplies the row's index within the list. So the row's delegate wraps it rather than replacing it. Forwarding `onInitializeAccessibilityNodeInfo` is the load bearing part, and the labelled long click action is added after it, because a labelled standard action replaces the unlabelled one only if it is added on top of the node the base already populated.

`getItemDelegate` was checked as public on the resolved 1.0.0 aar rather than assumed.

## What this touches, and what it does not

Below 840dp, People becomes the only item list where tapping a row does not open its detail panel. The sibling item lists are untouched. At 840dp and above the detail panel is permanently on screen, so a tap keeps feeding it and People behaves like every other list. A device that crosses that width only in landscape answers the same tap differently in each orientation.

The destination is filtered by the wallet selected in the drawer, exactly as every other item drilldown in this app already is. A person whose money sits in another wallet opens an empty list. That predates this change, and the destination screen now names the wallet in its toolbar, but promoting this route from a menu action to the default gesture means more people will meet it. Raising it here rather than leaving it for review.

## Verification

Driven on an Android 16 emulator.

| Check | Result |
|---|---|
| tap a person at phone width | lands on the transaction list filtered to that person |
| long press a person | detail panel opens with show transactions, edit and delete all present |
| person panel toolbar | draws a receipt, and tapping it still opens the filtered list |

**The accessibility change was checked with a screen reader on a physical device**, because it cannot be checked without one. A row reporting itself clickable and long clickable proves nothing: it would report that either way, including in the failure case this change exists to avoid, where the delegate replaces the item delegate instead of wrapping it and the row index is silently lost.

With TalkBack running on a list of two people, a row announces:

> person icon, test, two of two, double tap to activate, double tap and hold to open person details

Both halves are in that one utterance. "Two of two" is the collection item info that only the wrapped item delegate supplies. The named long press does not exist without the delegate at all. A single row list cannot test this, since a screen reader does not announce a position for one of one.

The archive variant of the shared menu was not opened on screen, because the test fixture has no debts or savings.
