### PR TITLE
Draw the pie chart percentage labels at the size the font setting asks

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/chart/PieChart.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/chart/PieChart.java
@@ -25,12 +25,14 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.annotation.RequiresApi;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.View;
 
 import com.oriondev.moneywallet.R;
@@ -50,6 +52,7 @@ public class PieChart extends View {
     private final static int DEFAULT_HOLE_COLOR = Color.WHITE;
     private final static int DEFAULT_LINE_COLOR = Color.GRAY;
     private final static float DEFAULT_LINE_SIZE = 3f;
+    private final static float PERCENTAGE_TEXT_SIZE_SP = 12f;
 
     // current data
     private int[] mColors = new int[] {
@@ -75,6 +78,7 @@ public class PieChart extends View {
     private RectF mRectangle;
     private Paint mSlicePaint;
     private Paint mLinePaint;
+    private final Rect mTextBounds = new Rect();
 
     private boolean mIsRunning;
     private PieData mPieData;
@@ -304,9 +308,9 @@ public class PieChart extends View {
         float iconDistance = maxRadius * 0.8f;
         float iconRadius = maxRadius * 0.1f;
         float textDistance = maxRadius * 0.95f;
-        float textSize = 30;
         mLinePaint.setColor(mLineColor);
-        mLinePaint.setTextSize(textSize);
+        mLinePaint.setTextSize(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP,
+                PERCENTAGE_TEXT_SIZE_SP, getResources().getDisplayMetrics()));
         // set padding
         mRectangle.set(centerX - chartRadius, centerY - chartRadius, centerX + chartRadius, centerY + chartRadius);
         // calculating initial angle
@@ -339,11 +343,22 @@ public class PieChart extends View {
             }
             // draw percentage
             if (mPercentageEnabled) {
-                // calculate center text coordinates
+                String label = Math.round(sweepAngle * 100 / 360f) + "%";
+                mLinePaint.getTextBounds(label, 0, label.length(), mTextBounds);
+                // half the advance, which is what a centered alignment lays the string out around
+                float halfAdvance = mLinePaint.measureText(label) / 2;
+                // calculate center text coordinates, putting the middle of the glyphs on the point.
+                // The old offset put the baseline half a text size below it, more than half the
+                // height of these glyphs, so the label sat low
                 float textX = ((float) (Math.cos(Math.toRadians(iconAngle)) * textDistance)) + centerX;
-                float textY = ((float) (Math.sin(Math.toRadians(iconAngle)) * textDistance)) + centerY + (textSize / 2);
-                int percentage = Math.round(sweepAngle * 100 / 360f);
-                c.drawText(String.valueOf(percentage) + "%", textX, textY, mLinePaint);
+                float textY = ((float) (Math.sin(Math.toRadians(iconAngle)) * textDistance)) + centerY - ((mTextBounds.top + mTextBounds.bottom) / 2f);
+                // a percentage cut off by the edge of the view reads as a different number rather
+                // than as a clipped label, so one that would cross an edge is moved in instead, at
+                // the cost of sitting nearer its icon. A label wider than the view cannot be saved
+                // this way and is still cut, from the trailing end
+                textX = Math.max(Math.min(textX, measuredWidth - halfAdvance), halfAdvance);
+                textY = Math.max(Math.min(textY, measuredHeight - mTextBounds.bottom), -mTextBounds.top);
+                c.drawText(label, textX, textY, mLinePaint);
             }
         }
         // draw hole if required


### PR DESCRIPTION
The percentage drawn beside each category icon on the period detail chart is drawn at a raw pixel size, and it sits below the point it labels. Both lines date from the file's first commit in 2018. The labels are off by default and the single layout that hosts this view switches them on, which happened first in v1.2.0, so that is the first release to draw them at all.

## The mechanism

`PieChart.onDraw` set `float textSize = 30` and passed it straight to `Paint.setTextSize`, which takes pixels. A pixel value ignores the accessibility font setting, so at font scale 2.0 the tabs, the totals and the category rows on that same screen all grow while the percentages stay exactly where they were.

The vertical position was `centerY + (textSize / 2)`, which puts the baseline half a text size below the point the label belongs to. That is more than half the height of these glyphs, since digits carry no ink under the baseline, so the middle of every label sat about a seventh of a text size low.

## The change

The size comes from a 12sp constant through `TypedValue.applyDimension`, so it follows the setting. The vertical position comes from the ink the font reports for that label through `Paint.getTextBounds`, so the middle of the glyphs lands on the point rather than a fraction of the size below it.

A label that would cross an edge of the view is moved in rather than cut. A percentage cut off by an edge does not read as a clipped label, it reads as a different number: in a 320dp wide window a single expense category puts `100%` against the left edge, where cutting it leaves `00%`. A label wider than the whole view cannot be saved this way and is still cut, from the trailing end.

Horizontal placement is bounded by the advance width, which is what a centered alignment lays a string out around, while only the vertical uses the ink box.

## What this touches

One file, and one method inside it: `PieChart.onDraw`. One view, hosted by one layout. Nothing changes about the slices, the icons, the connector lines or the chart geometry.

## Tested

On an emulator at API 36 and density 420, against a build of the parent commit on the same device with the same data, in four configurations, comparing the pixels the labels cover.

At 1080 by 2400 and font scale 1.0 the labels are 5 percent wider and taller, since 12sp is 31.5px there against 30, and their top edge sits about 5px higher. At font scale 2.0 the parent draws them at the same size it draws them at 1.0, while this build draws them larger. In a 320dp wide window the parent cuts the leftmost label against the edge, both with six categories arranged so that an icon lands near 180 degrees and with a single category where the label is `100%`; this build draws both whole.

## What this does not address

A moved label sits nearer its category icon. Labels moved against the same edge come to rest against it together and can stack. Nothing checks labels against each other, so two labels can overlap.

The pager that holds the chart is a fixed dp tall, at a dimension shared with a screen that does not contain this view.

At font scale 1.0, a density below 2.5 puts 12sp under the old 30px, and the labels there become smaller than they were. Not tested on such a device.
