### PR TITLE
Say why an item transaction list is empty

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelCursorListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelCursorListFragment.java
@@ -23,6 +23,7 @@ import android.database.Cursor;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
 import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -58,6 +59,16 @@ public abstract class MultiPanelCursorListFragment extends MultiPanelFragment im
     }
 
     protected abstract void onPrepareRecyclerView(AdvancedRecyclerView recyclerView);
+
+    /**
+     * Replace the message shown when the list has nothing in it. Available after the primary
+     * panel has been created, which is where the recycler view is inflated.
+     */
+    protected void setEmptyText(@StringRes int resId) {
+        if (mAdvancedRecyclerView != null) {
+            mAdvancedRecyclerView.setEmptyText(resId);
+        }
+    }
 
     protected abstract AbstractCursorAdapter onCreateAdapter();
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/TransactionMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/TransactionMultiPanelFragment.java
@@ -28,6 +28,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.loader.app.LoaderManager;
 import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -60,6 +62,14 @@ public class TransactionMultiPanelFragment extends MultiPanelCursorListItemFragm
     private static final String FILTER_END_DATE = "TransactionMultiPanelFragment::Arguments::FilterEndDate";
 
     private static final String SECONDARY_PANEL_TAG = "TransactionMultiPanelFragment::Tag::SecondaryPanel";
+
+    private static final int HIDDEN_TRANSACTIONS_LOADER_ID = 60002;
+
+    private static final String[] HIDDEN_PROJECTION = new String[] {
+            Contract.Transaction.WALLET_ID,
+            Contract.Transaction.WALLET_COUNT_IN_TOTAL,
+            Contract.Transaction.DATE
+    };
 
     public enum FilterType {
         CATEGORY,
@@ -123,37 +133,9 @@ public class TransactionMultiPanelFragment extends MultiPanelCursorListItemFragm
         Activity activity = getActivity();
         Bundle arguments = getArguments();
         if (activity != null && arguments != null) {
-            Uri uri = DataContentProvider.CONTENT_TRANSACTIONS;
-            FilterType type = (FilterType) arguments.getSerializable(FILTER_TYPE);
-            long itemId = arguments.getLong(FILTER_ID);
+            Uri uri = buildItemTransactionsUri(arguments);
             Date startDate = (Date) arguments.getSerializable(FILTER_START_DATE);
             Date endDate = (Date) arguments.getSerializable(FILTER_END_DATE);
-            if (type != null) {
-                switch (type) {
-                    case CATEGORY:
-                        uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_CATEGORIES, itemId);
-                        break;
-                    case DEBT:
-                        uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, itemId);
-                        break;
-                    case BUDGET:
-                        uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_BUDGETS, itemId);
-                        break;
-                    case SAVING:
-                        uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, itemId);
-                        break;
-                    case EVENT:
-                        uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_EVENTS, itemId);
-                        break;
-                    case PLACE:
-                        uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_PLACES, itemId);
-                        break;
-                    case PERSON:
-                        uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_PEOPLE, itemId);
-                        break;
-                }
-                uri = Uri.withAppendedPath(uri, "transactions");
-            }
             String selection;
             String[] selectionArgs;
             long currentWallet = PreferenceManager.getCurrentWallet();
@@ -165,17 +147,170 @@ public class TransactionMultiPanelFragment extends MultiPanelCursorListItemFragm
                 selectionArgs = new String[] {String.valueOf(currentWallet)};
             }
             selection += " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('now', 'localtime')";
-            if (startDate != null) {
-                selection += " AND DATETIME(" + Contract.Transaction.DATE + ") >= DATETIME('" + DateUtils.getSQLDateTimeString(startDate) + "')";
-            }
-            if (endDate != null) {
-                selection += " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('" + DateUtils.getSQLDateTimeString(endDate) + "')";
+            String dateRange = buildDateRangeSelection(startDate, endDate);
+            if (dateRange != null) {
+                selection += " AND " + dateRange;
             }
             String sortOrder = Contract.Transaction.DATE + " DESC";
             Group groupType = PreferenceManager.getCurrentGroupType();
             return new WrappedCursorLoader(activity, uri, null, selection, selectionArgs, sortOrder, groupType, startDate, endDate);
         }
         return null;
