### PR TITLE
Derive a transfer's exchange rate the way convert applies it

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/model/MoneyScale.java
+++ b/app/src/main/java/com/oriondev/moneywallet/model/MoneyScale.java
@@ -83,4 +83,23 @@ public final class MoneyScale {
                 .movePointRight(toDecimals)
                 .longValue();
     }
+
+    /**
+     * Recover the rate {@link #convert(long, int, int, double)} was called with from the pair of
+     * stored amounts it produced. Since convert shifts the decimal point between the two currency
+     * scales as well as applying the rate, the bare ratio of the stored values is
+     * {@code rate x 10^(toDecimals - fromDecimals)} rather than the rate, and feeding that ratio
+     * back into convert would apply the shift a second time.
+     *
+     * Returns zero when the source amount is zero: the ratio is undefined there, and the infinite
+     * or NaN double it would otherwise produce cannot be read by
+     * {@link BigDecimal#valueOf(double)}. Zero is the value the currency pickers already treat as
+     * no rate known.
+     */
+    public static double deriveRate(long fromMinorUnits, long toMinorUnits, int fromDecimals, int toDecimals) {
+        if (fromMinorUnits == 0) {
+            return 0D;
+        }
+        return (double) toMinorUnits / fromMinorUnits * Math.pow(10, fromDecimals - toDecimals);
+    }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditRecurrentTransferActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditRecurrentTransferActivity.java
@@ -37,6 +37,7 @@ import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.RecurrenceBroadcastReceiver;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Event;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.model.Place;
 import com.oriondev.moneywallet.model.RecurrenceSetting;
 import com.oriondev.moneywallet.model.Wallet;
@@ -345,7 +346,9 @@ public class NewEditRecurrentTransferActivity extends NewEditItemActivity implem
                                     DateUtils.getDateFromSQLDateString(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.EVENT_END_DATE)))
                             );
                         }
-                        conversionRate = (double) moneyTo / moneyFrom;
+                        conversionRate = MoneyScale.deriveRate(moneyFrom, moneyTo,
+                                CurrencyManager.getDecimals(walletFrom.getCurrency()),
+                                CurrencyManager.getDecimals(walletTo.getCurrency()));
                         mConfirmedCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.CONFIRMED)) == 1);
                         mCountInTotalCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.RecurrentTransfer.COUNT_IN_TOTAL)) == 1);
                         Date startDate = DateUtils.getDateFromSQLDateString(cursor.getString(cursor.getColumnIndex(Contract.RecurrentTransfer.START_DATE)));

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferActivity.java
@@ -42,6 +42,7 @@ import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Attachment;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Event;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.model.Person;
 import com.oriondev.moneywallet.model.Place;
 import com.oriondev.moneywallet.model.Wallet;
@@ -405,7 +406,9 @@ public class NewEditTransferActivity extends NewEditItemActivity  implements Cur
                                     DateUtils.getDateFromSQLDateString(cursor.getString(cursor.getColumnIndex(Contract.Transfer.EVENT_END_DATE)))
                             );
                         }
-                        conversionRate = (double) moneyTo / moneyFrom;
+                        conversionRate = MoneyScale.deriveRate(moneyFrom, moneyTo,
+                                CurrencyManager.getDecimals(walletFrom.getCurrency()),
+                                CurrencyManager.getDecimals(walletTo.getCurrency()));
                         mConfirmedCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transfer.CONFIRMED)) == 1);
                         mCountInTotalCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transfer.COUNT_IN_TOTAL)) == 1);
                     }
@@ -534,7 +537,9 @@ public class NewEditTransferActivity extends NewEditItemActivity  implements Cur
                                         DateUtils.getDateFromSQLDateString(cursor.getString(cursor.getColumnIndex(Contract.TransferModel.EVENT_END_DATE)))
                                 );
                             }
-                            conversionRate = (double) moneyTo / moneyFrom;
+                            conversionRate = MoneyScale.deriveRate(moneyFrom, moneyTo,
+                                    CurrencyManager.getDecimals(walletFrom.getCurrency()),
+                                    CurrencyManager.getDecimals(walletTo.getCurrency()));
                             mConfirmedCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.TransferModel.CONFIRMED)) == 1);
                             mCountInTotalCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.TransferModel.COUNT_IN_TOTAL)) == 1);
                         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferModelActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferModelActivity.java
@@ -36,6 +36,7 @@ import android.widget.TextView;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Event;
+import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.model.Place;
 import com.oriondev.moneywallet.model.Wallet;
 import com.oriondev.moneywallet.picker.CurrencyConverterPicker;
