### PR TITLE
Declare a type for the foreground services that start one

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <application
         android:icon="@mipmap/ic_launcher"
@@ -118,9 +119,13 @@
                 android:resource="@xml/file_provider_paths" />
         </provider>
 
-        <service android:name=".service.openexchangerates.OpenExchangeRatesCurrencyRateDownloadIntentService" />
+        <service
+            android:name=".service.openexchangerates.OpenExchangeRatesCurrencyRateDownloadIntentService"
+            android:foregroundServiceType="dataSync" />
         <service android:name=".service.AttachmentHandlerIntentService" />
-        <service android:name=".service.BackupHandlerIntentService" />
+        <service
+            android:name=".service.BackupHandlerIntentService"
+            android:foregroundServiceType="dataSync" />
         <service android:name=".service.BackendHandlerIntentService" />
         <service
             android:name=".service.RecurrenceHandlerIntentService"

--- a/app/src/main/java/com/oriondev/moneywallet/service/AbstractCurrencyRateDownloadIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/AbstractCurrencyRateDownloadIntentService.java
@@ -65,7 +65,7 @@ public abstract class AbstractCurrencyRateDownloadIntentService extends IntentSe
                 .setContentTitle(getString(R.string.notification_title_download_exchange_rates))
                 .setProgress(0, 0, true)
                 .setCategory(NotificationCompat.CATEGORY_PROGRESS);
