### PR TITLE
Say the debt list is filtered rather than empty when it is filtered

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
@@ -25,6 +25,7 @@ import android.database.Cursor;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.fragment.app.Fragment;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
@@ -101,6 +102,16 @@ public abstract class CursorListFragment extends Fragment implements SwipeRefres
     public void onRefresh() {
         getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.REFRESHING);
+    }
+
+    /**
+     * Change the text shown when the list comes back with nothing in it. The list applies this
+     * when it next becomes empty, so it has to be set before the query it belongs to finishes.
+     */
+    protected void setEmptyText(@StringRes int stringRes) {
+        if (mAdvancedRecyclerView != null) {
+            mAdvancedRecyclerView.setEmptyText(stringRes);
+        }
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/DebtListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/DebtListFragment.java
@@ -107,11 +107,15 @@ public class DebtListFragment extends CursorListFragment implements DebtCursorAd
                 selectionArgs = new String[] {String.valueOf(currentWallet)};
             }
             selection += " AND " + Contract.Debt.TYPE + " = " + String.valueOf(debtType.getValue());
-            if (PreferenceManager.isDebtFinishedOnlyEnabled()) {
+            // read once and used for both, so an empty list cannot claim there are no debts at all
+            // while the query that emptied it was only asking for the finished ones
+            boolean finishedOnly = PreferenceManager.isDebtFinishedOnlyEnabled();
+            if (finishedOnly) {
                 // the same expression the sort and the grouping use, so the filter cannot decide a
                 // debt is finished while the header above it says otherwise
                 selection += " AND " + DebtHeaderCursor.SQL_IS_SETTLED + " = 1";
             }
+            setEmptyText(finishedOnly ? R.string.message_no_finished_debt_found : R.string.message_no_debt_found);
             // a debt that has been paid off in full is finished whether or not anyone remembered to
             // archive it, so it belongs below the ones that still need attention. The grouping
             // reads the same value back out of the projection, so the two cannot drift apart.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="message_no_transfer_found">"No transfer found"</string>
     <string name="message_no_category_found">"No category found"</string>
     <string name="message_no_debt_found">"No debt found"</string>
+    <string name="message_no_finished_debt_found">"No finished debt found"</string>
     <string name="message_no_budget_found">"No budget found"</string>
     <string name="message_no_saving_found">"No saving found"</string>
     <string name="message_no_event_found">"No event found"</string>


### PR DESCRIPTION
Closes #100.

With the finished filter on and nothing finished in that tab, the debt list said "No debt found", which is what it says when there are no debts at all. The filter is stored and survives a restart, so the only thing telling the reader why the list looks empty could be a tick they set days earlier, behind the overflow menu.

## The mechanism

The empty text came from a single string set once when the list was built, in `onPrepareRecyclerView`. The filter is read separately, when the query is made. The two were never connected.

The filter is now read once and used for both, so the message and the query cannot disagree about what was asked for.

It is set from `onCreateLoader` rather than beside the other view setup because `AdvancedRecyclerView.setEmptyText` only stores the resource. The text is applied by `setState`, and `setState` returns early when the state has not changed. Setting it while the query is being made puts it in place before that query can empty the list, which is the transition that applies it.

`CursorListFragment` gained a setter for it, since the view it belongs to is private there, beside the reload the filter already uses.

The unfiltered message stays where it was, as part of how the list is built. Nothing reaches the empty state without a query having been made first, so the conditional one replaces it before it is ever read.

## Tested

On an API 36 emulator, four checks.

With the filter on, one pending credit and nothing finished, the tab reads "No finished debt found" where it read "No debt found" before. Toggling the filter off brings the pending credit back. Toggling it on again returns the new message, so it works on a live toggle and not only on a fresh start.

The fourth is the control: with the filter off and the last credit deleted, so the tab is empty because there is genuinely nothing there, it still reads "No debt found". The message follows the filter rather than replacing the old one outright.

## What this does not address

The other lists in the app keep a single empty message each. None of them filters itself this way, so none of them has the same gap.

Not verified on any physical device.