@@ -324,7 +325,9 @@ public class NewEditTransferModelActivity extends NewEditItemActivity implements
                                     DateUtils.getDateFromSQLDateString(cursor.getString(cursor.getColumnIndex(Contract.TransferModel.EVENT_END_DATE)))
                             );
                         }
-                        conversionRate = (double) moneyTo / moneyFrom;
+                        conversionRate = MoneyScale.deriveRate(moneyFrom, moneyTo,
+                                CurrencyManager.getDecimals(walletFrom.getCurrency()),
+                                CurrencyManager.getDecimals(walletTo.getCurrency()));
                         mConfirmedCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.TransferModel.CONFIRMED)) == 1);
                         mCountInTotalCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.TransferModel.COUNT_IN_TOTAL)) == 1);
                     }

--- a/app/src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java
@@ -171,6 +171,14 @@ public class CurrencyManager {
     }
 
     /**
+     * @return the number of decimals of the currency, or 0 when the currency is null because
+     *         {@link #getCurrency(String)} did not know the iso code stored on the row.
+     */
+    public static int getDecimals(CurrencyUnit currency) {
+        return currency != null ? currency.getDecimals() : 0;
+    }
+
+    /**
      * @return the rate between the two currencies, or null if either is absent or no rate is
      *         known for the pair.
      */

