### PR TITLE
Let the debt lists show only the debts that are finished

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
@@ -54,6 +54,7 @@ public class PreferenceManager {
     private static final String GROUP_DIGITS = "group_digits";
     private static final String ROUND_DECIMALS = "round_decimals";
     private static final String SHOW_PLUS_MINUS_SYMBOL = "show_plus_minus_symbol";
+    private static final String DEBT_FINISHED_ONLY = "debt_finished_only";
     private static final String DATE_FORMAT = "date_format";
     private static final String FIRST_DAY_OF_WEEK = "first_day_of_week";
     private static final String FIRST_DAY_OF_MONTH = "first_day_of_month";
@@ -263,6 +264,18 @@ public class PreferenceManager {
 
     public static boolean isShowPlusMinusSymbolEnabled() {
         return mPreferences.getBoolean(SHOW_PLUS_MINUS_SYMBOL, false);
+    }
+
+    /**
+     * Whether the debt lists are showing only the debts that are finished. Stored once rather
+     * than held per tab, so the two debt tabs cannot disagree about it.
+     */
+    public static boolean isDebtFinishedOnlyEnabled() {
+        return mPreferences.getBoolean(DEBT_FINISHED_ONLY, false);
+    }
+
+    public static void setDebtFinishedOnlyEnabled(boolean enabled) {
+        mPreferences.edit().putBoolean(DEBT_FINISHED_ONLY, enabled).apply();
     }
 
     public static int getCurrentDateFormatIndex() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
@@ -103,6 +103,18 @@ public abstract class CursorListFragment extends Fragment implements SwipeRefres
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.REFRESHING);
     }
 
