### PR TITLE
Name the months from the locale instead of cutting them to three characters

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/LabelFit.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/LabelFit.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.view.calendar;
+
+import android.text.Layout;
+import android.text.TextPaint;
+
+/**
+ * One text size for a whole strip of fixed width cells, small enough that every label in it
+ * measures inside a cell.
+ *
+ * Both calendar strips shorten a localized date name to fit a cell they cannot resize. Cutting
+ * to a character count was how they used to do it, which assumes a language distinguishes its
+ * names within that count, so overflow is sized away here instead. The size is derived once for
+ * the strip rather than per cell, because a size per cell would let neighbouring labels render
+ * at different sizes.
+ */
+final class LabelFit {
+
+    private LabelFit() {
+    }
+
+    /**
+     * @param paint     the label's paint, carrying the text size to start from
+     * @param labels    every label the strip can render in the current locale
+     * @param available the width a label has inside one cell, in pixels
+     * @return the starting size unchanged when the labels already fit at it, and also when
+     *         {@code available} is not positive, which is the case before the cell has a width
+     */
+    static float sizeToFit(TextPaint paint, String[] labels, int available) {
+        float size = paint.getTextSize();
+        if (available <= 0) {
+            return size;
+        }
+        // Step down and measure again rather than deriving a ratio from the overflow and trusting
+        // it. Every label is measured rather than only the one that came out widest at the
+        // starting size, which costs nothing at these counts and removes the question of whether
+        // that ranking holds at every size.
+        TextPaint measured = new TextPaint(paint);
+        while (size > 1f && !fits(measured, labels, available)) {
+            size -= 0.5f;
+            measured.setTextSize(size);
+        }
+        return size;
+    }
+
+    private static boolean fits(TextPaint paint, String[] labels, int available) {
+        for (String label : labels) {
+            // Rounded up, which is what a TextView does with the width it asks for.
+            if (Math.ceil(Layout.getDesiredWidth(label, paint)) > available) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/MonthView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/MonthView.java
@@ -24,7 +24,9 @@ import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import android.text.TextPaint;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -32,14 +34,16 @@ import android.widget.TextView;
 
 import com.oriondev.moneywallet.R;
 
-import java.text.DateFormatSymbols;
+import android.icu.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.Locale;
 
 public class MonthView extends RecyclerView {
 
     // per instance so the names follow an app language change, which rebuilds this view
-    private final String[] months = DateFormatSymbols.getInstance().getShortMonths();
+    private final String[] months = abbreviatedMonths();
+
+    private float labelSize = 0f;
 
     private MonthAdapter adapter;
     private LinearLayoutManager layoutManager;
@@ -49,7 +53,6 @@ public class MonthView extends RecyclerView {
 
     private int startYear = 1970, startMonth = 0;
     private int yearDigitCount = 2;
-    private boolean yearOnNewLine = false;
 
     private int selectedYear, selectedMonth;
     private int selectedPosition = -1;
@@ -68,6 +71,77 @@ public class MonthView extends RecyclerView {
     public MonthView(Context context, @Nullable AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
         init();
+    }
+
+    /**
+     * The abbreviated month names, indexed by the {@link Calendar#JANUARY} to
+     * {@link Calendar#DECEMBER} values.
+     *
+     * Standalone rather than the form a full date uses, because this strip names a month on its
+     * own rather than inside a date. Catalan is the case that showed it here: its formatting
+     * abbreviations are de gen., de febr. and so on, so cutting them to three characters left
+     * five of the seven visible cells reading DE.
+     */
+    private static String[] abbreviatedMonths() {
+        return new DateFormatSymbols(Locale.getDefault()).getMonths(
+                DateFormatSymbols.STANDALONE, DateFormatSymbols.ABBREVIATED);
+    }
+
+    private String monthName(int month) {
+        return months[month].toUpperCase(Locale.getDefault());
+    }
+
+    /**
+     * Every label this strip can render, each carrying a stand in for its year.
+     *
+     * The year differs per cell, so the stand in is the widest digit repeated rather than one
+     * chosen year, which keeps the derived size from depending on which months and years
+     * happened to be on screen when it was derived.
+     */
+    private String[] widestLabels(TextPaint paint) {
+        String year = widestYear(paint);
+        String[] labels = new String[months.length];
+        for (int month = 0; month < months.length; month++) {
+            labels[month] = monthName(month) + year;
+        }
+        return labels;
+    }
+
+    private String widestYear(TextPaint paint) {
+        if (yearDigitCount <= 0) {
+            return "";
+        }
+        char widest = '0';
+        float widestWidth = 0f;
+        for (char digit = '0'; digit <= '9'; digit++) {
+            float width = paint.measureText(String.valueOf(digit));
+            if (width > widestWidth) {
+                widestWidth = width;
+                widest = digit;
+            }
+        }
+        StringBuilder year = new StringBuilder(" ");
+        for (int digit = 0; digit < yearDigitCount; digit++) {
+            year.append(widest);
+        }
+        return year.toString();
+    }
+
+    /**
+     * One text size for every month label, small enough that each of them measures within a
+     * cell.
+     *
+     * Sized rather than cut, because cutting to a character count is the defect this change
+     * removes, and sized rather than left to wrap: read off the running strip in Malayalam,
+     * master renders month labels at two different heights in one row.
+     */
+    private float labelSize(TextView sample, View cell) {
+        if (labelSize > 0f) {
+            return labelSize;
+        }
+        int available = cell.getLayoutParams().width - cell.getPaddingLeft() - cell.getPaddingRight();
+        labelSize = LabelFit.sizeToFit(sample.getPaint(), widestLabels(sample.getPaint()), available);
+        return labelSize;
     }
 
     private void init() {
@@ -251,14 +325,6 @@ public class MonthView extends RecyclerView {
         return yearDigitCount;
     }
 
-    public void setYearOnNewLine(boolean yearOnNewLine) {
-        this.yearOnNewLine = yearOnNewLine;
-    }
-
-    public boolean isYearOnNewLine() {
-        return yearOnNewLine;
-    }
-
     public void setFirstDate(int startYear, int startMonth) {
         this.startYear = startYear;
         this.startMonth = startMonth;
@@ -330,6 +396,7 @@ public class MonthView extends RecyclerView {
 
             indicator = root.findViewById(R.id.mti_view_indicator);
             lbl = root.findViewById(R.id.mti_month_lbl);
+            lbl.setTextSize(TypedValue.COMPLEX_UNIT_PX, labelSize(lbl, root));
 
             root.setOnClickListener(new OnClickListener() {
                 @Override
@@ -343,10 +410,9 @@ public class MonthView extends RecyclerView {
             this.year = year;
             this.month = month;
 
-            String text = months[month];
-            text = text.substring(0, Math.min(text.length(), 3)).toUpperCase(Locale.getDefault());
+            String text = monthName(month);
             if (yearDigitCount > 0) {
-                text += yearOnNewLine ? "\n" : " ";
+                text += " ";
                 text += year % (int) Math.pow(10, yearDigitCount);
             }
             lbl.setText(text);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
@@ -24,8 +24,6 @@ import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import android.text.Layout;
-import android.text.TextPaint;
 import android.text.format.DateUtils;
 import android.util.AttributeSet;
 import android.util.TypedValue;
@@ -107,46 +105,33 @@ public class TimelineView extends RecyclerView {
     }
 
     /**
+     * The seven labels this strip renders. Built from the rendered form rather than passing the
+     * array behind it, which is indexed from {@link Calendar#SUNDAY} rather than from zero and
+     * does not carry the uppercasing this class adds.
+     */
+    private String[] dayLabels() {
+        String[] labels = new String[Calendar.SATURDAY - Calendar.SUNDAY + 1];
+        for (int dayOfWeek = Calendar.SUNDAY; dayOfWeek <= Calendar.SATURDAY; dayOfWeek++) {
+            labels[dayOfWeek - Calendar.SUNDAY] = dayLabel(dayOfWeek);
+        }
+        return labels;
+    }
+
+    /**
      * One text size for all seven weekday labels, small enough that each of them measures
-     * within a cell. Returns the size unchanged if the cell has no fixed width to fit to,
-     * and for most locales it returns it unchanged anyway.
+     * within a cell. For most locales it returns the starting size unchanged.
      *
-     * Of the locales bundled here only Malayalam grows wide enough to need this, and only
-     * at accessibility font scales. The label comes from the system locale rather than
-     * from those translations, so the check is not limited to that set. Overflow is sized
-     * away rather than cut because cutting is the defect this class just removed, and one
-     * size is derived for the whole strip so that neighbouring letters match, where a size
-     * per cell would let adjacent letters differ.
+     * Of the locales bundled here only Malayalam grows wide enough to need this, and only at
+     * accessibility font scales. The label comes from the system locale rather than from those
+     * translations, so the check is not limited to that set.
      */
     private float dayLabelSize(TextView sample, View cell) {
         if (dayLabelSize > 0f) {
             return dayLabelSize;
         }
-        dayLabelSize = sample.getTextSize();
         int available = cell.getLayoutParams().width - cell.getPaddingLeft() - cell.getPaddingRight();
-        if (available <= 0) {
-            return dayLabelSize;
-        }
-        // Step down and measure again until every label fits, rather than deriving a ratio and
-        // trusting it. Measuring every label rather than only the one that came out widest
-        // at the starting size costs nothing here and removes the question of whether that
-        // ranking holds at every size.
-        TextPaint paint = new TextPaint(sample.getPaint());
-        while (dayLabelSize > 1f && !labelsFit(paint, available)) {
-            dayLabelSize -= 0.5f;
-            paint.setTextSize(dayLabelSize);
-        }
+        dayLabelSize = LabelFit.sizeToFit(sample.getPaint(), dayLabels(), available);
         return dayLabelSize;
-    }
-
-    private boolean labelsFit(TextPaint paint, int available) {
-        for (int dayOfWeek = Calendar.SUNDAY; dayOfWeek <= Calendar.SATURDAY; dayOfWeek++) {
-            // Rounded up, which is what a TextView does with the width it asks for.
-            if (Math.ceil(Layout.getDesiredWidth(dayLabel(dayOfWeek), paint)) > available) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private void init() {

--- a/app/src/main/res/layout/view_mti_item_month.xml
+++ b/app/src/main/res/layout/view_mti_item_month.xml
@@ -47,8 +47,8 @@
         android:layout_marginTop="16dp"
         android:ellipsize="end"
         android:gravity="center"
-        android:maxLength="8"
+        android:maxLines="1"
         android:textSize="@dimen/view_mti_month_lbl_text"
-        tools:text="Feb\n17"/>
+        tools:text="Feb 17"/>
 
 </FrameLayout>


### PR DESCRIPTION
Closes #75. The weekday half of that issue shipped in `e4a98d6`; this is the month strip, which was left open pending a decision recorded in the thread.

## What was wrong

`MonthView.bind` took the abbreviated month name for a full date and cut it with `substring(0, 3)`, then upper cased. Cutting to a character count assumes a language distinguishes its months within that count.

Read off the running strip on an emulator, master build, four locales:

| locale | distinct labels | what it renders |
|---|---|---|
| Catalan | 3 of 7 | five of the seven visible cells read `DE` plus the year |
| Greek | 6 of 7 | June and July are the same three characters |
| Malayalam | 7 of 7 | the labels render at two different heights in one row |
| English | 7 of 7 | correct |

Catalan is the unreadable one. Its formatting abbreviations are `de gen.`, `de febr.` and so on, so three characters is the preposition and a space.

## The fix, and why it is not the two options in the thread

Two things were wrong and they need different answers.

**The names.** They now come from `android.icu.text.DateFormatSymbols` with `STANDALONE` and `ABBREVIATED`. Standalone is the form for a month named on its own rather than inside a date, and that is what drops the Catalan `de`. That class is available at the project `minSdk` of 24, so no desugaring and no new dependency, and the weekday strip already uses it. Lint reports no `NewApi` issue anywhere in this variant.

**The cut.** Deleting `substring(0, 3)` leaves a label that is no longer three characters, in a cell that cannot grow. Left to wrap, the label renders at more than one height in a single row. That is not hypothetical: master renders Malayalam that way today, with the cut still in place.

The thread weighed `lines="2"`, which costs app bar height in every locale, against `maxLines="1"` alone, which lets a long name eat the year. Neither is needed. The strip derives one text size for the whole row and steps it down, checking again each step, until every label fits. That is what `TimelineView` already does for the weekday letters, so the loop moves into `LabelFit` and both strips call it. Nothing wraps, so the height is uniform without spending any app bar height.

The size is derived from every month name, each carrying the widest digit repeated in place of a year, so it does not depend on which cells happened to be built first.

## What this touches

- `MonthView` name source, label composition and sizing
- `TimelineView` calls the extracted helper; its behaviour is unchanged
- `LabelFit`, new, holds the sizing loop that used to live in `TimelineView`
- `view_mti_item_month.xml` drops `maxLength="8"` and takes `maxLines="1"`, keeping the `ellipsize` that was already there as the last resort
- `setYearOnNewLine` is deleted. Nothing called it, and it put the year on a second line, which the one line label contradicts.

## What I tested

Two builds of the two trees on the same emulator, verified to be different builds rather than assumed: `LabelFit` is present in the branch dex and absent from master's. Labels read out of the view hierarchy rather than off a screenshot.

| locale | master | this branch |
|---|---|---|
| Catalan | 3 distinct of 7 | 7 of 7 |
| Greek | 6 of 7 | 7 of 7 |
| English | 7 of 7 | identical to master |
| Malayalam | 7 of 7, label heights 55 and 99 px | 7 of 7, single height 41 px |

Every cell carries its year in both builds. The weekday strip was captured from the same dumps and renders identically in all four locales, which is the control on the extraction.

The available width is computed as the cell width minus its padding. At the emulator's density that predicts 147 px, and the label nodes are 147 px.

## What I did not test

Accessibility font scales. Everything above was captured at the default scale. The cell width is a fixed dimension and does not grow with the font, so at larger scales the labels grow while the cell does not, and I have not checked where the step down lands.

There is no unit test. `LabelFit` measures through `Layout.getDesiredWidth` and the names come from `android.icu`, so neither is reachable from a JVM test, and adding a seam for one implementation is not worth it.
