### PR TITLE
Let a saved recurrence be edited, and make the save write something

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/model/RecurrenceSetting.java
+++ b/app/src/main/java/com/oriondev/moneywallet/model/RecurrenceSetting.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Created by andrea on 07/11/18.
@@ -369,6 +370,39 @@ public class RecurrenceSetting implements Parcelable {
                 DateUtils.getFixedDate(lastOccurrence),
                 nextOccurrence != null ? DateUtils.getFixedDate(nextOccurrence) : null
         );
+    }
+
+    /**
+     * Where an edited recurrence resumes, as an SQL date string, or null when the rule it now
+     * carries is exhausted. Every date argument is an SQL date string as stored on the row.
+     *
+     * When neither the rule nor the start date moved, the stored pointer is handed back
+     * untouched. An edit to an amount, a description or a category cannot then step over
+     * occurrences that have come due and have not yet been written to the ledger, and that
+     * matters here because the recurrence service only ever walks forward from this pointer, so
+     * an occurrence it has been moved past is never written.
+     *
+     * When the schedule itself moved, the pointer becomes the first instance of the new rule
+     * after {@code now}, seeded from the new start date so the rule keeps the anchor its own
+     * fields are relative to. Occurrences the old rule left owed are not carried across, since
+     * the new rule need not contain them at all.
+     *
+     * @param oldRule           rule currently stored on the row.
+     * @param oldStartDate      start date currently stored on the row.
+     * @param oldNextOccurrence pointer currently stored on the row, possibly already past.
+     * @param newRule           rule the editor is saving.
+     * @param newStartDate      start date the editor is saving.
+     * @param now               the moment the edit is being saved at.
+     * @return the value the NEXT_OCCURRENCE column must be set to.
+     */
+    public static String resumeAfterEdit(String oldRule, String oldStartDate, String oldNextOccurrence,
+                                         String newRule, String newStartDate, Date now) {
+        if (Objects.equals(oldRule, newRule) && Objects.equals(oldStartDate, newStartDate)) {
+            return oldNextOccurrence;
+        }
+        Date startDate = DateUtils.getDateFromSQLDateString(newStartDate);
+        Date nextOccurrence = computeOccurrences(newRule, startDate, now).getNextOccurrence();
+        return nextOccurrence != null ? DateUtils.getSQLDateString(nextOccurrence) : null;
     }
 
     public static class Builder {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -30,6 +30,7 @@ import android.text.TextUtils;
 import android.util.SparseLongArray;
 
 import com.oriondev.moneywallet.model.CurrencyUnit;
+import com.oriondev.moneywallet.model.RecurrenceSetting;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.DateUtils;
 import com.oriondev.moneywallet.utils.MoneyFormatter;
@@ -3412,7 +3413,35 @@ import java.util.UUID;
             String[] selectionArgs = new String[] {String.valueOf(transactionId)};
             return getWritableDatabase().update(Schema.RecurrentTransaction.TABLE, cv, where, selectionArgs);
         }
