### PR TITLE
Fall back to the total wallet when the selected wallet is deleted

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -665,7 +665,17 @@ public class DataContentProvider extends ContentProvider {
                 break;
             case WALLET_ITEM:
                 notifyUri = DataContentProvider.CONTENT_WALLETS;
-                result = mDatabase.deleteWallet(ContentUris.parseId(uri));
+                long deletedWalletId = ContentUris.parseId(uri);
+                result = mDatabase.deleteWallet(deletedWalletId);
+                Context deleteContext = getContext();
+                if (result > 0 && deleteContext != null
+                        && deletedWalletId == PreferenceManager.getCurrentWallet()) {
+                    // the deleted wallet still has its id stored as the current one, and every
+                    // scoped query keeps filtering on it, so all of them come back with
+                    // nothing. reset here rather than in the screen that triggers the delete,
+                    // because every wallet delete passes through this point.
+                    PreferenceManager.setCurrentWallet(deleteContext, PreferenceManager.TOTAL_WALLET_ID);
+                }
                 break;
             case TRANSACTION_ITEM:
                 notifyUri = DataContentProvider.CONTENT_TRANSACTIONS;


### PR DESCRIPTION
Fixes #85.

Deleting the wallet that is currently selected left its id sitting in the `current_wallet_id` preference. Nothing on the delete path writes that preference, so every wallet scoped query kept filtering on a row that no longer exists, and it survived a restart.

## The mechanism

`PreferenceManager.setCurrentWallet` has two callers today: `MainActivity.onProfileChanged`, when a profile in the drawer header is tapped, and `DataContentProvider.notifyDatabaseIsChanged`, which resets to `NO_CURRENT_WALLET` on a backup restore or a legacy edition import. Deleting a wallet goes through neither.

`MainActivity.onLoadFinished` does have a repair path, but it only runs when the stored id is already `NO_CURRENT_WALLET`. With a deleted id it takes the other branch, `setActiveProfile(currentWalletId)`, which matches no profile and writes nothing back.

Fourteen call sites build a query selection from that id, and every one of them came back with nothing: eleven cursor backed lists render their empty state, and the three loaders behind the overview and period screens return a result carrying no money. Other sites resolve the same preference by wallet uri instead, including the toolbar subtitle, which goes blank.

## The change

One guard in `DataContentProvider.delete`, case `WALLET_ITEM`: if the row was actually removed and its id is the stored current wallet, set the preference to `TOTAL_WALLET_ID`.

It goes in the provider rather than in the screen that triggers the delete, because that is the one point every wallet delete passes through. Only the manage wallets screen deletes a wallet today, so this is placement rather than extra coverage.

`setCurrentWallet` already broadcasts the change and the fragments hosting those fourteen listen for it, so they reload without a relaunch.

## Why the total wallet rather than the first remaining one

The total wallet shows everything, so nothing is hidden while the user decides, and the drawer is where they pick a specific wallet again. Falling back to the first remaining wallet would silently scope the app to a wallet the user never chose.

## What this touches

One file, one case in `DataContentProvider.delete`. No schema change, no change to any query, no change to any screen.

## Verified

On an emulator, both ways, with the same seeded data and the same delete gesture: two wallets, one of them holding a single transaction, and the other one selected and then deleted through manage wallets.

Before: the transaction list rendered empty and the toolbar subtitle was blank, and the preference still held the deleted id after a full relaunch.

After: the preference reads `0` and the list shows the surviving wallet's transaction under a `Total` subtitle, without a relaunch. That wallet counts in the total, which is what the total branch selects on.

The control run matters here, because an empty list is also what a correctly scoped empty wallet looks like. The seeded transaction in the other wallet is what makes the two runs distinguishable.

## Two states this does not reach, neither of which it creates

If every remaining wallet is excluded from the total count, the total wallet matches nothing either, and `MainActivity.createTotalWalletAccount` returns null so the drawer stops offering it. That state is already reachable by selecting the total wallet and then turning off the count in total flag on every wallet.

Archiving the selected wallet strands the preference too, through `update` rather than `delete`, so this guard cannot reach it. The symptom differs: the rows stay, so the lists keep showing the archived wallet's items while the drawer drops its profile. Worth its own issue.
