### PR TITLE
Stop the calculator rounding a division to the dividend's scale

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
@@ -27,6 +27,7 @@ import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.MoneyScale;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 
 /**
  * Created by andrea on 31/03/18.
@@ -153,13 +154,22 @@ public class EquationSolver {
                     result = first.multiply(second);
                     break;
                 case DIVISION:
-                    result = first.divide(second,BigDecimal.ROUND_HALF_EVEN);
+                    // divide(divisor, roundingMode) returns a value whose scale is the dividend's,
+                    // so a 10 typed with no decimals rounded 10 / 4 to 2. Divide at 16 significant
+                    // digits instead. Narrowing to the currency scale here would narrow every step
+                    // of a chain rather than the answer: with a zero decimal currency, 10.0 / 4 * 4
+                    // would give 8. getResult converts the finished equation to minor units, and
+                    // truncates whatever is left below the currency scale, as it does for a typed
+                    // amount with too many decimals.
+                    result = first.divide(second, MathContext.DECIMAL64);
                     break;
                 default:
                     result = BigDecimal.valueOf(0);
                     break;
             }
-            mFirstNumber = String.valueOf(result);
+            // String.valueOf renders a small enough result in scientific notation, the product
+            // 0.001 * 0.0001 as 1E-7, and the next keypress appends to whatever string lands here.
+            mFirstNumber = result.toPlainString();
             if (mFirstNumber.endsWith(".0")) {
                 mFirstNumber = mFirstNumber.substring(0, mFirstNumber.length() - 2);
             }

--- a/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
@@ -80,6 +80,10 @@ public class EquationSolver {
         outState.putString(SS_FIRST_NUMBER, mFirstNumber);
         outState.putString(SS_SECOND_NUMBER, mSecondNumber);
         outState.putSerializable(SS_OPERATION_NUMBER, mOperation);
+        // The constructor reads this key back, and the activity only calls setValue when there is
+        // no saved state, so leaving the currency out made getResult return the typed number
+        // rather than its minor units after a rotation: 12.50 came back as 12, not 1250.
+        outState.putParcelable(SS_CURRENCY, mCurrency);
     }
 
     public void clear() {

--- a/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
@@ -28,6 +28,7 @@ import com.oriondev.moneywallet.model.MoneyScale;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.math.RoundingMode;
 
 /**
  * Created by andrea on 31/03/18.
@@ -38,6 +39,7 @@ public class EquationSolver {
     private static final String SS_SECOND_NUMBER = "EquationSolver::SavedState::SecondNumber";
     private static final String SS_OPERATION_NUMBER = "EquationSolver::SavedState::Operation";
     private static final String SS_CURRENCY = "EquationSolver::SavedState::Currency";
+    private static final String SS_COMPUTED = "EquationSolver::SavedState::Computed";
 
     private final Controller mController;
 
@@ -47,6 +49,13 @@ public class EquationSolver {
     private Operation mOperation;
     @VisibleForTesting
     /*package-local*/ CurrencyUnit mCurrency;
+    /**
+     * True while mFirstNumber holds an answer an operation produced rather than a number the
+     * keypad typed. getResult rounds an answer to the currency scale and leaves a typed number
+     * to toMinorUnits, which truncates whatever will not fit.
+     */
+    @VisibleForTesting
+    /*package-local*/ boolean mComputed;
 
     public EquationSolver(Bundle savedInstanceState, Controller controller) {
         mController = controller;
@@ -55,11 +64,13 @@ public class EquationSolver {
             mSecondNumber = savedInstanceState.getString(SS_SECOND_NUMBER, null);
             mOperation = (Operation) savedInstanceState.getSerializable(SS_OPERATION_NUMBER);
             mCurrency = savedInstanceState.getParcelable(SS_CURRENCY);
+            mComputed = savedInstanceState.getBoolean(SS_COMPUTED, false);
         } else {
             mFirstNumber = "0";
             mSecondNumber = null;
             mOperation = null;
             mCurrency = null;
+            mComputed = false;
         }
         updateDisplaySafely();
     }