-        return 0;
+        String rule = contentValues.getAsString(Contract.RecurrentTransaction.RULE);
+        try {
+            // parsed for its exception: an invalid rule is refused here as it is on insert
+            new RecurrenceRule(rule);
+        } catch (InvalidRecurrenceRuleException e) {
+            throw new SQLiteDataException(Contract.ErrorCode.INVALID_RECURRENCE_RULE, e.getMessage());
+        }
+        String startDate = contentValues.getAsString(Contract.RecurrentTransaction.START_DATE);
+        ContentValues cv = new ContentValues();
+        cv.put(Schema.RecurrentTransaction.MONEY, contentValues.getAsLong(Contract.RecurrentTransaction.MONEY));
+        cv.put(Schema.RecurrentTransaction.DESCRIPTION, contentValues.getAsString(Contract.RecurrentTransaction.DESCRIPTION));
+        cv.put(Schema.RecurrentTransaction.CATEGORY, contentValues.getAsLong(Contract.RecurrentTransaction.CATEGORY_ID));
+        cv.put(Schema.RecurrentTransaction.DIRECTION, contentValues.getAsInteger(Contract.RecurrentTransaction.DIRECTION));
+        cv.put(Schema.RecurrentTransaction.WALLET, contentValues.getAsLong(Contract.RecurrentTransaction.WALLET_ID));
+        cv.put(Schema.RecurrentTransaction.PLACE, contentValues.getAsLong(Contract.RecurrentTransaction.PLACE_ID));
+        cv.put(Schema.RecurrentTransaction.EVENT, contentValues.getAsLong(Contract.RecurrentTransaction.EVENT_ID));
+        cv.put(Schema.RecurrentTransaction.NOTE, contentValues.getAsString(Contract.RecurrentTransaction.NOTE));
+        cv.put(Schema.RecurrentTransaction.CONFIRMED, contentValues.getAsBoolean(Contract.RecurrentTransaction.CONFIRMED));
+        cv.put(Schema.RecurrentTransaction.COUNT_IN_TOTAL, contentValues.getAsBoolean(Contract.RecurrentTransaction.COUNT_IN_TOTAL));
+        cv.put(Schema.RecurrentTransaction.START_DATE, startDate);
+        cv.put(Schema.RecurrentTransaction.RULE, rule);
+        cv.put(Schema.RecurrentTransaction.NEXT_OCCURRENCE, resumedNextOccurrence(
+                Schema.RecurrentTransaction.TABLE, Schema.RecurrentTransaction.ID,
+                Schema.RecurrentTransaction.RULE, Schema.RecurrentTransaction.START_DATE,
+                Schema.RecurrentTransaction.NEXT_OCCURRENCE, transactionId, rule, startDate));
+        cv.put(Schema.RecurrentTransaction.LAST_EDIT, System.currentTimeMillis());
+        String where = Schema.RecurrentTransaction.ID + " = ?";
+        String[] selectionArgs = new String[] {String.valueOf(transactionId)};
+        return getWritableDatabase().update(Schema.RecurrentTransaction.TABLE, cv, where, selectionArgs);
     }
 
     /**
@@ -3667,7 +3696,36 @@ import java.util.UUID;
             String[] selectionArgs = new String[] {String.valueOf(transferId)};
             return getWritableDatabase().update(Schema.RecurrentTransfer.TABLE, cv, where, selectionArgs);
         }
-        return 0;
+        String rule = contentValues.getAsString(Contract.RecurrentTransfer.RULE);
+        try {
+            // parsed for its exception: an invalid rule is refused here as it is on insert
+            new RecurrenceRule(rule);
+        } catch (InvalidRecurrenceRuleException e) {
+            throw new SQLiteDataException(Contract.ErrorCode.INVALID_RECURRENCE_RULE, e.getMessage());
+        }
+        String startDate = contentValues.getAsString(Contract.RecurrentTransfer.START_DATE);
+        ContentValues cv = new ContentValues();
+        cv.put(Schema.RecurrentTransfer.DESCRIPTION, contentValues.getAsString(Contract.RecurrentTransfer.DESCRIPTION));
+        cv.put(Schema.RecurrentTransfer.WALLET_FROM, contentValues.getAsLong(Contract.RecurrentTransfer.WALLET_FROM_ID));
+        cv.put(Schema.RecurrentTransfer.WALLET_TO, contentValues.getAsLong(Contract.RecurrentTransfer.WALLET_TO_ID));
+        cv.put(Schema.RecurrentTransfer.MONEY_FROM, contentValues.getAsLong(Contract.RecurrentTransfer.MONEY_FROM));
+        cv.put(Schema.RecurrentTransfer.MONEY_TO, contentValues.getAsLong(Contract.RecurrentTransfer.MONEY_TO));
+        cv.put(Schema.RecurrentTransfer.MONEY_TAX, contentValues.getAsLong(Contract.RecurrentTransfer.MONEY_TAX));
+        cv.put(Schema.RecurrentTransfer.NOTE, contentValues.getAsString(Contract.RecurrentTransfer.NOTE));
+        cv.put(Schema.RecurrentTransfer.EVENT, contentValues.getAsLong(Contract.RecurrentTransfer.EVENT_ID));
+        cv.put(Schema.RecurrentTransfer.PLACE, contentValues.getAsLong(Contract.RecurrentTransfer.PLACE_ID));
+        cv.put(Schema.RecurrentTransfer.CONFIRMED, contentValues.getAsBoolean(Contract.RecurrentTransfer.CONFIRMED));
+        cv.put(Schema.RecurrentTransfer.COUNT_IN_TOTAL, contentValues.getAsBoolean(Contract.RecurrentTransfer.COUNT_IN_TOTAL));
+        cv.put(Schema.RecurrentTransfer.START_DATE, startDate);
+        cv.put(Schema.RecurrentTransfer.RULE, rule);
+        cv.put(Schema.RecurrentTransfer.NEXT_OCCURRENCE, resumedNextOccurrence(
+                Schema.RecurrentTransfer.TABLE, Schema.RecurrentTransfer.ID,
+                Schema.RecurrentTransfer.RULE, Schema.RecurrentTransfer.START_DATE,
+                Schema.RecurrentTransfer.NEXT_OCCURRENCE, transferId, rule, startDate));
+        cv.put(Schema.RecurrentTransfer.LAST_EDIT, System.currentTimeMillis());
+        String where = Schema.RecurrentTransfer.ID + " = ?";
+        String[] selectionArgs = new String[] {String.valueOf(transferId)};
+        return getWritableDatabase().update(Schema.RecurrentTransfer.TABLE, cv, where, selectionArgs);
     }
 
     /**
@@ -4488,6 +4546,42 @@ import java.util.UUID;
      */
     private String getRecurrentItemUUID(String recurrenceUUID, Date date) {
         return String.format("%s:%s", recurrenceUUID, DateUtils.getSQLDateString(date));
+    }
+
+    /**
+     * Read the schedule currently stored on a recurrence row and hand it, together with the
+     * schedule the editor is saving, to {@link RecurrenceSetting#resumeAfterEdit}, which owns
+     * the decision. Both recurrence tables use this, so the caller names every column.
+     *
+     * @param table table holding the row.
+     * @param idColumn primary key column of that table.
+     * @param ruleColumn rule column of that table.
+     * @param startDateColumn start date column of that table.
+     * @param nextOccurrenceColumn next occurrence column of that table.
+     * @param id id of the row being edited.
+     * @param newRule rule the editor is saving.
+     * @param newStartDate start date the editor is saving, as an SQL date string.
+     * @return the value the next occurrence column must be set to, null when the rule is exhausted.
+     */
+    private String resumedNextOccurrence(String table, String idColumn, String ruleColumn,
+                                         String startDateColumn, String nextOccurrenceColumn,
+                                         long id, String newRule, String newStartDate) {
+        String oldRule = null;
+        String oldStartDate = null;
+        String oldNextOccurrence = null;
+        String[] projection = new String[] {ruleColumn, startDateColumn, nextOccurrenceColumn};
+        Cursor cursor = getWritableDatabase().query(table, projection, idColumn + " = ?",
+                new String[] {String.valueOf(id)}, null, null, null);
+        if (cursor != null) {
+            if (cursor.moveToFirst()) {
+                oldRule = cursor.getString(0);
+                oldStartDate = cursor.getString(1);
+                oldNextOccurrence = cursor.isNull(2) ? null : cursor.getString(2);
+            }
+            cursor.close();
+        }
+        return RecurrenceSetting.resumeAfterEdit(oldRule, oldStartDate, oldNextOccurrence,
+                newRule, newStartDate, new Date());
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransactionItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransactionItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -47,6 +48,8 @@ import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.RecurrenceSetting;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
+import com.oriondev.moneywallet.ui.activity.NewEditRecurrentTransactionActivity;
 import com.oriondev.moneywallet.ui.fragment.base.SecondaryPanelFragment;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.CurrencyManager;
@@ -112,13 +115,18 @@ public class RecurrentTransactionItemFragment extends SecondaryPanelFragment imp
 
     @Override
     protected int onInflateMenu() {
-        return R.menu.menu_delete_item;
+        return R.menu.menu_edit_delete_item;
     }
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         int itemId = item.getItemId();
-        if (itemId == R.id.action_delete_item) {
+        if (itemId == R.id.action_edit_item) {
+            Intent intent = new Intent(getActivity(), NewEditRecurrentTransactionActivity.class);
+            intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.EDIT_ITEM);
+            intent.putExtra(NewEditItemActivity.ID, getItemId());
+            startActivity(intent);
+        } else if (itemId == R.id.action_delete_item) {
             showDeleteDialog(getActivity());
         }
         return false;

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransferItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransferItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -47,6 +48,8 @@ import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.RecurrenceSetting;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
+import com.oriondev.moneywallet.ui.activity.NewEditRecurrentTransferActivity;
 import com.oriondev.moneywallet.ui.fragment.base.SecondaryPanelFragment;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.CurrencyManager;
@@ -114,13 +117,18 @@ public class RecurrentTransferItemFragment extends SecondaryPanelFragment implem
 
     @Override
     protected int onInflateMenu() {
-        return R.menu.menu_delete_item;
+        return R.menu.menu_edit_delete_item;
     }
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         int itemId = item.getItemId();
-        if (itemId == R.id.action_delete_item) {
+        if (itemId == R.id.action_edit_item) {
+            Intent intent = new Intent(getActivity(), NewEditRecurrentTransferActivity.class);
+            intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.EDIT_ITEM);
+            intent.putExtra(NewEditItemActivity.ID, getItemId());
+            startActivity(intent);
+        } else if (itemId == R.id.action_delete_item) {
             showDeleteDialog(getActivity());
         }
         return false;

--- a/app/src/test/java/com/oriondev/moneywallet/model/RecurrenceSettingTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/model/RecurrenceSettingTest.java
@@ -216,4 +216,83 @@ public class RecurrenceSettingTest {
         assertDay(update.getLastOccurrence(), 2020, 2, 3);
         assertNull(update.getNextOccurrence());
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // editing a saved recurrence. resumeAfterEdit owns the whole decision, so these fail if the
+    // editor path in SQLDatabase is reverted to writing the pointer unconditionally.
+    // ---------------------------------------------------------------------------------------------
+
+    /** The service only walks forward from the pointer, so an unrelated edit must not move it. */
+    @Test
+    public void anEditThatLeavesTheScheduleAloneKeepsAnAlreadyOwedPointer() {
+        // the service is behind: the stored pointer is a month in the past and nothing has emitted it
+        String owed = sql(day(2020, 1, 10));
+        String resumed = RecurrenceSetting.resumeAfterEdit(
+                "FREQ=MONTHLY", sql(day(2020, 0, 10)), owed,
+                "FREQ=MONTHLY", sql(day(2020, 0, 10)), day(2020, 2, 5));
+        assertEquals(owed, resumed);
+    }
+
+    @Test
+    public void anEditThatLeavesTheScheduleAloneKeepsAFuturePointerToo() {
+        String pointer = sql(day(2020, 3, 10));
+        String resumed = RecurrenceSetting.resumeAfterEdit(
+                "FREQ=MONTHLY", sql(day(2020, 0, 10)), pointer,
+                "FREQ=MONTHLY", sql(day(2020, 0, 10)), day(2020, 2, 5));
+        assertEquals(pointer, resumed);
+    }
+
+    @Test
+    public void anEditThatLeavesTheScheduleAloneKeepsAnExhaustedPointer() {
+        String resumed = RecurrenceSetting.resumeAfterEdit(
+                "FREQ=DAILY;UNTIL=20200201", sql(day(2020, 0, 10)), null,
+                "FREQ=DAILY;UNTIL=20200201", sql(day(2020, 0, 10)), day(2020, 2, 5));
+        assertNull(resumed);
+    }
+
+    @Test
+    public void changingTheRuleMovesThePointerOntoTheNewCadence() {
+        // daily would fire tomorrow; monthly keeps the day of month the rule started on
+        String resumed = RecurrenceSetting.resumeAfterEdit(
+                "FREQ=DAILY", sql(day(2020, 0, 10)), sql(day(2020, 2, 6)),
+                "FREQ=MONTHLY", sql(day(2020, 0, 10)), day(2020, 2, 5));
+        assertEquals(sql(day(2020, 2, 10)), resumed);
+    }
+
+    @Test
+    public void changingOnlyTheStartDateAlsoMovesThePointer() {
+        String resumed = RecurrenceSetting.resumeAfterEdit(
+                "FREQ=MONTHLY", sql(day(2020, 0, 10)), sql(day(2020, 2, 10)),
+                "FREQ=MONTHLY", sql(day(2020, 0, 20)), day(2020, 2, 5));
+        assertEquals(sql(day(2020, 2, 20)), resumed);
+    }
+
+    /** Pinned deliberately: a rule change does drop occurrences the old rule left owed. */
+    @Test
+    public void changingTheRuleDropsAnOwedPointer() {
+        String resumed = RecurrenceSetting.resumeAfterEdit(
+                "FREQ=DAILY", sql(day(2020, 0, 10)), sql(day(2020, 1, 10)),
+                "FREQ=MONTHLY", sql(day(2020, 0, 10)), day(2020, 2, 5));
+        assertEquals(sql(day(2020, 2, 10)), resumed);
+    }
+
+    @Test
+    public void editingOntoAnAlreadyExhaustedRuleLeavesNoNextOccurrence() {
+        String resumed = RecurrenceSetting.resumeAfterEdit(
+                "FREQ=DAILY", sql(day(2020, 0, 10)), sql(day(2020, 2, 6)),
+                "FREQ=DAILY;UNTIL=20200201", sql(day(2020, 0, 10)), day(2020, 2, 5));
+        assertNull(resumed);
+    }
+
+    @Test
+    public void editingAScheduleThatHasNotStartedResumesOnItsStartDate() {
+        String resumed = RecurrenceSetting.resumeAfterEdit(
+                "FREQ=DAILY", sql(day(2020, 0, 10)), sql(day(2020, 4, 2)),
+                "FREQ=MONTHLY", sql(day(2020, 5, 10)), day(2020, 4, 1));
+        assertEquals(sql(day(2020, 5, 10)), resumed);
+    }
+
+    private static String sql(Date date) {
+        return DateUtils.getSQLDateString(date);
+    }
 }


### PR DESCRIPTION
Closes #51.

A saved recurring transaction or transfer can only be deleted and recreated. The two panels offer Delete alone, and the update behind them was never finished, so adding the action by itself would give a screen that looks like it works and writes nothing.

## The mechanism

`updateRecurrentTransaction` and `updateRecurrentTransfer` wrote only the two occurrence columns, and only when the caller supplied both:

```java
if (contentValues.containsKey(LAST_OCCURRENCE) && contentValues.containsKey(NEXT_OCCURRENCE)) {
    ...
}
return 0;
```

That guard describes the recurrence service, which is the only caller of these two methods that supplies both. The editors supply neither, so the method returned 0. `DataContentProvider.update` only notifies on `result > 0`, so no screen refreshed, and the activity finished with `RESULT_OK` either way.

## The change

Both methods take a second path for the editors. It writes every column the editors send, and leaves alone four that the insert also writes: `LAST_OCCURRENCE` because an edit emits nothing, `TAG` and `UUID` because no editor sends them, and `DELETED` because this is not a deletion. Both panels now offer Edit beside Delete.

Where an edited schedule resumes is the decision this carries, and **the pointer only moves when the schedule moved**. `RecurrenceSetting.resumeAfterEdit` returns the stored `NEXT_OCCURRENCE` untouched when neither the rule nor the start date changed, and otherwise the first instance of the new rule after now, seeded from the new start date so the rule keeps the anchor its own fields are relative to.

The reason for the first half is that the recurrence service only ever walks forward from that pointer: it selects rows whose next occurrence has come due and seeds the walk with that same value. An occurrence the pointer has been moved past is never written, and nothing in the app reports one. Rewriting the pointer on every save would mean an edit to an amount or a description was enough to lose one.

The second half is the deliberate cost: a rule the user has just rewritten need not contain the occurrences the old one left owed, so those are not carried across.

The decision lives in the model rather than in the database layer, which is what makes it reachable from a test at all.

## What this touches

The two update methods in `SQLDatabase` and one new private helper beside them, one new method on `RecurrenceSetting`, and the menu and click handler of the two recurrence panels. No other screen, and nothing about how occurrences are generated once the pointer is set.

Adding Edit switches on `Mode.EDIT_ITEM` in both recurrence editors, which nothing in the tree launches today.

## Tested

Eight tests on `RecurrenceSetting.resumeAfterEdit`, which is plain JVM code. Removing the equality check fails two of them, so they cannot pass against the code they replace. Full suite 108 tests, 0 failures.

On an API 36 emulator, against a build of the parent commit on the same device, with the row restored to identical values between the two runs.

A daily rule starting 1 August 2026 was given a next occurrence of 6 August and a last occurrence of 5 August, so five days stood owed and unwritten. The row was seeded while the app was already running, so the drain that runs at launch could not consume it first. The editor was then opened and saved with nothing typed.

The parent moved the pointer to 11 August, left the last occurrence at 5 August, and wrote nothing, so 6 through 10 August were never entered. This build kept the pointer at 6 August, and the service that runs after the save wrote all five, dated 6, 7, 8, 9 and 10 August, moving the last occurrence to 10 August.

**Both runs end on the same pointer**, which is why the ledger rows are the value that discriminates here and the pointer is not.

Changing the rule was driven the same way, daily to monthly through the recurrence picker. The pointer moved from 6 August to 1 September and the five owed daily occurrences were not written, which is the cost named above.

## What this does not address

The transfer editor takes the identical path through the same shared method, but was not driven on the emulator. Neither was any physical device.

The editor path for a rule that fails to parse is refused there the way the insert refuses it, and was not exercised.

An occurrence skipped by a rule change is not reported anywhere. `last_occurrence` and the rule still bracket the range, so it is reconstructible in principle, but nothing in the app does that and no screen reads `last_occurrence`.