--- a/app/src/test/java/com/oriondev/moneywallet/model/MoneyScaleTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/model/MoneyScaleTest.java
@@ -3,6 +3,7 @@ package com.oriondev.moneywallet.model;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -166,6 +167,84 @@ public class MoneyScaleTest {
         assertNotEquals(exact, buggyResult);
         assertTrue(buggyResult.compareTo(new BigDecimal("99999999999999991611392")) == 0);
         assertTrue(canonicalResult.compareTo(exact) == 0);
+    }
+
+    // regression: the three transfer editors derived the exchange rate on load as
+    // (double) moneyTo / moneyFrom. convert() shifts the decimal point between the two
+    // currency scales as well as applying the rate, so that ratio carries the shift and
+    // saving applied it a second time.
+
+    @Test
+    public void deriveRate_thenConvert_leavesTheStoredAmountWhereItWas() {
+        // Opening a transfer and saving it again without touching the amounts is the flow
+        // that corrupted the destination value: the editor derives a rate from the stored
+        // pair on load and converts with it on save.
+        long[][] storedPairs = {
+                {10000L, 15000L}, {15000L, 10000L}, {6499L, 5832L}, {100000L, 92L}, {7L, 900000L}
+        };
+        for (int fromDecimals = 0; fromDecimals <= 3; fromDecimals++) {
+            for (int toDecimals = 0; toDecimals <= 3; toDecimals++) {
+                for (long[] pair : storedPairs) {
+                    long from = pair[0];
+                    long to = pair[1];
+                    String where = "from=" + from + " to=" + to
+                            + " fromDecimals=" + fromDecimals + " toDecimals=" + toDecimals;
+
+                    double rate = MoneyScale.deriveRate(from, to, fromDecimals, toDecimals);
+                    long resaved = MoneyScale.convert(from, fromDecimals, toDecimals, rate);
+                    // convert truncates toward zero, so a non terminating ratio can cost one
+                    // minor unit. That is a property of convert and not of the derivation.
+                    assertTrue(where + " moved to " + resaved, Math.abs(resaved - to) <= 1L);
+
+                    if (fromDecimals != toDecimals) {
+                        // the old derivation, kept here so this test discriminates: it is wrong
+                        // by the whole scale factor between the two currencies, not by one unit
+                        double oldRate = (double) to / from;
+                        long oldResaved = MoneyScale.convert(from, fromDecimals, toDecimals, oldRate);
+                        assertTrue(where + " old path happened to be right", Math.abs(oldResaved - to) > 1L);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void deriveRate_matchesTheOldRatioWhenBothScalesAgree() {
+        // Same decimal count on both sides is the case the bug was invisible in, and the
+        // one every same currency transfer takes. It must not move.
+        for (int decimals = 0; decimals <= 3; decimals++) {
+            assertEquals((double) 5832L / 6499L, MoneyScale.deriveRate(6499L, 5832L, decimals, decimals), 0d);
+        }
+    }
+
+    @Test
+    public void deriveRate_appliesTheScaleShiftInTheDirectionConvertUndoes() {
+        // 100.00 in a two decimal currency stored as 15000 in a zero decimal one is a rate
+        // of 150, not the bare ratio of 1.5.
+        assertEquals(150d, MoneyScale.deriveRate(10000L, 15000L, 2, 0), 1e-9);
+        assertEquals(1.5d, MoneyScale.deriveRate(10000L, 15000L, 2, 2), 1e-9);
+        assertEquals(0.015d, MoneyScale.deriveRate(10000L, 15000L, 0, 2), 1e-9);
+    }
+
+    @Test
+    public void deriveRate_zeroSourceAmountYieldsNoRateRatherThanANonFiniteOne() {
+        assertEquals(0d, MoneyScale.deriveRate(0L, 15000L, 2, 0), 0d);
+        assertEquals(0d, MoneyScale.deriveRate(0L, 0L, 2, 2), 0d);
+    }
+
+    @Test
+    public void deriveRate_guardIsLoadBearingBecauseBigDecimalRejectsNonFiniteRates() {
+        // Without the zero check the ratio is infinite or NaN, and convert cannot read it.
+        assertTrue(Double.isInfinite((double) 15000L / 0L));
+        assertTrue(Double.isNaN((double) 0L / 0L));
+        for (double nonFinite : new double[] {Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, Double.NaN}) {
+            try {
+                BigDecimal.valueOf(nonFinite);
+                fail("BigDecimal.valueOf accepted " + nonFinite);
+            } catch (NumberFormatException expected) {
+                // this is why deriveRate must not return it
+            }
+        }
     }
 
     private static void assertRoundTrip(long minorUnits, int decimals) {


### PR DESCRIPTION
Opening a transfer between two currencies with different decimal counts and saving it, with nothing typed, rewrites the destination amount by the scale factor between those currencies. The transfer editor and the transfer model editor both do this today. The amount never has to be touched, because the corrupted value is already on screen when the editor opens.

## The mechanism

Each transfer editor recovers the exchange rate from the pair of stored amounts as it loads the row:

```java
conversionRate = (double) moneyTo / moneyFrom;
```

`MoneyScale.convert` is what produced those two amounts, and it does not only apply a rate:

```java
BigDecimal.valueOf(minorUnits)
        .movePointLeft(fromDecimals)
        .multiply(BigDecimal.valueOf(rate))
        .movePointRight(toDecimals)
```

That is `minorUnits x 10^(toDecimals - fromDecimals) x rate`, so the ratio of the two stored values is the rate multiplied by the scale shift between the currencies, not the rate. Saving passes that ratio back through `convert`, which applies the shift a second time.

The two shifts cancel only when both currencies carry the same number of decimals, which is every transfer inside a single currency.

## The change

`MoneyScale.deriveRate` inverts `convert` and now feeds all four call sites. It returns zero when the source amount is zero, because the ratio is undefined there and `BigDecimal.valueOf` rejects the infinite or NaN double a bare division hands back, so `convert` could not read it. Zero is the value the currency pickers already read as no rate known.

The decimals come from the wallet currencies the same block already builds from the cursor, read through `CurrencyManager.getDecimals`. `CurrencyManager.getCurrency` is a cache lookup that returns null for an iso code it does not hold, and reading the decimals without a null check would turn a screen that currently loads and then refuses to save into one that throws while loading.

## What this touches

Four call sites across three editors, one new method on `MoneyScale` and one on `CurrencyManager`. Three of the four are reachable in a shipped build: `NewEditTransferActivity` for a stored transfer and again for one prefilled from a transfer model, and `NewEditTransferModelActivity` for a stored model. The fourth is `NewEditRecurrentTransferActivity`, which nothing launches in edit mode today.

Nothing changes about how a rate is entered, stored or fetched, only the value the editor starts from.

## Tested

Five tests in `MoneyScaleTest`, which is plain JVM code. The load bearing one walks every pair of decimal counts from 0 to 3 over five stored amount pairs, derives a rate, converts with it, and requires the destination amount to come back within one minor unit. It carries the old derivation alongside and requires that one to be wrong by more than a minor unit wherever the two scales differ, so it cannot pass against the code it replaces. Putting the old expression back fails two of the tests, and dropping only the zero check fails one.

On an API 36 emulator, against a build of the parent commit on the same device, with the seeded rows restored to the same values between the two runs.

A transfer of 10000 minor units out of a two decimal wallet into 15000 minor units in a zero decimal wallet, a true rate of 150, was opened and saved with nothing typed. The parent build shows the rate as 1.50 and the destination as 150 before the save, and the save writes 150 over the stored 15000. This build shows 150.00 and 15,000 on the same screen and the save leaves 15000 standing. A transfer between two wallets of one currency was driven the same way on this build and both amounts stayed at 25000.

## What this does not address

The transfer model editor and the model to transfer path take the identical change but were not driven on the emulator. The recurrent transfer editor cannot be reached at all.

Nothing was tested on a physical device.

The test allows the resaved amount to differ from the stored one by a single minor unit, because `convert` truncates toward zero. That behaviour is unchanged here.