-        startForeground(NotificationContract.NOTIFICATION_ID_EXCHANGE_RATE_PROGRESS, mBuilder.build());
+        ForegroundServices.startDataSync(this, NotificationContract.NOTIFICATION_ID_EXCHANGE_RATE_PROGRESS, mBuilder.build());
         Exception exception = null;
         try {
             updateExchangeRates();
@@ -94,7 +94,7 @@ public abstract class AbstractCurrencyRateDownloadIntentService extends IntentSe
     protected void setCurrentProgress(String operation, int percentage) {
         mBuilder.setContentText(operation)
                 .setProgress(100, percentage, false);
-        startForeground(NotificationContract.NOTIFICATION_ID_EXCHANGE_RATE_PROGRESS, mBuilder.build());
+        ForegroundServices.startDataSync(this, NotificationContract.NOTIFICATION_ID_EXCHANGE_RATE_PROGRESS, mBuilder.build());
     }
 
     private void showError(String error) {

--- a/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
@@ -348,7 +348,7 @@ public class BackupHandlerIntentService extends IntentService {
         // update the notification if required
         if (mNotificationBuilder != null) {
             mNotificationBuilder.setContentTitle(getNotificationContentTitle(action, false));
-            startForeground(NotificationContract.NOTIFICATION_ID_BACKUP_PROGRESS, mNotificationBuilder.build());
+            ForegroundServices.startDataSync(this, NotificationContract.NOTIFICATION_ID_BACKUP_PROGRESS, mNotificationBuilder.build());
         }
     }
 
@@ -364,7 +364,7 @@ public class BackupHandlerIntentService extends IntentService {
         if (mNotificationBuilder != null) {
             mNotificationBuilder.setContentText(getNotificationContentText(status));
             mNotificationBuilder.setProgress(100, progress, false);
-            startForeground(NotificationContract.NOTIFICATION_ID_BACKUP_PROGRESS, mNotificationBuilder.build());
+            ForegroundServices.startDataSync(this, NotificationContract.NOTIFICATION_ID_BACKUP_PROGRESS, mNotificationBuilder.build());
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/service/ForegroundServices.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/ForegroundServices.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.service;
+
+import android.app.Notification;
+import android.app.Service;
+import android.content.pm.ServiceInfo;
+import android.os.Build;
+
+/*package-local*/ class ForegroundServices {
+
+    private ForegroundServices() {
+    }
+
+    /**
+     * An app targeting API 34 or later must declare a type on any foreground service it starts,
+     * and starting one without a type throws rather than being ignored. The typed overload of
+     * startForeground exists from API 29, so anything older keeps the two argument call.
+     *
+     * <p>The caller's own service entry in the manifest must declare dataSync as well. The
+     * runtime type has to be a subset of the manifest declaration, and that check is not gated on
+     * a target version: it has thrown since API 29. So this is not safe to call from a service
+     * that has not been given the declaration.
+     *
+     * @param service      the service asking to run in the foreground.
+     * @param id           notification id, which must not be zero.
+     * @param notification the notification to show while it runs.
+     */
+    /*package-local*/ static void startDataSync(Service service, int id, Notification notification) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            service.startForeground(id, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC);
+        } else {
+            service.startForeground(id, notification);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #83.

## The crash

Tapping "Update exchange rates" killed the app. No dialog, no error, back to the launcher.

```
FATAL EXCEPTION: IntentService[OpenExchangeRatesCurrencyRateDownloadIntentService]
android.app.MissingForegroundServiceTypeException: Starting FGS without a type  targetSDK=35
        at android.app.Service.startForeground(Service.java:776)
        at ...AbstractCurrencyRateDownloadIntentService.onHandleIntent(...:68)
```

That `startForeground` call sits outside the try that wraps the download, so the exception left `onHandleIntent`, went uncaught on the IntentService worker thread, and took the process with it.

## Why

An app targeting API 34 or later must declare a type on any foreground service it starts, and starting one without a type throws rather than being ignored. This app sets `targetSdk 35`, and not one of the seven service declarations in the manifest carried `android:foregroundServiceType`. It also requested only `FOREGROUND_SERVICE`, none of the per type permissions API 34 added alongside.

## The change

Two services call `startForeground`: the currency rate download at two call sites, and the backup handler at two more. One fetches data on the user's behalf and the other is a backup or restore, both of which Android lists under `dataSync`. The manifest declares that on those two and requests the matching permission, which older releases ignore because they do not know the name.

The type is passed at the call sites as well, through one helper rather than four copies of the version check. The typed overload of `startForeground` arrives at API 29 and this app supports 24, so older releases keep the two argument call. `ServiceCompat` gained a typed overload too, but only in androidx core 1.12, and this project resolves 1.3.2.

## What this does not fix

Android 15 refuses a `dataSync` foreground service whose start is attributed to a `BOOT_COMPLETED` broadcast, for an app targeting 35, and this app has such a path: `BootBroadcastReceiver` runs `scheduleAutoBackupTask`, which starts the backup service inline rather than scheduling an alarm whenever a backup is already overdue.

That path is broken today and stays broken. It is not made worse here. The type check and the boot check both run inside `Service.startForeground` rather than at the caller, and an undeclared service reaches the boot check with a type of none, which fails it just the same. The enforcement point is visible in the crash above, whose stack ends at `Service.startForeground` and not at the call that started the service.

Fixing it needs a change to how that path launches, not a type. Filed as #88.

## Verification

Driven on an Android 16 emulator, both directions.

| Build | Result |
|---|---|
| before | the process died on every attempt |
| after | the service starts, ActivityManager logs it entering the foreground, the crash buffer is empty |
| after, manual backup | completes, "Backup created correctly" |

The positive signal is the point: a run that never reached the service would also produce no crash, so "no crash" alone would not have been a check.

## Two things seen and stated rather than left

`ForegroundServiceTypeLoggerModule` still logs that the start and stop calls carry no types. It maps `foregroundServiceType` onto capability API types only, camera, microphone, location and the rest, and `dataSync` maps to none of them, so an empty set is what a correctly typed `dataSync` service produces.

Android 15 gives `dataSync` a six hour budget per day for apps targeting 35, after which the system calls `onTimeout` and then kills the service. A rate download and an ordinary backup are nowhere near it; a very large restore over a slow link, repeated, could be.