+    }
+
+    /**
+     * The content uri of the transactions belonging to the item this screen was opened for.
+     * Falls back to the unfiltered transaction uri when there is no item, which is the same
+     * default the loader has always carried.
+     */
+    private static Uri buildItemTransactionsUri(@Nullable Bundle arguments) {
+        Uri uri = DataContentProvider.CONTENT_TRANSACTIONS;
+        if (arguments == null) {
+            return uri;
+        }
+        FilterType type = (FilterType) arguments.getSerializable(FILTER_TYPE);
+        if (type == null) {
+            return uri;
+        }
+        long itemId = arguments.getLong(FILTER_ID);
+        switch (type) {
+            case CATEGORY:
+                uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_CATEGORIES, itemId);
+                break;
+            case DEBT:
+                uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, itemId);
+                break;
+            case BUDGET:
+                uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_BUDGETS, itemId);
+                break;
+            case SAVING:
+                uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, itemId);
+                break;
+            case EVENT:
+                uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_EVENTS, itemId);
+                break;
+            case PLACE:
+                uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_PLACES, itemId);
+                break;
+            case PERSON:
+                uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_PEOPLE, itemId);
+                break;
+        }
+        return Uri.withAppendedPath(uri, "transactions");
+    }
+
+    /**
+     * The period the caller asked for, which is scope this screen was given rather than scope it
+     * applies on its own. Null when the caller asked for no period at all.
+     */
+    @Nullable
+    private static String buildDateRangeSelection(@Nullable Date startDate, @Nullable Date endDate) {
+        StringBuilder builder = new StringBuilder();
+        if (startDate != null) {
+            builder.append("DATETIME(").append(Contract.Transaction.DATE).append(") >= DATETIME('")
+                    .append(DateUtils.getSQLDateTimeString(startDate)).append("')");
+        }
+        if (endDate != null) {
+            if (builder.length() > 0) {
+                builder.append(" AND ");
+            }
+            builder.append("DATETIME(").append(Contract.Transaction.DATE).append(") <= DATETIME('")
+                    .append(DateUtils.getSQLDateTimeString(endDate)).append("')");
+        }
+        return builder.length() > 0 ? builder.toString() : null;
+    }
+
+    /**
+     * An empty list on this screen has three meanings the user cannot tell apart: the item has
+     * no transactions at all, it has some in a wallet that is not the selected one, or it has
+     * some dated in the future. {@link #onCreateLoader(int, Bundle)} hides the second and third
+     * without saying so, so when it comes back with nothing, ask what it is hiding.
+     */
+    @Override
+    public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
+        boolean empty = cursor == null || cursor.getCount() == 0;
+        if (empty) {
+            // back to the plain message before the base makes it visible: a refined one from an
+            // earlier load would otherwise stand on screen while this load is being explained
+            setEmptyText(R.string.message_no_transaction_found);
+        }
+        super.onLoadFinished(loader, cursor);
+        if (empty) {
+            getLoaderManager().restartLoader(HIDDEN_TRANSACTIONS_LOADER_ID, null, mHiddenTransactionsCallbacks);
+        } else {
+            getLoaderManager().destroyLoader(HIDDEN_TRANSACTIONS_LOADER_ID);
+        }
+    }
+
+    private final LoaderManager.LoaderCallbacks<Cursor> mHiddenTransactionsCallbacks = new LoaderManager.LoaderCallbacks<Cursor>() {
+
+        @NonNull
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, @Nullable Bundle args) {
+            Bundle arguments = getArguments();
+            Date startDate = arguments != null ? (Date) arguments.getSerializable(FILTER_START_DATE) : null;
+            Date endDate = arguments != null ? (Date) arguments.getSerializable(FILTER_END_DATE) : null;
+            // the same item, the same period, without the two clauses the user cannot see
+            return new CursorLoader(getActivity(), buildItemTransactionsUri(arguments), HIDDEN_PROJECTION,
+                    buildDateRangeSelection(startDate, endDate), null, null);
+        }
+
+        @Override
+        public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor data) {
+            setEmptyText(describeHiddenTransactions(data));
+        }
+
+        @Override
+        public void onLoaderReset(@NonNull Loader<Cursor> loader) {
+            // the message holds a copy of the string, not the cursor
+        }
+
+    };
+
+    /**
+     * Walks the rows on the main thread, and stops early only once both answers are known, so
+     * an item with many transactions and none of them dated ahead is read in full. The cost is
+     * bounded by that one item's transactions and is paid only on a list that is already empty.
+     *
+     * @param cursor every transaction of this item within the period asked for, including the
+     *               ones the list itself filters out.
+     * @return the message for an empty list, naming what is being hidden from it.
+     */
+    @StringRes
+    private int describeHiddenTransactions(@Nullable Cursor cursor) {
+        boolean otherWallets = false;
+        boolean future = false;
+        if (cursor != null) {
+            long currentWallet = PreferenceManager.getCurrentWallet();
+            // compared as text rather than parsed: the column and this string are both
+            // yyyy-MM-dd HH:mm:ss in local time, which is the comparison the query itself makes
+            String now = DateUtils.getSQLDateTimeString(new Date());
+            int indexWalletId = cursor.getColumnIndex(Contract.Transaction.WALLET_ID);
+            int indexCountInTotal = cursor.getColumnIndex(Contract.Transaction.WALLET_COUNT_IN_TOTAL);
+            int indexDate = cursor.getColumnIndex(Contract.Transaction.DATE);
+            for (int i = 0; i < cursor.getCount() && !(otherWallets && future); i++) {
+                cursor.moveToPosition(i);
+                boolean inSelectedWallet = currentWallet == PreferenceManager.TOTAL_WALLET_ID
+                        ? cursor.getInt(indexCountInTotal) == 1
+                        : cursor.getLong(indexWalletId) == currentWallet;
+                if (!inSelectedWallet) {
+                    otherWallets = true;
+                } else {
+                    // in the selected wallet and still missing from the list, so the date is
+                    // the only clause that can be holding it back
+                    String date = cursor.getString(indexDate);
+                    future |= date != null && date.compareTo(now) > 0;
+                }
+            }
+        }
+        if (otherWallets && future) {
+            return R.string.message_no_transaction_found_other_wallets_and_future;
+        } else if (otherWallets) {
+            return R.string.message_no_transaction_found_other_wallets;
+        } else if (future) {
+            return R.string.message_no_transaction_found_future;
+        }
+        return R.string.message_no_transaction_found;
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/AdvancedRecyclerView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/AdvancedRecyclerView.java
@@ -82,8 +82,14 @@ public class AdvancedRecyclerView extends SwipeRefreshLayout {
         mRecyclerView.setAdapter(adapter);
     }
 
+    /**
+     * The text is also written by {@link #setState(State)}. Setting it on the view here as well
+     * is what lets a caller refine the message after the empty view is already on screen, with
+     * no further state change to carry it there.
+     */
     public void setEmptyText(@StringRes int resId) {
         mEmptyTextRes = resId;
+        mEmptyTextView.setText(resId);
     }
 
     public void setErrorText(@StringRes int resId) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,6 +334,9 @@
     <string name="message_no_currency_found">"No currency found"</string>
     <string name="message_no_wallet_found">"No wallet found"</string>
     <string name="message_no_transaction_found">"No transaction found"</string>
+    <string name="message_no_transaction_found_other_wallets">"No transaction found in the selected wallet. There are transactions in other wallets."</string>
+    <string name="message_no_transaction_found_future">"No transaction found in the selected wallet. There are transactions dated in the future."</string>
+    <string name="message_no_transaction_found_other_wallets_and_future">"No transaction found in the selected wallet. There are transactions in other wallets, and transactions dated in the future."</string>
     <string name="message_no_transfer_found">"No transfer found"</string>
     <string name="message_no_category_found">"No category found"</string>
     <string name="message_no_debt_found">"No debt found"</string>


### PR DESCRIPTION
Fixes #82.

## The problem

Every "show this item's transactions" route applies two clauses nothing on screen accounts for: the wallet selected in the drawer, and a date no later than now. When they filter everything out, the list reads "No transaction found", which is the same message the app shows for an item that has nothing anywhere.

`0458290` already put the selected wallet in the toolbar subtitle, so the scope is visible. The empty message was not part of that change, and the message is the part a reader is actually looking at when the screen is blank.

## The reported case, before and after

The repro in #82 is a person with a transaction in a different wallet. Run on an emulator with two wallets, against a person holding one row in the wallet that is not selected, alongside a person holding nothing at all.

| | person with a row in the other wallet | person with nothing anywhere |
|---|---|---|
| master `369a137` | No transaction found | No transaction found |
| this branch | No transaction found in the selected wallet. There are transactions in other wallets. | No transaction found |

The second column is the control. Its message does not change, so the new text follows the data instead of replacing the old text outright.

## How it works

When the primary loader returns no rows, a second loader asks for the same item over the same period with those two clauses dropped. No rows means the item really is empty and the message stays as it was. Rows are sorted into the two reasons and the message names whichever apply.

A row counts as hidden by the date only when it is in the selected wallet already, because the wallet clause is then satisfied and the date is the only clause left that can hold it back. Under the total wallet, in scope means the row's wallet carries `count_in_total`, which is the test the list itself makes.

The period the caller asked for is kept in both queries. The two period detail screens pass a start and an end, and that is scope this screen was handed rather than scope it applies on its own, so reaching past it would count rows the caller never asked about.

## What this touches

Four files. `TransactionMultiPanelFragment` carries the second loader and the classification. `MultiPanelCursorListFragment` gains a protected forwarder so a subclass can replace the empty message. `AdvancedRecyclerView.setEmptyText` now writes the text to the view as well as storing it, because storing alone only works while the message is set during setup, and `setState` is the only other writer with no state change following an already empty list. The five call sites that existed before this change all set the text during setup, so each writes exactly the text `setState` would have applied afterwards. Three strings are added and none is removed.

Also run: a category with rows only in a second wallet, a category with a row dated ahead, a category with one of each, a category with rows visible, a category with nothing, and the total wallet with the second wallet excluded from it, where the excluded row reads as another wallet and the toolbar reads Total. 108 unit tests, 0 failures, read from the result XML.

## Costs and limits

The second query runs only on an empty list, so the normal path pays nothing. Its rows are walked on the main thread, and the walk stops early only once both answers are known, so an item with many rows and none dated ahead is read in full. The cost is bounded by that one item's transactions.

Budgets are the one filter type this cannot reach. Six of the seven route through `getTransactions`, which carries no date clause of its own, but `getBudgetTransactions` builds its own query and bakes the same date test into all three of its branches, inside the derived table that the projection is applied outside of. A budget with a row dated ahead therefore still reads "No transaction found", confirmed on the emulator next to a budget whose row renders, which is what rules out a broken fixture. A budget also cannot produce the other wallets message and should not: its rows are joined through `budget_wallets`, so a transaction in a wallet outside the budget is not part of that budget at all.

## Not in this change

The empty message says where the transactions are and offers no way to get there. A tap target that switches to the wallet holding them is a separate change, and it is only correct when there is exactly one such wallet, so it needs the grouping this branch does not do.

The screen title is still the static menu string and names neither the item nor the wallet.
