### PR TITLE
Run the auto backup from the job scheduler instead of a foreground service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -129,6 +129,10 @@
             android:foregroundServiceType="dataSync" />
         <service android:name=".service.BackendHandlerIntentService" />
         <service
+            android:name=".service.AutoBackupJobService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false" />
+        <service
             android:name=".service.RecurrenceHandlerIntentService"
             android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />
@@ -137,7 +141,6 @@
 
         <receiver android:name=".broadcast.DailyBroadcastReceiver" />
         <receiver android:name=".broadcast.RecurrenceBroadcastReceiver" />
-        <receiver android:name=".broadcast.AutoBackupBroadcastReceiver" />
         <receiver android:name=".broadcast.NotificationBroadcastReceiver" />
         <receiver android:name=".broadcast.BootBroadcastReceiver"
             android:exported="true">

--- a/app/src/main/java/com/oriondev/moneywallet/App.java
+++ b/app/src/main/java/com/oriondev/moneywallet/App.java
@@ -82,7 +82,7 @@ public class App extends Application {
         // canceled by the OS. This is the best place where all those things can be scheduled again.
         DailyBroadcastReceiver.scheduleDailyNotification(this);
         RecurrenceBroadcastReceiver.scheduleRecurrenceTask(this);
-        AutoBackupBroadcastReceiver.scheduleAutoBackupTask(this);
+        AutoBackupBroadcastReceiver.ensureAutoBackupTaskScheduled(this);
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/broadcast/AutoBackupBroadcastReceiver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/broadcast/AutoBackupBroadcastReceiver.java
@@ -19,130 +19,103 @@
 
 package com.oriondev.moneywallet.broadcast;
 
-import android.app.AlarmManager;
-import android.app.PendingIntent;
-import android.app.Service;
-import android.content.BroadcastReceiver;
+import android.app.job.JobInfo;
+import android.app.job.JobScheduler;
+import android.content.ComponentName;
 import android.content.Context;
-import android.content.Intent;
 import android.util.Log;
 
-import com.oriondev.moneywallet.api.BackendServiceFactory;
-import com.oriondev.moneywallet.model.IFile;
-import com.oriondev.moneywallet.service.BackupHandlerIntentService;
+import com.oriondev.moneywallet.service.AutoBackupJobService;
 import com.oriondev.moneywallet.storage.preference.BackendManager;
-import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 
+import java.util.ArrayList;
 import java.util.Set;
 
 /**
  * Created by andrea on 27/11/18.
+ *
+ * No longer a broadcast receiver: the alarm it used to answer is gone, and an alarm queued by
+ * an older build does not survive the update that removes it. The name is kept so that the
+ * change moving the auto backup to the scheduler does not also touch every caller.
  */
-public class AutoBackupBroadcastReceiver extends BroadcastReceiver {
+public class AutoBackupBroadcastReceiver {
 
     private static final int MILLIS_IN_HOUR = 1000 * 60 * 60;
+    private static final int JOB_ID = 3565;
+    private static final long MINIMUM_LATENCY_MILLIS = 60 * 1000;
     private static final String TAG = "AutoBackup";
 
+    /**
+     * Queue the next auto backup sweep with the job scheduler. This never runs the sweep
+     * inline: an overdue occurrence is queued at the minimum latency like any other. Running
+     * it inline is what made this method and the sweep call each other, so a backend that
+     * failed without moving its timestamp forward recursed until the process was killed.
+     */
     public static void scheduleAutoBackupTask(Context context) {
-        cancelPendingIntent(context);
+        scheduleAutoBackupTask(context, true);
+    }
+
+    /**
+     * For callers that only want a job to exist, not to move one that already does.
+     *
+     * Scheduling an id that is already queued cancels it, and the framework documents that as
+     * one of the ways a job is cancelled by its own app. When the scheduler starts the process
+     * to run the sweep, Application.onCreate runs first, so an unconditional call there kills
+     * the sweep before onStartJob is ever reached.
+     */
+    public static void ensureAutoBackupTaskScheduled(Context context) {
+        scheduleAutoBackupTask(context, false);
+    }
+
+    private static void scheduleAutoBackupTask(Context context, boolean replaceExisting) {
+        JobScheduler jobScheduler = (JobScheduler) context.getSystemService(Context.JOB_SCHEDULER_SERVICE);
+        if (jobScheduler == null) {
+            return;
+        }
         Set<String> backendIdSet = BackendManager.getAutoBackupEnabledServices();
-        if (backendIdSet != null && !backendIdSet.isEmpty()) {
-            Long nextTimestamp = null;
-            for (String backendId : backendIdSet) {
-                long lastTimestamp = BackendManager.getAutoBackupLastTime(backendId);
-                int hourOffset = BackendManager.getAutoBackupHoursOffset(backendId);
-                long nextOccurrence = lastTimestamp + (hourOffset * MILLIS_IN_HOUR);
-                if (nextTimestamp == null || nextOccurrence < nextTimestamp) {
-                    nextTimestamp = nextOccurrence;
-                }
-            }
-            if (nextTimestamp != null) {
-                if (nextTimestamp <= System.currentTimeMillis()) {
-                    startBackgroundTask(context);
-                } else {
-                    schedulePendingIntent(context, nextTimestamp);
-                }
-            }
+        if (backendIdSet == null || backendIdSet.isEmpty()) {
+            // Nothing enabled, so drop any job left over from when something was.
+            jobScheduler.cancel(JOB_ID);
+            return;
         }
-    }
-
-    private static void schedulePendingIntent(Context context, long timestamp) {
-        PendingIntent pendingIntent = createPendingIntent(context);
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Service.ALARM_SERVICE);
-        if (alarmManager != null) {
-            alarmManager.set(AlarmManager.RTC_WAKEUP, timestamp, pendingIntent);
-            System.out.println("[ALARM] AutoBackupTask scheduled at: " + timestamp);
+        if (!replaceExisting && jobScheduler.getPendingJob(JOB_ID) != null) {
+            return;
         }
-    }
-
-    private static void cancelPendingIntent(Context context) {
-        PendingIntent pendingIntent = createPendingIntent(context);
-        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Service.ALARM_SERVICE);
-        if (alarmManager != null) {
-            alarmManager.cancel(pendingIntent);
-        }
-    }
-
-    private static PendingIntent createPendingIntent(Context context) {
-        Intent intent = new Intent(context, AutoBackupBroadcastReceiver.class);
-        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
-    }
-
-    @Override
-    public void onReceive(Context context, Intent intent) {
-        startBackgroundTask(context);
-    }
-
-    private static void startBackgroundTask(Context context) {
-        System.out.println("[ALARM] AutoBackupTask fired now");
-        Set<String> backendIdSet = BackendManager.getAutoBackupEnabledServices();
-        if (backendIdSet != null && !backendIdSet.isEmpty()) {
-            for (String backendId : backendIdSet) {
-                try {
-                    long lastTimestamp = BackendManager.getAutoBackupLastTime(backendId);
-                    int hourOffset = BackendManager.getAutoBackupHoursOffset(backendId);
-                    long nextOccurrence = lastTimestamp + (hourOffset * MILLIS_IN_HOUR);
-                    if (nextOccurrence <= System.currentTimeMillis()) {
-                        if (!BackendManager.isAutoBackupWhenDataIsChangedOnly(backendId) || PreferenceManager.getLastTimeDataIsChanged() > lastTimestamp) {
-                            boolean onlyOnWiFi = BackendManager.isAutoBackupOnWiFiOnly(backendId);
-                            IFile folder = BackendServiceFactory.getFile(backendId, BackendManager.getAutoBackupFolder(backendId));
-                            if (folder == null) {
-                                // Legacy or undecodable backup location (issue #177): skip this
-                                // backend's auto-backup instead of crashing at startup. The backend
-                                // stays configured; the user can re-select the folder. Do not advance
-                                // the timer for a backup that did not run.
-                                Log.w(TAG, "Skipping auto-backup for '" + backendId + "': backup location missing or not decodable");
-                                continue;
-                            }
-                            String password = BackendManager.getAutoBackupPassword(backendId);
-                            // build the intent to start the service
-                            Intent intent = new Intent(context, BackupHandlerIntentService.class);
-                            intent.putExtra(BackupHandlerIntentService.ACTION, BackupHandlerIntentService.ACTION_BACKUP);
-                            intent.putExtra(BackupHandlerIntentService.BACKEND_ID, backendId);
-                            intent.putExtra(BackupHandlerIntentService.AUTO_BACKUP, true);
-                            intent.putExtra(BackupHandlerIntentService.ONLY_ON_WIFI, onlyOnWiFi);
-                            intent.putExtra(BackupHandlerIntentService.PARENT_FOLDER, folder);
-                            intent.putExtra(BackupHandlerIntentService.PASSWORD, password);
-                            BackupHandlerIntentService.startInForeground(context, intent);
-                        }
-                        // register the next occurrence as the last time the auto backup
-                        // for this specific backend has been executed: if an error occur
-                        // and the backup process is interrupted, the error is shown in
-                        // a specific notification (no auto rescheduling because we don't
-                        // know if the error is a recoverable error or a critical one)
-                        BackendManager.setAutoBackupLastTime(backendId, nextOccurrence);
-                    }
-                } catch (Exception e) {
-                    // Never let a single misconfigured backend crash app startup (issue #177).
-                    Log.w(TAG, "Skipping auto-backup for '" + backendId + "': " + e.getMessage());
-                }
+        Long nextTimestamp = null;
+        // Copy first: getStringSet hands back its own live instance, and disabling a backend
+        // elsewhere in the app removes an element from it while this loop is walking it.
+        for (String backendId : new ArrayList<>(backendIdSet)) {
+            long lastTimestamp = BackendManager.getAutoBackupLastTime(backendId);
+            long nextOccurrence = lastTimestamp + intervalMillis(backendId);
+            if (nextTimestamp == null || nextOccurrence < nextTimestamp) {
+                nextTimestamp = nextOccurrence;
             }
         }
-        // reschedule the auto backup immediately (if one or more intent services are fired, they
-        // are executed in a serial way but the last time is already updated). in this way we can
-        // calculate the next occurrence without waiting that all the intent services are executed.
-        // if an exception occur inside one intent service and a backend should be disabled, it
-        // will handle it automatically without the need to wait here for a response.
-        AutoBackupBroadcastReceiver.scheduleAutoBackupTask(context);
+        long latency = Math.max(nextTimestamp - System.currentTimeMillis(), MINIMUM_LATENCY_MILLIS);
+        ComponentName service = new ComponentName(context, AutoBackupJobService.class);
+        // No network constraint. WiFi only is a per backend setting and this is one job for
+        // every enabled backend, so a job level constraint could only ever apply when they all
+        // agree. None of the network types available at this minSdk names a transport, and the
+        // nearest one, unmetered, is not WiFi in either direction: a metered WiFi would hold the
+        // job for ever for a backend the sweep would have run, and an unmetered mobile network
+        // would release it into a skip. A real WiFi requirement needs setRequiredNetwork, which
+        // is API 28. The sweep reads the transport itself instead, which covers a mix of
+        // backends as well.
+        JobInfo jobInfo = new JobInfo.Builder(JOB_ID, service)
+                .setMinimumLatency(latency)
+                .setPersisted(true)
+                .build();
+        jobScheduler.schedule(jobInfo);
+        Log.d(TAG, "Auto backup sweep queued in " + latency + " ms");
     }
+
+    /**
+     * The configured interval, never less than an hour. The settings screen offers 24 to 168,
+     * but a zero or negative value read from anywhere else would make every occurrence due
+     * for ever, and the walk to the most recent passed occurrence would never terminate.
+     */
+    public static long intervalMillis(String backendId) {
+        return Math.max((long) BackendManager.getAutoBackupHoursOffset(backendId), 1L) * MILLIS_IN_HOUR;
+    }
+
 }

--- a/app/src/main/java/com/oriondev/moneywallet/broadcast/BootBroadcastReceiver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/broadcast/BootBroadcastReceiver.java
@@ -35,7 +35,7 @@ public class BootBroadcastReceiver extends BroadcastReceiver {
         if (ACTION_BOOT_COMPLETED.equals(intent.getAction())) {
             DailyBroadcastReceiver.scheduleDailyNotification(context);
             RecurrenceBroadcastReceiver.scheduleRecurrenceTask(context);
-            AutoBackupBroadcastReceiver.scheduleAutoBackupTask(context);
+            AutoBackupBroadcastReceiver.ensureAutoBackupTaskScheduled(context);
         }
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/service/AutoBackupJobService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/AutoBackupJobService.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.service;
+
+import android.app.job.JobParameters;
+import android.app.job.JobService;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
+import android.util.Log;
+
+import androidx.core.app.NotificationCompat;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.api.BackendException;
+import com.oriondev.moneywallet.api.BackendServiceFactory;
+import com.oriondev.moneywallet.api.IBackendServiceAPI;
+import com.oriondev.moneywallet.broadcast.AutoBackupBroadcastReceiver;
+import com.oriondev.moneywallet.model.IFile;
+import com.oriondev.moneywallet.storage.preference.BackendManager;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.ui.notification.NotificationContract;
+
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Runs the auto backup from the job scheduler.
+ *
+ * The backup used to run in {@link BackupHandlerIntentService}, started inline. The alarm ran it
+ * straight from onReceive; everyone else reached it through the scheduling method, which ran the
+ * sweep itself whenever the occurrence was already past. That method was called from
+ * Application.onCreate, the boot receiver, the settings dialog, the backup service at two points,
+ * and the sweep's own tail call, which is the one that closed the loop. When such a caller runs
+ * with the app in the background, which is the case this feature is for
+ * even though it is not the only one, a recent Android refuses the foreground service start,
+ * and refuses a plain service start too. Tested on API 36; the background restriction on a
+ * plain start arrived at 26 and the one on a foreground start at 31, so the oldest devices this
+ * app supports were never affected. The scheduler is the platform's own answer for deferrable
+ * work, so the
+ * sweep runs here, on a thread this class starts, and calls the backup directly.
+ */
+public class AutoBackupJobService extends JobService {
+
+    private static final String TAG = "AutoBackup";
+
+    private static final AtomicBoolean sSweepInProgress = new AtomicBoolean(false);
+
+    @Override
+    public boolean onStartJob(final JobParameters params) {
+        final Context context = getApplicationContext();
+        if (!sSweepInProgress.compareAndSet(false, true)) {
+            // A sweep started by an earlier run of this job is still going. onStopJob asks
+            // for the job back, and nothing interrupts the thread, so the two would otherwise
+            // overlap: both read the stored timestamp before either advances it, and the same
+            // occurrence is exported and uploaded twice.
+            Log.d(TAG, "Auto backup sweep already in progress, skipping this run");
+            return false;
+        }
+        new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    runSweep(context);
+                } catch (Throwable throwable) {
+                    // This thread belongs to the process, not to the job. An escape here would
+                    // take the whole app down, which is the failure this class exists to remove.
+                    Log.e(TAG, "Auto backup sweep failed", throwable);
+                } finally {
+                    sSweepInProgress.set(false);
+                    jobFinished(params, false);
+                }
+            }
+
+        }, "auto-backup-sweep").start();
+        // the sweep continues on its own thread after this returns
+        return true;
+    }
+
+    @Override
+    public boolean onStopJob(JobParameters params) {
+        // Ask for this job back. The sweep queues the next occurrence itself, and being
+        // stopped is the case where it may not get that far. The other callers would
+        // eventually queue one, but they all need the app opened or the device rebooted,
+        // which is not something a background backup should wait on.
+        return true;
+    }
+
+    /**
+     * Back up every enabled backend whose next occurrence has passed, then queue the next run.
+     * Runs on the calling thread.
+     */
+    public static void runSweep(Context context) {
+        Log.d(TAG, "Auto backup sweep running");
+        try {
+            Set<String> backendIdSet = BackendManager.getAutoBackupEnabledServices();
+            if (backendIdSet != null && !backendIdSet.isEmpty()) {
+                // Copy before iterating. SharedPreferences.getStringSet hands back its own
+                // live instance, and a backend that fails unrecoverably is disabled, which
+                // removes an element from that very set.
+                for (String backendId : new ArrayList<>(backendIdSet)) {
+                    runBackendIfDue(context, backendId);
+                }
+            }
+        } finally {
+            // Queue the next occurrence whatever the loop did. The other callers all need the
+            // app opened or the device rebooted, so a throw from the loop skipping this line is
+            // how the backup stops running unattended. The job that ran this sweep is spent.
+            //
+            // Not a guarantee, and the gap is the same one runBackendIfDue guards: scheduling
+            // reads the stored timestamp and the interval itself, so a preference of the wrong
+            // type takes this line down too, and the catch below only keeps it from taking the
+            // thread with it. Nothing is queued in that case.
+            try {
+                AutoBackupBroadcastReceiver.scheduleAutoBackupTask(context);
+            } catch (Exception e) {
+                Log.e(TAG, "Could not queue the next auto backup", e);
+            }
+        }
+    }
+
+    private static void runBackendIfDue(Context context, String backendId) {
+        long lastTimestamp;
+        long interval;
+        long nextOccurrence;
+        try {
+            lastTimestamp = BackendManager.getAutoBackupLastTime(backendId);
+            interval = AutoBackupBroadcastReceiver.intervalMillis(backendId);
+            nextOccurrence = lastTimestamp + interval;
+        } catch (Exception e) {
+            // Reading a preference of the wrong type throws. Keep it to this backend rather
+            // than losing the rest of the sweep with it (issue #177).
+            Log.w(TAG, "Auto backup settings unreadable for '" + backendId + "': " + e.getMessage());
+            return;
+        }
+        if (nextOccurrence > System.currentTimeMillis()) {
+            return;
+        }
+        try {
+            if (!BackendManager.isAutoBackupWhenDataIsChangedOnly(backendId) || PreferenceManager.getLastTimeDataIsChanged() > lastTimestamp) {
+                runBackend(context, backendId);
+            }
+        } catch (Exception e) {
+            // Never let a single misconfigured backend take the sweep down (issue #177).
+            Log.w(TAG, "Auto backup failed for '" + backendId + "': " + e.getMessage());
+            notifyFailure(context, e);
+        } finally {
+            if (BackendManager.isAutoBackupEnabled(backendId)) {
+                // Consume the occurrence whatever the outcome, and skip straight to the most
+                // recent one. Leaving the timestamp behind queues the job again at the
+                // minimum latency, so a failing backend would repeat every minute. Advancing
+                // by a single interval instead would make a fortnight away one run per missed
+                // day. A failure is reported in its own notification.
+                //
+                // Not written back for a backend that the failure above just disabled: that
+                // clears its stored timestamp, and putting one back makes the backup fire
+                // immediately if the user ever switches the backend on again.
+                BackendManager.setAutoBackupLastTime(backendId, latestPassedOccurrence(nextOccurrence, interval));
+            }
+        }
+    }
+
+    /**
+     * The most recent occurrence at or before now, so one missed run is performed rather than
+     * one for every occurrence a device slept through.
+     */
+    private static long latestPassedOccurrence(long occurrence, long interval) {
+        long now = System.currentTimeMillis();
+        while (occurrence + interval <= now) {
+            occurrence += interval;
+        }
+        return occurrence;
+    }
+
+    private static void runBackend(Context context, String backendId) throws Exception {
+        IFile folder = BackendServiceFactory.getFile(backendId, BackendManager.getAutoBackupFolder(backendId));
+        if (folder == null) {
+            // Legacy or undecodable backup location (issue #177): skip this backend instead of
+            // failing the sweep. The backend stays configured; the folder can be chosen again.
+            // The occurrence is consumed either way, so tell the user rather than leaving a
+            // backup that never runs to be discovered when it is needed.
+            Log.w(TAG, "Skipping auto backup for '" + backendId + "': backup location missing or not decodable");
+            notifyMessage(context, context.getString(R.string.notification_content_backup_error_location));
+            return;
+        }
+        if (BackendManager.isAutoBackupOnWiFiOnly(backendId) && !isConnectedToWiFi(context)) {
+            // Same reasoning as the location above: the occurrence is spent, so say so.
+            Log.w(TAG, "Skipping auto backup for '" + backendId + "': not on a WiFi network");
+            notifyMessage(context, context.getString(R.string.notification_content_backup_error_wifi_network));
+            return;
+        }
+        IBackendServiceAPI backendServiceAPI = BackendServiceFactory.getServiceAPIById(context, backendId);
+        try {
+            BackupOperation.createAndUpload(context, backendServiceAPI, folder, BackendManager.getAutoBackupPassword(backendId), null);
+        } catch (BackendException e) {
+            if (!e.isRecoverable()) {
+                BackendManager.setAutoBackupEnabled(backendId, false);
+            }
+            throw e;
+        }
+    }
+
+    private static boolean isConnectedToWiFi(Context context) {
+        ConnectivityManager connectivityManager = (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
+        if (connectivityManager == null) {
+            return false;
+        }
+        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
+        return networkInfo != null && networkInfo.isConnected();
+    }
+
+    /**
+     * Report a failure in the wording the auto backup's own notification carried before it
+     * moved off the service, so an expired token or an unreachable server is not described to
+     * the user as a bug in the app. The user started backup does not share it: that reports
+     * through a dialog carrying the raw exception, and always did.
+     */
+    private static void notifyFailure(Context context, Exception exception) {
+        if (exception instanceof BackendException) {
+            boolean recoverable = ((BackendException) exception).isRecoverable();
+            notifyMessage(context, context.getString(recoverable
+                    ? R.string.notification_content_backup_error_backend_recoverable
+                    : R.string.notification_content_backup_error_backend));
+            return;
+        }
+        notifyMessage(context, context.getString(R.string.notification_content_backup_error_internal, exception.getMessage()));
+    }
+
+    private static void notifyMessage(Context context, String message) {
+        TaskReporter reporter = new TaskReporter(context);
+        NotificationCompat.Builder builder = reporter.newNotification(NotificationContract.NOTIFICATION_CHANNEL_ERROR)
+                .setContentTitle(context.getString(R.string.notification_title_backup_creation_failed))
+                .setCategory(NotificationCompat.CATEGORY_ERROR)
+                .setContentText(message)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(message));
+        reporter.showNotification(NotificationContract.NOTIFICATION_ID_BACKUP_ERROR, builder);
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
@@ -23,14 +23,11 @@ import android.app.IntentService;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.net.ConnectivityManager;
-import android.net.NetworkInfo;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
-import android.text.TextUtils;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.BackendException;
@@ -45,18 +42,14 @@ import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.database.ExportException;
 import com.oriondev.moneywallet.storage.database.ImportException;
 import com.oriondev.moneywallet.storage.database.SQLDatabaseImporter;
-import com.oriondev.moneywallet.storage.database.backup.AbstractBackupExporter;
 import com.oriondev.moneywallet.storage.database.backup.AbstractBackupImporter;
 import com.oriondev.moneywallet.storage.database.backup.BackupManager;
-import com.oriondev.moneywallet.storage.database.backup.DefaultBackupExporter;
 import com.oriondev.moneywallet.storage.database.backup.DefaultBackupImporter;
 import com.oriondev.moneywallet.storage.database.backup.LegacyBackupImporter;
 import com.oriondev.moneywallet.storage.preference.BackendManager;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.notification.NotificationContract;
 import com.oriondev.moneywallet.utils.CurrencyManager;
-import com.oriondev.moneywallet.utils.DateUtils;
-import com.oriondev.moneywallet.utils.ProgressInputStream;
 import com.oriondev.moneywallet.utils.ProgressOutputStream;
 import com.oriondev.moneywallet.utils.Utils;
 
@@ -64,9 +57,7 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.UUID;
 
 /**
@@ -88,11 +79,8 @@ public class BackupHandlerIntentService extends IntentService {
     public static final String PROGRESS_VALUE = "BackupHandlerIntentService::Argument::ProgressValue";
     public static final String CALLER_ID = "BackupHandlerIntentService::Argument::CallerId";
 
-    private static final String ATTACHMENT_FOLDER = "attachments";
     private static final String BACKUP_CACHE_FOLDER = "backups";
     private static final String TEMP_FOLDER = "temp";
-    private static final String FILE_DATETIME_PATTERN = "yyyy-MM-dd_HH-mm-ss";
-    private static final String OUTPUT_FILE = "backup_%s%s";
 
     private static final int ACTION_NONE = 0;
     public static final int ACTION_LIST = 1;
@@ -107,8 +95,6 @@ public class BackupHandlerIntentService extends IntentService {
     private static final boolean DEFAULT_AUTO_BACKUP = false;
     private static final boolean DEFAULT_ONLY_ON_WIFI = false;
     private static final boolean DEFAULT_RUN_FOREGROUND = false;
-
-    private boolean mAutoBackup;
 
     private IBackendServiceAPI mBackendServiceAPI;
 
@@ -135,8 +121,6 @@ public class BackupHandlerIntentService extends IntentService {
             // unpack the base intent
             int action = intent.getIntExtra(ACTION, ACTION_NONE);
             String backendId = intent.getStringExtra(BACKEND_ID);
-            mAutoBackup = intent.getBooleanExtra(AUTO_BACKUP, DEFAULT_AUTO_BACKUP);
-            boolean onlyOnWiFi = intent.getBooleanExtra(ONLY_ON_WIFI, DEFAULT_ONLY_ON_WIFI);
             boolean runForeground = intent.getBooleanExtra(RUN_FOREGROUND, DEFAULT_RUN_FOREGROUND);
             mCallerId = intent.getStringExtra(CALLER_ID);
             // execute the action in a safe code-block: if an exception is thrown, it
@@ -156,18 +140,6 @@ public class BackupHandlerIntentService extends IntentService {
                 notifyTaskStarted(action);
                 // check if backend id is available and initialize it
                 mBackendServiceAPI = BackendServiceFactory.getServiceAPIById(this, backendId);
-                // the first step is to check if the task should be executed only when
-                // connected on a WiFi network: in this case we need to check if the
-                // device is connected to a WiFi network or stop the task
-                if (onlyOnWiFi && (action == ACTION_BACKUP || action == ACTION_RESTORE)) {
-                    ConnectivityManager connectivityManager = (ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE);
-                    if (connectivityManager != null) {
-                        NetworkInfo networkInfo = connectivityManager.getNetworkInfo(ConnectivityManager.TYPE_WIFI);
-                        if (!networkInfo.isConnected()) {
-                            throw new WiFiNotConnectedException();
-                        }
-                    }
-                }
                 switch (action) {
                     case ACTION_LIST:
                         onActionList(intent);
@@ -208,57 +180,16 @@ public class BackupHandlerIntentService extends IntentService {
 
     private void onActionBackup(@NonNull Intent intent) throws ExportException, BackendException, IOException {
         IFile remoteFolder = intent.getParcelableExtra(PARENT_FOLDER);
-        File folder = getExternalFilesDir(null);
-        File cache = new File(folder, BACKUP_CACHE_FOLDER);
-        File revision = new File(cache, UUID.randomUUID().toString());
-        try {
-            FileUtils.forceMkdir(revision);
-            String password = intent.getStringExtra(PASSWORD);
-            notifyTaskProgress(ACTION_BACKUP, STATUS_BACKUP_CREATION, 0);
-            File backup = prepareLocalBackupFile(revision, password);
-            notifyTaskProgress(ACTION_BACKUP, STATUS_BACKUP_UPLOADING, 30);
-            IFile uploaded = mBackendServiceAPI.uploadFile(remoteFolder, backup, new ProgressInputStream.UploadProgressListener() {
+        String password = intent.getStringExtra(PASSWORD);
+        IFile uploaded = BackupOperation.createAndUpload(this, mBackendServiceAPI, remoteFolder, password, new BackupOperation.ProgressListener() {
 
-                @Override
-                public void onUploadProgressUpdate(int percentage) {
-                    int realProgress = 30 + (percentage * 70 / 100);
-                    notifyTaskProgress(ACTION_BACKUP, STATUS_BACKUP_UPLOADING, realProgress);
-                }
+            @Override
+            public void onProgress(int status, int progress) {
+                notifyTaskProgress(ACTION_BACKUP, status, progress);
+            }
 
-            });
-            notifyTaskProgress(ACTION_BACKUP, STATUS_BACKUP_UPLOADING, 100);
-            notifyUploadTaskFinished(uploaded);
-        } finally {
-            FileUtils.deleteQuietly(revision);
-        }
-    }
-
-    /**
-     * Create a local zip file that contains the database entries according to the backup
-     * file specification. If a password is provided, set it to the zip file.
-     * @param folder where the local backup is stored.
-     * @param password if the backup should be protected.
-     * @return the backup file is success.
-     */
-    private File prepareLocalBackupFile(@NonNull File folder, @Nullable String password) throws ExportException, IOException {
-        File backupFile = createBackupFile(folder, BackupManager.getExtension(!TextUtils.isEmpty(password)));
-        AbstractBackupExporter exporter = new DefaultBackupExporter(getContentResolver(), backupFile, password);
-        exporter.exportDatabase(getFilesDir());
-        exporter.exportAttachments(getAttachmentFolder());
-        return backupFile;
-    }
-
-    private File createBackupFile(@NonNull File folder, @NonNull String extension) {
-        String datetime = DateUtils.getDateTimeString(new Date(), FILE_DATETIME_PATTERN);
-        String name = String.format(Locale.ENGLISH, OUTPUT_FILE, datetime, extension);
-        return new File(folder, name);
-    }
-
-    private File getAttachmentFolder() throws IOException {
-        File root = getExternalFilesDir(null);
-        File folder = new File(root, ATTACHMENT_FOLDER);
-        FileUtils.forceMkdir(folder);
-        return folder;
+        });
+        notifyUploadTaskFinished(uploaded);
     }
 
     private void onActionRestore(@NonNull Intent intent) throws ImportException, BackendException, IOException {
@@ -281,7 +212,12 @@ public class BackupHandlerIntentService extends IntentService {
                 });
                 notifyTaskProgress(ACTION_RESTORE, STATUS_BACKUP_RESTORING, 75);
                 String password = intent.getStringExtra(PASSWORD);
-                restoreLocalBackupFile(backup, password);
+                // The auto backup no longer runs on this service's serial queue, so a sweep
+                // can now be reading the database and the attachment folder that the import
+                // is about to replace and empty.
+                synchronized (BackupOperation.LOCK) {
+                    restoreLocalBackupFile(backup, password);
+                }
                 notifyTaskProgress(ACTION_RESTORE, STATUS_BACKUP_RESTORING, 100);
                 DataContentProvider.notifyDatabaseIsChanged(this);
                 PreferenceManager.setLastTimeDataIsChanged(0L);
@@ -310,7 +246,7 @@ public class BackupHandlerIntentService extends IntentService {
         try {
             File databaseFile = getDatabasePath(SQLDatabaseImporter.DATABASE_NAME);
             importer.importDatabase(temporaryFolder, databaseFile.getParentFile());
-            importer.importAttachments(getAttachmentFolder());
+            importer.importAttachments(BackupOperation.getAttachmentFolder(this));
         } finally {
             FileUtils.cleanDirectory(temporaryFolder);
         }
@@ -406,13 +342,11 @@ public class BackupHandlerIntentService extends IntentService {
         extras.putString(CALLER_ID, mCallerId);
         mReporter.broadcast(LocalAction.ACTION_BACKUP_SERVICE_FAILED, extras);
         // update the notification if required
-        if (mNotificationBuilder != null || mAutoBackup) {
+        if (mNotificationBuilder != null) {
             mNotificationBuilder = mReporter.newNotification(NotificationContract.NOTIFICATION_CHANNEL_ERROR)
                     .setContentTitle(getNotificationContentTitle(action, true))
                     .setCategory(NotificationCompat.CATEGORY_ERROR);
-            if (exception instanceof WiFiNotConnectedException) {
-                setupRetryNotification(baseIntent, action, R.string.notification_content_backup_error_wifi_network);
-            } else if (exception instanceof BackendException) {
+            if (exception instanceof BackendException) {
                 if (((BackendException) exception).isRecoverable()) {
                     setupRetryNotification(baseIntent, action, R.string.notification_content_backup_error_backend_recoverable);
                 } else {
@@ -432,10 +366,16 @@ public class BackupHandlerIntentService extends IntentService {
     }
 
     /**
-     * Build the error notification body for the two recoverable failures that
-     * offer a retry action. Both cases copy the same service arguments into the
-     * retry pending intent and differ only in the content text, so the copy is
-     * done once here and the text resource is passed in.
+     * Build the error notification body for a recoverable failure that offers a
+     * retry action, copying the service arguments into the retry pending intent.
+     *
+     * Nothing reaches this today. The builder it fills is created only when the
+     * service was asked to run in the foreground, and the only caller that asks
+     * is the retry action itself, so the first notification carrying that action
+     * is never built. The auto backup used to reach it and no longer uses this
+     * service. Left in place rather than deleted with the rest, because the
+     * screen that starts a backup is the thing that should decide whether a
+     * failure it is watching also deserves a notification.
      */
     private void setupRetryNotification(Intent baseIntent, int action, int contentTextRes) {
         // create a copy of the arguments used in this service
@@ -460,10 +400,4 @@ public class BackupHandlerIntentService extends IntentService {
         mNotificationBuilder.addAction(R.drawable.ic_refresh_black_24dp, getString(R.string.notification_action_retry), pendingIntent);
     }
 
-    private class WiFiNotConnectedException extends Exception {
-
-        private WiFiNotConnectedException() {
-            super("the device is not connected to a WiFi network");
-        }
-    }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/service/BackupOperation.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/BackupOperation.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.service;
+
+import android.content.Context;
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.oriondev.moneywallet.api.BackendException;
+import com.oriondev.moneywallet.api.IBackendServiceAPI;
+import com.oriondev.moneywallet.model.IFile;
+import com.oriondev.moneywallet.storage.database.ExportException;
+import com.oriondev.moneywallet.storage.database.backup.AbstractBackupExporter;
+import com.oriondev.moneywallet.storage.database.backup.BackupManager;
+import com.oriondev.moneywallet.storage.database.backup.DefaultBackupExporter;
+import com.oriondev.moneywallet.utils.DateUtils;
+import com.oriondev.moneywallet.utils.ProgressInputStream;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * The backup half of {@link BackupHandlerIntentService}, lifted out of it so the auto backup
+ * can run inside {@link AutoBackupJobService} instead of starting a service.
+ *
+ * Tested on an API 36 emulator, neither a foreground nor a plain service can be started while
+ * the app is in the background, so the work runs on the caller's own thread. Both callers share
+ * this one copy rather than the backup path being written twice.
+ */
+class BackupOperation {
+
+    private static final String ATTACHMENT_FOLDER = "attachments";
+    private static final String BACKUP_CACHE_FOLDER = "backups";
+    private static final String FILE_DATETIME_PATTERN = "yyyy-MM-dd_HH-mm-ss";
+    private static final String OUTPUT_FILE = "backup_%s%s";
+
+    /**
+     * Reports progress to a caller that has somewhere to show it. The auto backup passes null,
+     * because a job has no notification of its own to update.
+     */
+    interface ProgressListener {
+
+        void onProgress(int status, int progress);
+    }
+
+    /**
+     * Held for the length of a backup or a restore, so the two do not run at once. A restore
+     * renames the live database away and empties the attachment folder, and the auto backup no
+     * longer shares the serial service queue that used to keep them apart. It guards these two
+     * against each other only: attachment writes elsewhere in the app are outside it.
+     */
+    static final Object LOCK = new Object();
+
+    /**
+     * Export the database and attachments into a local file and upload it to the backend.
+     * Runs on the calling thread and returns the uploaded file.
+     */
+    static IFile createAndUpload(@NonNull Context context, @NonNull IBackendServiceAPI backendServiceAPI,
+                                 IFile remoteFolder, @Nullable String password,
+                                 @Nullable final ProgressListener listener)
+            throws ExportException, BackendException, IOException {
+        synchronized (LOCK) {
+            return createAndUploadLocked(context, backendServiceAPI, remoteFolder, password, listener);
+        }
+    }
+
+    private static IFile createAndUploadLocked(@NonNull Context context, @NonNull IBackendServiceAPI backendServiceAPI,
+                                               IFile remoteFolder, @Nullable String password,
+                                               @Nullable final ProgressListener listener)
+            throws ExportException, BackendException, IOException {
+        File cache = new File(context.getExternalFilesDir(null), BACKUP_CACHE_FOLDER);
+        File revision = new File(cache, UUID.randomUUID().toString());
+        try {
+            FileUtils.forceMkdir(revision);
+            notifyProgress(listener, BackupHandlerIntentService.STATUS_BACKUP_CREATION, 0);
+            File backup = prepareLocalBackupFile(context, revision, password);
+            notifyProgress(listener, BackupHandlerIntentService.STATUS_BACKUP_UPLOADING, 30);
+            IFile uploaded = backendServiceAPI.uploadFile(remoteFolder, backup, new ProgressInputStream.UploadProgressListener() {
+
+                @Override
+                public void onUploadProgressUpdate(int percentage) {
+                    notifyProgress(listener, BackupHandlerIntentService.STATUS_BACKUP_UPLOADING, 30 + (percentage * 70 / 100));
+                }
+
+            });
+            notifyProgress(listener, BackupHandlerIntentService.STATUS_BACKUP_UPLOADING, 100);
+            return uploaded;
+        } finally {
+            FileUtils.deleteQuietly(revision);
+        }
+    }
+
+    private static void notifyProgress(@Nullable ProgressListener listener, int status, int progress) {
+        if (listener != null) {
+            listener.onProgress(status, progress);
+        }
+    }
+
+    /**
+     * Create a local zip file that contains the database entries according to the backup
+     * file specification. If a password is provided, set it to the zip file.
+     */
+    private static File prepareLocalBackupFile(@NonNull Context context, @NonNull File folder,
+                                               @Nullable String password) throws ExportException, IOException {
+        File backupFile = createBackupFile(folder, BackupManager.getExtension(!TextUtils.isEmpty(password)));
+        AbstractBackupExporter exporter = new DefaultBackupExporter(context.getContentResolver(), backupFile, password);
+        exporter.exportDatabase(context.getFilesDir());
+        exporter.exportAttachments(getAttachmentFolder(context));
+        return backupFile;
+    }
+
+    private static File createBackupFile(@NonNull File folder, @NonNull String extension) {
+        String datetime = DateUtils.getDateTimeString(new Date(), FILE_DATETIME_PATTERN);
+        String name = String.format(Locale.ENGLISH, OUTPUT_FILE, datetime, extension);
+        return new File(folder, name);
+    }
+
+    static File getAttachmentFolder(@NonNull Context context) throws IOException {
+        File folder = new File(context.getExternalFilesDir(null), ATTACHMENT_FOLDER);
+        FileUtils.forceMkdir(folder);
+        return folder;
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -560,6 +560,7 @@
     <string name="notification_content_backup_error_backend_recoverable">"There was an error while communicating with the backend service. Check your internet connection and try again."</string>
     <string name="notification_content_backup_error_backend">"There was an error with the backend and the auto backup has been disabled. Check if there is any problem."</string>
     <string name="notification_content_backup_error_internal">"There was an internal error during the operation, which is probably a bug. Please report this message to the developer: %s"</string>
+    <string name="notification_content_backup_error_location">"The backup location is no longer available, so the automatic backup did not run. Open the backup settings and choose the folder again."</string>
     <string name="notification_action_retry">"Retry"</string>
     <string name="message_error_network_connection">"network connection"</string>
     <string name="message_error_invalid_response">"invalid response"</string>


### PR DESCRIPTION
Fixes #88. Fixes #93.

The automatic backup could not run at all on a recent Android, and on the startup path it took the process down with it. Both open reports are the same root cause reached by two different routes, so one change closes both.

## The mechanism

`scheduleAutoBackupTask` ran the backup inline whenever the next occurrence was already past, which is the normal case after a device has been off. It did that by starting `BackupHandlerIntentService` in the foreground, and that start is refused when the app is in the background. On an API 36 emulator with the app not running:

```
W ActivityManager: startForegroundService() not allowed due to
mAllowStartForeground false: service ...BackupHandlerIntentService
```

The refusal surfaces at `Context.startForegroundService`, so it lands in the caller, where the per backend catch swallowed it before the line that advances the stored timestamp. `startBackgroundTask` then called `scheduleAutoBackupTask` again, which computed the same overdue timestamp and started again. That run counted 3,720 iterations, then an ANR with reason "failed to complete startup" and the process killed, about 15 seconds after the first refusal. The reason names `Application.onCreate`, which is one of the callers; the boot receiver is another.

A backup location that cannot be decoded reaches the same loop by a different route, because that guard also continued without advancing the timestamp. Several hundred iterations on the same emulator, and the same ANR. Nothing in either cycle changes state, which is why neither terminates.

## The change

Scheduling goes through `JobScheduler`, which imposes no such restriction. The sweep and the scheduling call still reach each other, but never inline: an overdue occurrence is queued at a minimum latency like any other, so no call can re enter its own caller.

A plain `startService` does not help. The job sweep handing the work back to the service was refused with "Not allowed to start service ...: app is in background", so the sweep runs the backup on its own thread. The backup half of `BackupHandlerIntentService` moved into `BackupOperation`, which the sweep and the user started backup both call, so the export and the upload exist in one place. A lock keeps a sweep and a restore off the database and the attachment folder at the same time; the serial service queue used to do that and no longer covers both.

Two timing faults go with it. A backend that fails now consumes its occurrence, because leaving the timestamp behind requeues the job at the minimum latency and turns a failing backend into a run every minute. And the sweep skips to the most recent passed occurrence rather than advancing by one interval, because advancing by one turns a fortnight away into a run per missed day.

## What changes for the user

- The automatic backup runs again.
- It no longer shows a progress notification. The sweep passes no progress listener, having no notification of its own to update, and it is not a foreground service. The user started backup is unchanged except that it now waits for a running sweep to finish.
- A backup location that cannot be opened is reported instead of passing in silence. The occurrence is spent either way.
- Two auto backup failures lose their retry action. A backend set to WiFi only that wakes on another transport is still skipped with a notification, and a recoverable backend error, an expired token or a server that cannot be reached, is still reported, but neither notification carries the retry button the old service path put on both. Retrying means opening the app.
- The job itself takes no network requirement. WiFi only is a per backend setting and this is one job for all of them, so a job level constraint could only apply when every enabled backend agreed. None of the network types available at this minSdk names a transport, and the nearest one, unmetered, is not WiFi in either direction: a metered WiFi would hold the job for ever for a backend the sweep would have run, and an unmetered mobile network would release it into a skip. A real WiFi requirement needs `setRequiredNetwork`, which is API 28. The sweep reads the transport itself instead.

## What this touches

Eight files. `AutoBackupBroadcastReceiver` becomes scheduler only and is no longer a receiver; `AutoBackupJobService` is new and runs the sweep; `BackupOperation` is new and holds the export and upload shared with the user started backup. One manifest change, one string. No schema change, and no change to the backup file format.

## Tested

On an API 36 emulator, with the process killed and the job left to start it cold. The sweep survived its own `Application.onCreate`, a new backup file appeared, the stored timestamp advanced one interval, and the next occurrence was queued 23h57m out rather than at the 60 second minimum. The requeue figure is the one that discriminates: an occurrence left unconsumed lands on that minimum, and so does a sweep that never ran. Only one occurrence had passed in that fixture, so it says nothing either way about skipping to the most recent one. An earlier run, across a reboot with an undecodable location, produced the notification and a requeue about 20 hours out.

The WiFi only path was driven in both directions on the same fixture, because the passing direction alone shows nothing. On WiFi the backup file was written. With WiFi off and mobile data up, the sweep skipped, the notification appeared in the shade, no file was written, and the occurrence was still consumed. The user started backup was driven through the app after the rewrite and reported the backup created, with the file present in the picker.

## Not verified

No test run went near any of this: any physical device; the restore path at all, so the sweep and restore lock has been read on both sides and never contended, and the attachment folder helper it now shares is untried from that side; `onStopJob` asking for the job back; the overlap guard; the sweep's own failure notification and the disable path behind it, which nothing reached because a skipped backend returns normally rather than throwing; the catch around the requeue; the catch around the sweep thread; the settings unreadable catch; the interval clamp; the branch that cancels the job when the last backend is switched off; and Doze deferral.

Asserted from platform behaviour rather than tested: that an alarm queued by an older build does not survive the update that removes it, which is why this drops the cancel of that alarm.