@@ -73,6 +84,7 @@ public class EquationSolver {
         mSecondNumber = null;
         mOperation = null;
         mCurrency = currency;
+        mComputed = false;
         updateDisplaySafely();
     }
 
@@ -84,12 +96,17 @@ public class EquationSolver {
         // no saved state, so leaving the currency out made getResult return the typed number
         // rather than its minor units after a rotation: 12.50 came back as 12, not 1250.
         outState.putParcelable(SS_CURRENCY, mCurrency);
+        // Same trap as the currency above: a key the bundle does not carry comes back as the
+        // default, so an answer still on the display after a rotation would be truncated rather
+        // than rounded when it reaches the ledger.
+        outState.putBoolean(SS_COMPUTED, mComputed);
     }
 
     public void clear() {
         mFirstNumber = "0";
         mSecondNumber = null;
         mOperation = null;
+        mComputed = false;
         updateDisplaySafely();
     }
 
@@ -99,10 +116,12 @@ public class EquationSolver {
         } else if (mOperation != null) {
             mOperation = null;
         } else if (mFirstNumber != null && !mFirstNumber.isEmpty()) {
-            mFirstNumber = mFirstNumber.substring(0, mFirstNumber.length() - 1);
-            if (mFirstNumber.isEmpty()) {
-                mFirstNumber = "0";
+            String number = mFirstNumber.substring(0, mFirstNumber.length() - 1);
+            if (number.isEmpty()) {
+                number = "0";
             }
+            clearComputedIfValueChanged(number);
+            mFirstNumber = number;
         }
         updateDisplaySafely();
     }
@@ -121,6 +140,8 @@ public class EquationSolver {
         } else if (!number.contains(".")) {
             number += ".";
         }
+        // No clearComputedIfValueChanged here: a point is the one key that cannot change the
+        // amount. Every string this method can build parses to the number already on the display.
         mFirstNumber = mOperation == null ? number : mFirstNumber;
         mSecondNumber = mOperation == null ? null : number;
         updateDisplaySafely();
@@ -133,6 +154,7 @@ public class EquationSolver {
         } else {
             number += digit;
         }
+        clearComputedIfValueChanged(number);
         mFirstNumber = mOperation == null ? number : mFirstNumber;
         mSecondNumber = mOperation == null ? null : number;
         updateDisplaySafely();