+    /**
+     * Run the query behind this list again, for when something outside the list changes what it
+     * should hold. Does nothing before the view exists, since the query is run from
+     * {@link #onViewCreated} anyway once it does.
+     */
+    public void reloadList() {
+        if (mAdvancedRecyclerView != null) {
+            getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+            mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
+        }
+    }
+
     protected boolean shouldRefreshOnCurrentWalletChange() {
         return false;
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/DebtMultiPanelViewPagerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/DebtMultiPanelViewPagerFragment.java
@@ -24,7 +24,12 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.view.MenuItem;
+
+import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.viewpager.widget.PagerAdapter;
@@ -33,11 +38,13 @@ import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.broadcast.Message;
 import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.activity.NewEditDebtActivity;
 import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
 import com.oriondev.moneywallet.ui.adapter.pager.DebtViewPagerAdapter;
 import com.oriondev.moneywallet.ui.fragment.base.MultiPanelViewPagerItemFragment;
 import com.oriondev.moneywallet.ui.fragment.base.SecondaryPanelFragment;
+import com.oriondev.moneywallet.ui.fragment.primary.DebtListFragment;
 import com.oriondev.moneywallet.ui.fragment.secondary.DebtItemFragment;
 
 /**
@@ -61,6 +68,46 @@ public class DebtMultiPanelViewPagerFragment extends MultiPanelViewPagerItemFrag
     @Override
     protected boolean showsCurrentWallet() {
         return true;
+    }
+
+    @MenuRes
+    @Override
+    protected int onInflateMenu() {
+        return R.menu.menu_debt_multipanel_fragment;
+    }
+
+    @Override
+    protected void setupPrimaryToolbar(Toolbar toolbar) {
+        super.setupPrimaryToolbar(toolbar);
+        // the menu is inflated fresh each time the toolbar is set up, so the tick has to be read
+        // back from the stored value rather than left at whatever the resource declares
+        MenuItem item = toolbar.getMenu().findItem(R.id.action_show_finished_debts_only);
+        if (item != null) {
+            item.setChecked(PreferenceManager.isDebtFinishedOnlyEnabled());
+        }
+    }
+
+    @Override
+    public boolean onMenuItemClick(MenuItem item) {
+        if (item.getItemId() == R.id.action_show_finished_debts_only) {
+            boolean enabled = !item.isChecked();
+            item.setChecked(enabled);
+            PreferenceManager.setDebtFinishedOnlyEnabled(enabled);
+            reloadDebtLists();
+        }
+        return false;
+    }
+
+    /**
+     * Both tabs filter on the same stored value, and the pager keeps both alive, so the one that
+     * is not on screen has to be told as well.
+     */
+    private void reloadDebtLists() {
+        for (Fragment fragment : getChildFragmentManager().getFragments()) {
+            if (fragment instanceof DebtListFragment) {
+                ((DebtListFragment) fragment).reloadList();
+            }
+        }
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/DebtListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/DebtListFragment.java
@@ -107,6 +107,11 @@ public class DebtListFragment extends CursorListFragment implements DebtCursorAd
                 selectionArgs = new String[] {String.valueOf(currentWallet)};
             }
             selection += " AND " + Contract.Debt.TYPE + " = " + String.valueOf(debtType.getValue());
+            if (PreferenceManager.isDebtFinishedOnlyEnabled()) {
+                // the same expression the sort and the grouping use, so the filter cannot decide a
+                // debt is finished while the header above it says otherwise
+                selection += " AND " + DebtHeaderCursor.SQL_IS_SETTLED + " = 1";
+            }
             // a debt that has been paid off in full is finished whether or not anyone remembered to
             // archive it, so it belongs below the ones that still need attention. The grouping
             // reads the same value back out of the projection, so the two cannot drift apart.

--- a/app/src/main/res/menu/menu_debt_multipanel_fragment.xml
+++ b/app/src/main/res/menu/menu_debt_multipanel_fragment.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_show_finished_debts_only"
+        android:checkable="true"
+        android:title="@string/menu_action_show_finished_only"
+        app:showAsAction="never" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="menu_action_open_calendar">"Calendar"</string>
     <string name="menu_action_open_map">"Map"</string>
     <string name="menu_action_sort_items">"Sort"</string>
+    <string name="menu_action_show_finished_only">"Show finished only"</string>
     <string name="menu_action_show_transaction_list">"Show transactions"</string>
     <string name="menu_action_service_disconnect">"Disconnect"</string>
     <string name="menu_action_service_auto_backup">"Auto backup"</string>


### PR DESCRIPTION
Closes #57.

The debt lists already group finished debts under their own header and sort them below the ones that still need attention. There is still no way to look at only the finished ones, which is the other half of what the original report asked for.

## The change

A checkable overflow item on the debts screen, "Show finished only", applying to both tabs.

The filter reuses `DebtHeaderCursor.SQL_IS_SETTLED`, the expression the sort and the header grouping already share, so a debt cannot be filtered in while the header above it calls it something else. A debt counts as finished once it has been archived by hand or paid off in full.

## The mechanism

That expression reads `debt_progress`, which is not a stored column but an alias produced by the subquery the debt query wraps. It was already used in `ORDER BY` and is now used in the selection too. The selection is applied to the outer query over that subquery, which is where the existing filters on type and wallet already run, so the aliased columns are in scope there.

The state is stored once in `PreferenceManager` rather than held per tab, so the two debt tabs cannot disagree about it, and both read it when they build their query.

Toggling it runs the query again on both tabs, through a `reloadList` on `CursorListFragment` that mirrors what a wallet change already does. The pager keeps both tabs alive at this tab count, so the tab that is not on screen has to be told rather than left to rebuild itself.

The toolbar menu is inflated fresh every time the screen is set up, and the resource declares no tick, so the tick is read back from the stored value at that point rather than left at what the resource carries.

## What this touches

The debts screen gains a menu where it had none. `CursorListFragment` gains one public method, which is additive and does nothing before a view exists. `DebtListFragment` gains one clause on its selection. Nothing changes about how debts are sorted, grouped, drawn or stored.

## Tested

On an API 36 emulator against five seeded rows: a pending debt, a debt paid off in full by a confirmed payment, a debt archived by hand, a pending credit, and an archived credit.

With the filter off, all five are listed. Turned on from the debt tab, that tab drops the pending debt and keeps the two finished ones, and the credit tab, which was not on screen at the time, drops the pending credit and keeps the archived one. Since neither tab is destroyed at this tab count, the credit tab had not been rebuilt, so it can only have been told.

Turned off again, all five come back. Leaving the screen and returning keeps both the filtered list and the tick.

## What this does not address

With the filter on and nothing finished, the empty text still reads that no debt was found rather than naming the filter as the reason.

Not verified on any physical device.
