### PR TITLE
Request POST_NOTIFICATIONS where a feature depends on a notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
@@ -44,6 +44,7 @@ public class PreferenceManager {
     private static final String FILE_NAME = "preferences";
 
     private static final String CURRENT_WALLET = "current_wallet_id";
+    private static final String ASKED_NOTIFICATION_PERMISSION = "asked_notification_permission";
     private static final String CURRENT_LOCK_MODE = "current_lock_mode";
     private static final String CURRENT_LOCK_CODE = "current_lock_code";
     private static final String LAST_LOCK_TIMESTAMP = "last_lock_timestamp";
@@ -296,6 +297,14 @@ public class PreferenceManager {
 
     public static int getCurrentDailyReminder() {
         return mPreferences.getInt(DAILY_REMINDER, DAILY_REMINDER_DISABLED);
+    }
+
+    public static boolean hasAskedNotificationPermission() {
+        return mPreferences.getBoolean(ASKED_NOTIFICATION_PERMISSION, false);
+    }
+
+    public static void setAskedNotificationPermission() {
+        mPreferences.edit().putBoolean(ASKED_NOTIFICATION_PERMISSION, true).apply();
     }
 
     public static int getCurrentExchangeRateService() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
@@ -19,11 +19,13 @@
 
 package com.oriondev.moneywallet.ui.fragment.dialog;
 
+import android.Manifest;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.appcompat.widget.SwitchCompat;
@@ -40,8 +42,10 @@ import com.oriondev.moneywallet.api.BackendServiceFactory;
 import com.oriondev.moneywallet.broadcast.AutoBackupBroadcastReceiver;
 import com.oriondev.moneywallet.model.IFile;
 import com.oriondev.moneywallet.storage.preference.BackendManager;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.activity.BackendExplorerActivity;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+import com.oriondev.moneywallet.utils.Utils;
 
 /**
  * Created by andrea on 26/11/18.
@@ -56,6 +60,8 @@ public class AutoBackupSettingDialog extends DialogFragment {
     private static final int OFFSET_MIN_HOURS = 24;
     private static final int OFFSET_MAX_HOURS = 168;
     private static final int OFFSET_BETWEEN_HOURS = 4;
+
+    private static final int REQUEST_CODE_NOTIFICATION_PERMISSION = 35626;
 
     private String mBackendId;
 
@@ -184,6 +190,18 @@ public class AutoBackupSettingDialog extends DialogFragment {
         BackendManager.setAutoBackupFolder(mBackendId, mFolder != null ? mFolder.encodeToString() : null);
         BackendManager.setAutoBackupPassword(mBackendId, mPasswordEditText.getText().toString());
         AutoBackupBroadcastReceiver.scheduleAutoBackupTask(getActivity());
+        Activity activity = getActivity();
+        if (mServiceEnabledSwitchCompat.isChecked() && activity != null
+                && Utils.shouldAskNotificationPermission(activity)) {
+            // routed through the activity rather than a launcher on this fragment. this click
+            // dismisses the dialog on its way out, so a launcher owned by it is unregistered
+            // before the user can answer and the result would go nowhere. the result is
+            // discarded either way here, and the ask is recorded before it is made.
+            PreferenceManager.setAskedNotificationPermission();
+            ActivityCompat.requestPermissions(activity,
+                    new String[]{Manifest.permission.POST_NOTIFICATIONS},
+                    REQUEST_CODE_NOTIFICATION_PERMISSION);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UtilitySettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UtilitySettingFragment.java
@@ -19,6 +19,7 @@
 
 package com.oriondev.moneywallet.ui.fragment.secondary;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -26,6 +27,8 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 import android.text.format.DateUtils;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -51,6 +54,7 @@ import com.oriondev.moneywallet.ui.preference.ThemedInputPreference;
 import com.oriondev.moneywallet.ui.preference.ThemedListPreference;
 import com.oriondev.moneywallet.utils.DateFormatter;
 import com.oriondev.moneywallet.utils.Urls;
+import com.oriondev.moneywallet.utils.Utils;
 import com.oriondev.moneywallet.view.MapViewWrapper;
 
 import java.text.DateFormat;
@@ -67,6 +71,15 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
     private static final int REQUEST_CODE_LOCK_ACTIVITY = 8239;
 
     private static final int HOURS_IN_DAY = 24;
+
+    /**
+     * A fragment has to register before it is created, so this cannot move to the point of use.
+     */
+    private final ActivityResultLauncher<String> mNotificationPermissionLauncher =
+            registerForActivityResult(new ActivityResultContracts.RequestPermission(), granted -> {
+                // nothing to do either way. the reminder is scheduled on a denial too, its
+                // alarm just fires into nothing, and the ask is already recorded as spent.
+            });
 
     private ThemedListPreference mDailyReminderPreference;
     private ThemedListPreference mSecurityModeListPreference;
@@ -170,6 +183,9 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
                 int hour = Integer.parseInt((String) newValue);
                 PreferenceManager.setCurrentDailyReminder(getActivity(), hour);
                 setupCurrentDailyReminder();
+                if (hour != PreferenceManager.DAILY_REMINDER_DISABLED) {
+                    requestNotificationPermission();
+                }
                 return false;
             }
 
@@ -356,6 +372,14 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
 
     private static String formatHourOfDay(DateFormat format, int hour) {
         return format.format(new Date(hour * DateUtils.HOUR_IN_MILLIS));
+    }
+
+    private void requestNotificationPermission() {
+        Activity activity = getActivity();
+        if (activity != null && Utils.shouldAskNotificationPermission(activity)) {
+            PreferenceManager.setAskedNotificationPermission();
+            mNotificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
+        }
     }
 
     private void setupCurrentDailyReminder() {

--- a/app/src/main/java/com/oriondev/moneywallet/utils/Utils.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/Utils.java
@@ -19,18 +19,23 @@
 
 package com.oriondev.moneywallet.utils;
 
+import android.Manifest;
 import android.app.Activity;
+import android.content.Context;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import androidx.annotation.IdRes;
+import androidx.core.content.ContextCompat;
 import android.view.View;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.IFile;
 import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.storage.database.backup.BackupManager;
 
 import java.text.DecimalFormat;
@@ -87,6 +92,22 @@ public class Utils {
 
     public static boolean isAtLeastLollipop() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP;
+    }
+
+    /**
+     * From Android 13 POST_NOTIFICATIONS is a runtime permission, and an app targeting 33 or
+     * later gets no prompt from the system, so anything that speaks through a notification has
+     * to ask for itself.
+     *
+     * <p>At most once per install. Android treats a second refusal as permanent, and the caller
+     * cannot tell a never asked state from an exhausted one, so the count is kept here instead.
+     * Callers record the ask with {@link PreferenceManager#setAskedNotificationPermission()}.
+     */
+    public static boolean shouldAskNotificationPermission(Context context) {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+                && !PreferenceManager.hasAskedNotificationPermission()
+                && ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS)
+                        != PackageManager.PERMISSION_GRANTED;
     }
 
     public static void setBackgroundCompat(View view, Drawable drawable) {


### PR DESCRIPTION
Fixes #90.

The app posts notifications and never asked for `POST_NOTIFICATIONS`, while targeting SDK 35. From Android 13 that permission is runtime, and on a fresh install it starts denied with no prompt from the system, so every notification the app posted was dropped.

## What posts notifications

Three producers, and they are not the same shape.

- `DailyBroadcastReceiver` posts the daily reminder. The notification is the whole feature.
- `TaskReporter.showNotification` posts exactly two, both errors: a failed backup and a failed exchange rate download.
- Everything else reaches the shade through `startForeground`, which is the quiet case, because it needs no runtime permission. The service runs normally and shows nothing, so a run looks entirely successful in logs.

Import, export, attachments and the backend service post nothing and only broadcast.

## The change

The manifest declares the permission, and it is asked for at the two points the user turns on something that speaks through a notification: setting the daily reminder, and enabling automatic backup.

**At most one ask per install**, tracked in a preference. Android treats a second refusal as permanent, and an app cannot tell a never asked state from an exhausted one, so the count has to be kept locally.

The first shape I tried was an off to on edge instead, and it was wrong in a way worth recording: anyone who already had either feature on would never have been asked at all, which is a worse hole than the one being closed. A preference does not care which edge a user arrives on.

A cold prompt at first launch was considered and rejected. It carries no context, and a refusal there costs every notification rather than one.

## Two mechanisms, and why they differ

The reminder uses the `ActivityResultContracts.RequestPermission` contract, as `DiskBackendService` already does, registered as a field because a fragment has to register before it is created.

The auto backup dialog calls `ActivityCompat.requestPermissions` on the host activity instead. That ok press dismisses the dialog on its way out, so a launcher owned by it is unregistered before the user can answer and the result would be delivered nowhere. Neither call site uses the result.

## What this touches

Five files. One manifest line, one preference pair, one helper, and one call site in each of the two settings surfaces. No change to any notification, channel or service.

## Verified

On an Android 16 emulator, one build throughout so only the state differs.

While denied, the exchange rate download ran and logged its foreground service start, and its error notification did not appear. Granting and repeating the identical tap put that same error in the shade. That path is a premise of the bug rather than part of this change.

The gate itself was checked in all four cases:

| State | Action | Prompt |
|---|---|---|
| reminder already on, ask unspent | change the hour | yes |
| ask spent | change the hour | no |
| ask spent | enable auto backup | no |
| wiped data, ask unspent | enable auto backup | yes |

The first row is the one that matters, because it is exactly what the rejected edge design would have refused to do. Denial leaves the reminder written and auto backup enabled, read back from both preference files, and no run crashed.

## Two things this does not do

The exchange rate download meets the same test, since a failure has no other surface: the success broadcast sits inside the `try`. It is a repeatable action rather than a switch, so it needs its own rule about when asking is worth it. That belongs in its own change.

Answering either prompt takes longer than the one second lock timeout in `BaseActivity`, so an install with access protection on returns to the lock screen afterwards. That is the existing lock behaviour meeting a new prompt, not something introduced here.

Denial is otherwise left as the answer. Saying so on screen needs a new string across nineteen translations, which belongs with a wider look at how the app reports a blocked notification.