@@ -162,9 +184,7 @@ public class EquationSolver {
                     // so a 10 typed with no decimals rounded 10 / 4 to 2. Divide at 16 significant
                     // digits instead. Narrowing to the currency scale here would narrow every step
                     // of a chain rather than the answer: with a zero decimal currency, 10.0 / 4 * 4
-                    // would give 8. getResult converts the finished equation to minor units, and
-                    // truncates whatever is left below the currency scale, as it does for a typed
-                    // amount with too many decimals.
+                    // would give 8. getResult narrows the finished equation once.
                     result = first.divide(second, MathContext.DECIMAL64);
                     break;
                 default:
@@ -179,6 +199,16 @@ public class EquationSolver {
             }
             mSecondNumber = null;
             mOperation = null;
+            // An operation that hands the amount back unchanged has computed nothing the ledger
+            // can see, and the display still reads the number that was there before it. The equals
+            // key runs the equation whether or not a second number was entered, and appendOperation
+            // runs it again when a second operator is pressed, so both reach here against the zero
+            // parseNumber returns for a second number nobody typed. Adding that zero and
+            // multiplying by one land in the same place: leave the flag as it was found, so a typed
+            // amount stays typed and an answer stays an answer.
+            if (result.compareTo(first) != 0) {
+                mComputed = true;
+            }
             if (fireCallback) {
                 updateDisplaySafely();
             }
@@ -196,9 +226,28 @@ public class EquationSolver {
         }
         BigDecimal parsedNumber = parseNumber(mFirstNumber);
         if (mCurrency != null) {
+            if (mComputed) {
+                // An answer is rounded to the currency scale, so 20.00 / 3 stores 667, which is
+                // what master stored for it when it rounded the quotient at the dividend's scale.
+                // A typed number falls through to toMinorUnits, which truncates what will not fit:
+                // 64.9 on a zero decimal currency stays 64, as the entry tests pin.
+                parsedNumber = parsedNumber.setScale(mCurrency.getDecimals(), RoundingMode.HALF_EVEN);
+            }
             return MoneyScale.toMinorUnits(parsedNumber, mCurrency.getDecimals());
         }
         return parsedNumber.longValue();
+    }
+
+    /**
+     * Clears the computed flag when the candidate first number differs in value from the one on
+     * the display. Compared as numbers, not as strings: appending a zero to an answer, or
+     * backspacing one off it, leaves the display reading the same amount, and a keypress that
+     * changes nothing does not retype what is there.
+     */
+    private void clearComputedIfValueChanged(String number) {
+        if (mOperation == null && parseNumber(number).compareTo(parseNumber(mFirstNumber)) != 0) {
+            mComputed = false;
+        }
     }
 
     private BigDecimal parseNumber(String number) {

--- a/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
@@ -1,15 +1,27 @@
 package com.oriondev.moneywallet.utils;
 
+import android.os.Bundle;
+import android.os.Parcelable;
+
 import com.oriondev.moneywallet.model.CurrencyUnit;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EquationSolverTest {
@@ -445,6 +457,45 @@ public class EquationSolverTest {
         assertFalse(equationSolver.execute(false));
         assertEquals("10", equationSolver.mFirstNumber);
         assertTrue(equationSolver.isPendingOperation());
+    }
+
+    // Saved state
+
+    @Test
+    public void testOnSaveInstanceState_keepsTheCurrencyThroughARotation() {
+        // CalculatorActivity only calls setValue when there is no saved state, so a currency the
+        // bundle does not carry is gone for good: getResult then returns the bare typed number
+        // instead of its minor units, and 12.50 reaches the ledger as 12.
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "12.50";
+        Bundle bundle = fakeBundle();
+
+        equationSolver.onSaveInstanceState(bundle);
+        EquationSolver restored = new EquationSolver(bundle, null);
+
+        assertEquals("12.50", restored.mFirstNumber);
+        assertEquals(1250L, restored.getResult());
+    }
+
+    /**
+     * A Bundle backed by a map. The unit test classpath has the stub android.jar, whose Bundle
+     * throws on every call, so the state has to live in the mock.
+     */
+    private Bundle fakeBundle() {
+        final Map<String, Object> values = new HashMap<>();
+        Answer<Object> put = invocation -> {
+            values.put(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        };
+        Answer<Object> get = invocation -> values.get(invocation.getArgument(0));
+        Bundle bundle = mock(Bundle.class);
+        doAnswer(put).when(bundle).putString(anyString(), nullable(String.class));
+        doAnswer(put).when(bundle).putSerializable(anyString(), nullable(Serializable.class));
+        doAnswer(put).when(bundle).putParcelable(anyString(), nullable(Parcelable.class));
+        doAnswer(get).when(bundle).getString(anyString(), nullable(String.class));
+        doAnswer(get).when(bundle).getSerializable(anyString());
+        doAnswer(get).when(bundle).getParcelable(anyString());
+        return bundle;
     }
 
     @Test

--- a/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.doAnswer;
@@ -422,15 +423,242 @@ public class EquationSolverTest {
     }
 
     @Test
-    public void testGetResult_recurringDivisionTruncatesAtTheCurrencyScale() {
-        // A quotient that does not terminate keeps its digits on the display and loses the ones
-        // below the currency scale in the conversion, the same way a typed 6.669 does.
+    public void testGetResult_recurringDivisionRoundsAtTheCurrencyScale() {
+        // A quotient that does not terminate keeps its digits on the display and is rounded, not
+        // truncated, on the way to the ledger. Master stored 667 for the same division typed as
+        // 20.00, where the dividend's scale it rounded at was the currency scale.
         mockCurrencyUnit(2);
         enter("20", EquationSolver.Operation.DIVISION, "3");
 
         assertTrue(equationSolver.execute(false));
         assertEquals("6.666666666666667", equationSolver.mFirstNumber);
+        assertEquals(667L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testGetResult_anAnswerRoundsHalfEvenAndATypedNumberDoesNot() {
+        // Half up would store 3 and 1 for the two answers. The typed number is the control: it
+        // truncates, so rounding it at all would store 65.
+        mockCurrencyUnit(0);
+        enter("5", EquationSolver.Operation.DIVISION, "2");
+        assertEquals(2L, equationSolver.getResult());
+
+        equationSolver.clear();
+        mockCurrencyUnit(0);
+        enter("1", EquationSolver.Operation.DIVISION, "2");
+        assertEquals(0L, equationSolver.getResult());
+
+        equationSolver.clear();
+        mockCurrencyUnit(0);
+        type("64.9");
+        assertEquals(64L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testGetResult_anOperatorWithNoSecondNumberLeavesATypedAmountTyped() {
+        // Confirming right after an operator key runs the equation against the zero a missing
+        // second number parses to. That press computed nothing, so 0.999 has to truncate to 99
+        // the way it does with no operator at all, rather than round up to a whole unit.
+        mockCurrencyUnit(2);
+        type("0.999");
+        equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
+
+        assertEquals(99L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testGetResult_aSecondOperatorPressLeavesATypedAmountTyped() {
+        // appendOperation runs the pending equation before it takes the new operator, which is the
+        // same empty run as the case above reached by pressing an operator key twice.
+        mockCurrencyUnit(2);
+        type("0.999");
+        equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
+        equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
+
+        assertEquals(99L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testGetResult_anOperatorWithNoSecondNumberLeavesAnAnswerAnAnswer() {
+        // The mirror of the two above: an empty run must not retype a quotient either, or the
+        // rounding is lost to a stray keypress.
+        mockCurrencyUnit(2);
+        enter("20", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+        equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
+
+        assertEquals(667L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testAppendNumber_aKeypressThatDoesNotChangeTheAmountLeavesAnAnswerAnAnswer() {
+        // A zero appended to a quotient reads as the same amount, so it is not a retype. Compared
+        // as strings rather than as numbers this stored 666.
+        mockCurrencyUnit(2);
+        enter("20", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+
+        equationSolver.appendNumber("0");
+
+        assertEquals("6.6666666666666670", equationSolver.mFirstNumber);
+        assertEquals(667L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testAppendNumber_anAnswerTypedOverAndTakenBackIsTypedFromThenOn() {
+        // Editing an answer hands it to the keypad, and taking the edit back does not hand it
+        // returned: the amount stores as the same digits typed from scratch would, 666 rather
+        // than 667. The alternative, recording the answer and rounding again whenever the display
+        // matches it, rounds a number that was typed by hand later in the same session.
+        mockCurrencyUnit(2);
+        enter("20", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+
+        equationSolver.appendNumber("5");
+        equationSolver.cancel();
+
+        assertEquals("6.666666666666667", equationSolver.mFirstNumber);
         assertEquals(666L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testAppendNumber_anAmountTypedAfterAnAnswerIsClearedAwayIsTyped() {
+        // Backspacing an answer down to zero and typing an amount that happens to equal it must
+        // store what those digits store on a fresh keypad. On a currency with no decimals any
+        // half unit shows the difference: 7 typed, 8 rounded.
+        mockCurrencyUnit(0);
+        enter("15", EquationSolver.Operation.DIVISION, "2");
+        assertTrue(equationSolver.execute(false));
+        assertEquals("7.5", equationSolver.mFirstNumber);
+
+        for (int press = 0; press < 5; press++) {
+            equationSolver.cancel();
+        }
+        type("7.5");
+
+        assertEquals(7L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testAppendNumber_anAmountRebuiltOnTopOfAnAnswerIsTyped() {
+        mockCurrencyUnit(0);
+        enter("15", EquationSolver.Operation.DIVISION, "2");
+        assertTrue(equationSolver.execute(false));
+
+        equationSolver.cancel();
+        equationSolver.cancel();
+        equationSolver.appendPoint();
+        equationSolver.appendNumber("5");
+
+        assertEquals("7.5", equationSolver.mFirstNumber);
+        assertEquals(7L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testAppendNumber_aKeypressThatChangesTheAmountRetypesIt() {
+        mockCurrencyUnit(2);
+        enter("20", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+
+        equationSolver.appendNumber("5");
+
+        assertEquals(666L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testCancel_backspaceThatChangesTheAmountRetypesIt() {
+        mockCurrencyUnit(2);
+        enter("20", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+
+        equationSolver.cancel();
+
+        assertEquals(666L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testCancel_backspaceThatDoesNotChangeTheAmountLeavesAnAnswerAnAnswer() {
+        // The mirror of the appended zero: taking a trailing zero back off an answer leaves the
+        // display reading the same amount, so it is not a retype either.
+        mockCurrencyUnit(2);
+        enter("0.3335", EquationSolver.Operation.MULTIPLICATION, "2.0");
+        assertTrue(equationSolver.execute(false));
+        assertEquals("0.66700", equationSolver.mFirstNumber);
+
+        equationSolver.cancel();
+
+        assertEquals("0.6670", equationSolver.mFirstNumber);
+        assertEquals(67L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testGetResult_anOperationThatChangesNothingLeavesATypedAmountTyped() {
+        // Adding a zero, multiplying by one and pressing an operator on a number nobody followed
+        // up all hand back the amount that was typed, so none of them is an answer to round.
+        mockCurrencyUnit(2);
+        type("0.999");
+        equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
+        type("0");
+        assertEquals(99L, equationSolver.getResult());
+
+        equationSolver.clear();
+        mockCurrencyUnit(2);
+        type("0.999");
+        equationSolver.appendOperation(EquationSolver.Operation.MULTIPLICATION);
+        type("1");
+        assertEquals(99L, equationSolver.getResult());
+
+        equationSolver.clear();
+        mockCurrencyUnit(2);
+        type("0.999");
+        equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
+        equationSolver.appendPoint();
+        assertEquals(99L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testGetResult_aSecondNumberBackspacedAwayLeavesATypedAmountTyped() {
+        mockCurrencyUnit(2);
+        type("0.999");
+        equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
+        type("5");
+        equationSolver.cancel();
+
+        assertEquals(99L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testGetResult_aSecondNumberBackspacedAwayLeavesAnAnswerAnAnswer() {
+        // The helper only looks at the first number, and this is the sequence that proves it has
+        // to: the 1 typed here goes to the second number, and taking it back off must not retype
+        // the quotient underneath.
+        mockCurrencyUnit(2);
+        enter("20", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+        equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
+        type("1");
+        equationSolver.cancel();
+
+        assertEquals(667L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testGetResult_everyOperationRoundsItsAnswer() {
+        // Not only division. Master truncated all four, and a multiplication that lands below the
+        // currency scale is where that shows: 2.5 * 3 stored 7 there and stores 8 here.
+        mockCurrencyUnit(0);
+        enter("2.5", EquationSolver.Operation.MULTIPLICATION, "3");
+        assertEquals(8L, equationSolver.getResult());
+
+        equationSolver.clear();
+        mockCurrencyUnit(2);
+        enter("10", EquationSolver.Operation.SUBTRACTION, "0.001");
+        assertEquals(1000L, equationSolver.getResult());
+
+        equationSolver.clear();
+        mockCurrencyUnit(2);
+        enter("0.005", EquationSolver.Operation.ADDITION, "0.001");
+        assertEquals(1L, equationSolver.getResult());
     }
 
     @Test
@@ -477,6 +705,34 @@ public class EquationSolverTest {
         assertEquals(1250L, restored.getResult());
     }
 
+    @Test
+    public void testOnSaveInstanceState_keepsAnAnswerAnAnswerThroughARotation() {
+        mockCurrencyUnit(2);
+        enter("20", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+        Bundle bundle = fakeBundle();
+
+        equationSolver.onSaveInstanceState(bundle);
+        EquationSolver restored = new EquationSolver(bundle, null);
+
+        assertEquals(667L, restored.getResult());
+    }
+
+    @Test
+    public void testConstructor_aBundleWithoutTheComputedKeyLeavesTheAmountTyped() {
+        // The default a missing key falls back to is what a bundle written by any earlier build
+        // hands back, and it has to be the safe one: truncate rather than round an amount whose
+        // history is unknown.
+        Bundle bundle = fakeBundle();
+        bundle.putString("EquationSolver::SavedState::FirstNumber", "6.666666666666667");
+        bundle.putParcelable("EquationSolver::SavedState::Currency", new CurrencyUnit("", "", "", 2));
+
+        EquationSolver restored = new EquationSolver(bundle, null);
+
+        assertFalse(restored.mComputed);
+        assertEquals(666L, restored.getResult());
+    }
+
     /**
      * A Bundle backed by a map. The unit test classpath has the stub android.jar, whose Bundle
      * throws on every call, so the state has to live in the mock.
@@ -488,11 +744,19 @@ public class EquationSolverTest {
             return null;
         };
         Answer<Object> get = invocation -> values.get(invocation.getArgument(0));
+        // The two argument getters hand back the caller's default for a key the bundle never
+        // carried, which is the case a bundle written by an earlier build produces.
+        Answer<Object> getOrDefault = invocation -> {
+            Object stored = values.get(invocation.getArgument(0));
+            return stored != null ? stored : invocation.getArgument(1);
+        };
         Bundle bundle = mock(Bundle.class);
         doAnswer(put).when(bundle).putString(anyString(), nullable(String.class));
         doAnswer(put).when(bundle).putSerializable(anyString(), nullable(Serializable.class));
         doAnswer(put).when(bundle).putParcelable(anyString(), nullable(Parcelable.class));
-        doAnswer(get).when(bundle).getString(anyString(), nullable(String.class));
+        doAnswer(put).when(bundle).putBoolean(anyString(), anyBoolean());
+        doAnswer(getOrDefault).when(bundle).getString(anyString(), nullable(String.class));
+        doAnswer(getOrDefault).when(bundle).getBoolean(anyString(), anyBoolean());
         doAnswer(get).when(bundle).getSerializable(anyString());
         doAnswer(get).when(bundle).getParcelable(anyString());
         return bundle;

--- a/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
@@ -8,6 +8,8 @@ import org.mockito.InjectMocks;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EquationSolverTest {
@@ -298,5 +300,160 @@ public class EquationSolverTest {
         long result = equationSolver.getResult();
 
         assertEquals(result, -64999L);
+    }
+
+    // Arithmetic
+
+    private void type(String keys) {
+        for (char key : keys.toCharArray()) {
+            if (key == '.') {
+                equationSolver.appendPoint();
+            } else {
+                equationSolver.appendNumber(String.valueOf(key));
+            }
+        }
+    }
+
+    private void enter(String first, EquationSolver.Operation operation, String second) {
+        type(first);
+        equationSolver.appendOperation(operation);
+        type(second);
+    }
+
+    @Test
+    public void testExecute_addition() {
+        enter("2.75", EquationSolver.Operation.ADDITION, "0.25");
+
+        assertTrue(equationSolver.execute(false));
+        assertEquals("3.00", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testExecute_subtraction() {
+        enter("2.75", EquationSolver.Operation.SUBTRACTION, "0.25");
+
+        assertTrue(equationSolver.execute(false));
+        assertEquals("2.50", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testExecute_multiplication() {
+        enter("2.5", EquationSolver.Operation.MULTIPLICATION, "4");
+
+        assertTrue(equationSolver.execute(false));
+        assertEquals("10", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testExecute_divisionOfIntegerDividendKeepsTheFraction() {
+        mockCurrencyUnit(2);
+        enter("10", EquationSolver.Operation.DIVISION, "4");
+
+        assertTrue(equationSolver.execute(false));
+        assertEquals("2.5", equationSolver.mFirstNumber);
+        assertEquals(250L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testExecute_divisionIsIndependentOfTheDividendScale() {
+        // The displayed string still carries the dividend's trailing zeros, the stored value is
+        // what has to stop depending on how the dividend was typed.
+        mockCurrencyUnit(2);
+
+        enter("160", EquationSolver.Operation.DIVISION, "25");
+        assertEquals(640L, equationSolver.getResult());
+
+        equationSolver.clear();
+        enter("160.00", EquationSolver.Operation.DIVISION, "25");
+        assertEquals(640L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testExecute_chainedDivisionAndMultiplicationDoNotRoundBetweenSteps() {
+        // Narrowing the quotient to the currency scale inside execute would round every step of a
+        // chain: this one would come back as 8 with a zero decimal currency.
+        mockCurrencyUnit(0);
+        type("10.0");
+        equationSolver.appendOperation(EquationSolver.Operation.DIVISION);
+        type("4");
+        equationSolver.appendOperation(EquationSolver.Operation.MULTIPLICATION);
+        type("4");
+
+        assertEquals(10L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testExecute_chainedDivisionKeepsTheDigitsBelowTheCurrencyScale() {
+        mockCurrencyUnit(2);
+        type("1.234");
+        equationSolver.appendOperation(EquationSolver.Operation.DIVISION);
+        type("2");
+        equationSolver.appendOperation(EquationSolver.Operation.MULTIPLICATION);
+        type("2");
+
+        assertEquals(123L, equationSolver.getResult());
+        assertEquals("1.234", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testExecute_recurringDivisionKeepsSixteenSignificantDigits() {
+        // The second case is the one that fails if the division stops rounding half up or half
+        // even and starts truncating.
+        enter("1", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+        assertEquals("0.3333333333333333", equationSolver.mFirstNumber);
+
+        equationSolver.clear();
+        enter("2", EquationSolver.Operation.DIVISION, "3");
+        assertTrue(equationSolver.execute(false));
+        assertEquals("0.6666666666666667", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testGetResult_recurringDivisionTruncatesAtTheCurrencyScale() {
+        // A quotient that does not terminate keeps its digits on the display and loses the ones
+        // below the currency scale in the conversion, the same way a typed 6.669 does.
+        mockCurrencyUnit(2);
+        enter("20", EquationSolver.Operation.DIVISION, "3");
+
+        assertTrue(equationSolver.execute(false));
+        assertEquals("6.666666666666667", equationSolver.mFirstNumber);
+        assertEquals(666L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testExecute_multiplicationStaysInPlainNotation() {
+        enter("0.001", EquationSolver.Operation.MULTIPLICATION, "0.0001");
+
+        assertTrue(equationSolver.execute(false));
+        assertEquals("0.0000001", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testExecute_divisionStaysInPlainNotation() {
+        enter("100", EquationSolver.Operation.DIVISION, "0.5");
+
+        assertTrue(equationSolver.execute(false));
+        assertEquals("200", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testExecute_divisionByZeroFailsAndLeavesTheEquationAlone() {
+        mockCurrencyUnit(2);
+        enter("10", EquationSolver.Operation.DIVISION, "0");
+
+        assertFalse(equationSolver.execute(false));
+        assertEquals("10", equationSolver.mFirstNumber);
+        assertTrue(equationSolver.isPendingOperation());
+    }
+
+    @Test
+    public void testGetResult_twoDecimalCurrencyAndDividedValue() {
+        mockCurrencyUnit(2);
+        enter("10", EquationSolver.Operation.DIVISION, "4");
+
+        long result = equationSolver.getResult();
+
+        assertEquals(250L, result);
     }
 }


### PR DESCRIPTION
Fixes #103.

## The problem

The amount keypad rounded a division to however many decimals the first number was typed with, so 10 divided by 4 stored 2.00 instead of 2.50. `BigDecimal.divide(divisor, roundingMode)` returns a quotient at the dividend's scale, which lets an integer dividend force an integer answer.

## The reported case, before and after

10 divided by 4 on the amount keypad of a new transaction, in a wallet whose currency has two decimals, on an Android 16 emulator:

| | calculator display | amount field | stored minor units |
|---|---|---|---|
| master `af3f1fb` | 2 | 2.00 | 200 |
| this branch | 2.5 | 2.50 | 250 |

The last column is read out of `transactions.transaction_money` after saving, rather than from the amount field.

## How it works

Division uses `MathContext.DECIMAL64`, so the quotient is no longer rounded to the dividend's scale. Narrowing to the currency scale inside the division would narrow every step of a chain rather than the answer: with a currency that has no decimals, `10.0 / 4 * 4` would store 8.

The narrowing happens once, in `getResult`, which rounds `HALF_EVEN` at the currency scale while the display still reads an answer an operation produced. A typed number falls through to `MoneyScale.toMinorUnits` and truncates, so 64.9 on a currency with no decimals is still 64, as the existing entry tests pin. Without that rounding, `20.00 / 3` would store 666 where master stored 667.

**The flag is set only when the operation changed the amount.** The equals key runs the equation whether or not a second number was entered, and `appendOperation` runs it again when a second operator is pressed, so both compute against the zero a missing second number parses to. Adding that zero and multiplying by one hand back the number that was typed, and neither is an answer to round, so a typed 0.999 still stores 99 through all of them.

It is cleared by a keypress that changes the amount, compared as an amount rather than as a string, so a zero appended to `6.666666666666667` or taken back off it leaves the answer an answer.

**This reaches all four operations, not only division**, because all four produce an answer. On a currency with two decimals, `10 - 0.001` stored 999 before and stores 1000 now, and `0.05 * 0.15` stored 0 and stores 1. Master truncated every one of those.

## What this touches

One source file and its test, across three commits. The second is a separate bug in the same class: `onSaveInstanceState` never wrote the currency key, so after a rotation `getResult` returned the typed number rather than its minor units, and an amount entered as 12.50 came back to the caller as 12. The third writes that flag to the bundle for the same reason, since a key the bundle does not carry comes back as its default.

139 unit tests, 0 failures, read from the result XML, 57 of them this class's against 26 on master. Every rule was checked by breaking it: setting the flag on every operation fails four cases, `HALF_UP` in place of `HALF_EVEN` fails one, comparing strings rather than amounts fails two, dropping either clear fails one each, and dropping the rounding fails seven.

## Costs and limits

An answer and a typed amount that read the same on the display can differ by a minor unit in the ledger: 0.015 typed stores 1, while the same 0.015 reached as `0.03 / 2` stores 2.

Editing an answer hands it to the keypad for good. `20 / 3` with a digit typed onto the quotient and backspaced off again stores 666 rather than 667, which is what those digits store when typed from scratch. The alternative is to remember the answer and round again whenever the display matches it, and that is worse: an amount typed by hand later in the same session then rounds too, so `15 / 2` backspaced away and followed by a typed 7.5 would store 8 on a currency with no decimals where a fresh keypad stores 7. Both are pinned by tests.

`DECIMAL64` rounds a quotient at 16 significant digits before the currency narrowing sees it, so a division whose exact answer needs more than that loses low order units where master was exact. A 14 digit amount divided by a small enough divisor reaches it; nothing in a real ledger does.
