### PR TITLE
Fill the wallet when a saving deposit or withdrawal opens

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -657,11 +657,13 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     mSavingId = intent.getLongExtra(SAVING_ID, 0L);
                     long savingMoney = 0L;
                     // getItemId is the id of the transaction being edited, and this branch only
-                    // runs when there is no transaction yet, so it was always the NEW_ITEM
-                    // placeholder of -1. The query matched no saving, wallet stayed null, and the
-                    // amount keypad opened with no currency to scale against, so it read the typed
-                    // digits as minor units: 2000 became 20.00. Load the saving the intent names,
-                    // the way the debt branch above loads its debt.
+                    // runs when there is no transaction yet, so it was always the -1 assigned for
+                    // a new item. That built the uri savings/-1, which matches no route in the
+                    // content provider, so the query returned null without reaching the database,
+                    // wallet stayed null, and the amount keypad opened with no currency to scale
+                    // against: it read the typed digits as minor units and 2000 became 20.00.
+                    // Load the saving the intent names, the way the debt branch above loads its
+                    // debt.
                     Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
                     String[] projection = new String[] {
                             Contract.Saving.START_MONEY,
@@ -708,6 +710,10 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                         case SAVING_WITHDRAW_EVERYTHING:
                             money = savingMoney;
                             mSavingCompleted = true;
+                            // Deliberate fall through: withdraw everything needs the withdraw
+                            // category set below. A break here, which is what an IDE inspection
+                            // offers, leaves selectionArgs[0] null, and the query below then
+                            // crashes the editor as it opens: the bind value at index 1 is null.
                         case SAVING_WITHDRAW:
                             selectionArgs[0] = Contract.CategoryTag.SAVING_WITHDRAW;
                             break;

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -657,7 +657,13 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     mSavingId = intent.getLongExtra(SAVING_ID, 0L);
                     long savingMoney = 0L;
                     long savingProgress = 0L;
-                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, getItemId());
+                    // getItemId is the id of the transaction being edited, and this branch only
+                    // runs when there is no transaction yet, so it was always the NEW_ITEM
+                    // placeholder of -1. The query matched no saving, wallet stayed null, and the
+                    // amount keypad opened with no currency to scale against, so it read the typed
+                    // digits as minor units: 2000 became 20.00. Load the saving the intent names,
+                    // the way the debt branch above loads its debt.
+                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
                     String[] projection = new String[] {
                             Contract.Saving.END_MONEY,
                             Contract.Saving.WALLET_ID,

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -656,7 +656,6 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                 } else if (mType == TYPE_SAVING) {
                     mSavingId = intent.getLongExtra(SAVING_ID, 0L);
                     long savingMoney = 0L;
-                    long savingProgress = 0L;
                     // getItemId is the id of the transaction being edited, and this branch only
                     // runs when there is no transaction yet, so it was always the NEW_ITEM
                     // placeholder of -1. The query matched no saving, wallet stayed null, and the
@@ -665,7 +664,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     // the way the debt branch above loads its debt.
                     Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
                     String[] projection = new String[] {
-                            Contract.Saving.END_MONEY,
+                            Contract.Saving.START_MONEY,
+                            Contract.Saving.PROGRESS,
                             Contract.Saving.WALLET_ID,
                             Contract.Saving.WALLET_NAME,
                             Contract.Saving.WALLET_ICON,
@@ -674,7 +674,12 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     Cursor cursor = contentResolver.query(uri, projection, null, null, null);
                     if (cursor != null) {
                         if (cursor.moveToFirst()) {
-                            savingMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.END_MONEY));
+                            // What a saving holds is its start money plus its progress, the same
+                            // sum the savings list draws its current amount from. END_MONEY is the
+                            // target, and a saving can be deposited past its target, so the target
+                            // would strand the overshoot in a withdraw everything.
+                            savingMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY))
+                                    + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS));
                             wallet = new Wallet(
                                     cursor.getLong(cursor.getColumnIndex(Contract.Saving.WALLET_ID)),
                                     cursor.getString(cursor.getColumnIndex(Contract.Saving.WALLET_NAME)),

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
@@ -1,0 +1,60 @@
+package com.oriondev.moneywallet.ui.activity;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * The block checked here runs inside an Activity, reads instance fields and talks to a content
+ * resolver, so it cannot be driven from a JVM unit test: there is no Robolectric on the unit test
+ * classpath, and the instrumented suite is configured with clearPackageData, which empties the
+ * device it runs on. The invariant is pinned by reading the source instead.
+ *
+ * The invariant: inside the branch that fills a new transaction from its intent, getItemId is
+ * always the NEW_ITEM placeholder of -1, because that branch is the else of a
+ * getMode() == EDIT_ITEM test. Any row loaded there has to be keyed by an id the intent carried.
+ * Loading the saving with getItemId matched no row, so the editor opened with no wallet, the amount
+ * keypad had no currency to scale against, and a typed 2000 was stored as 20.00.
+ */
+public class NewEditTransactionActivitySourceTest {
+
+    private static final String SOURCE_PATH =
+            "src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java";
+
+    private static final String REGION_START = "mType = intent.getIntExtra(TYPE, TYPE_STANDARD);";
+    private static final String REGION_END = "datetime = new Date();";
+
+    @Test
+    public void newItemBranchDoesNotReadTheItemId() throws IOException {
+        assertEquals("getItemId() is read inside the branch that fills a new transaction from its "
+                + "intent, where it is always -1", -1, readIntentBranch().indexOf("getItemId()"));
+    }
+
+    @Test
+    public void savingIsLoadedByTheIdTheIntentCarried() throws IOException {
+        assertTrue("the saving must be loaded with mSavingId, the id the launching intent put in "
+                + "SAVING_ID", readIntentBranch().contains("CONTENT_SAVINGS, mSavingId"));
+    }
+
+    private static String readIntentBranch() throws IOException {
+        File source = new File(SOURCE_PATH);
+        if (!source.exists()) {
+            source = new File("app/" + SOURCE_PATH);
+        }
+        String text = new String(Files.readAllBytes(source.toPath()), StandardCharsets.UTF_8);
+        int start = text.indexOf(REGION_START);
+        int end = text.indexOf(REGION_END, start + 1);
+        if (start < 0 || end < 0) {
+            fail("could not find the branch that fills a new transaction from its intent in "
+                    + source.getAbsolutePath() + ", so this test can no longer check it");
+        }
+        return text.substring(start, end);
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
@@ -21,31 +21,32 @@ import static org.junit.Assert.fail;
  * Comments and string literals are stripped before anything is matched, so no assertion here can
  * be satisfied or broken by the wording of a comment.
  *
- * What these assertions check is that specific token sequences are still present in the source:
+ * What these assertions check is which token sequences the source does and does not carry:
  * that getItemId appears nowhere in the intent branch, that the saving uri is built from
- * mSavingId, that the statement assigning savingMoney reads START_MONEY and PROGRESS and adds
- * them, and that the statement assigning wallet builds a Wallet from the saving's wallet columns.
- * That makes them a tripwire against a revert or a careless rewrite. It does not make them a proof
- * of behaviour, and they cannot show the value the keypad ends up with. A rewrite that keeps those
- * tokens and still breaks the editor goes through: moving the prefill out of the withdraw
- * everything case, dropping a column from the projection while the getColumnIndex call that names
- * it stays, and adding a second assignment written with += or -= are all invisible here.
+ * mSavingId, that the statement assigning savingMoney reads START_MONEY and PROGRESS once each
+ * and adds them, that both columns are in the projection, that the prefill sits in the withdraw
+ * everything case and that the case falls through, and that the statement assigning wallet builds
+ * a Wallet from the saving's wallet columns. That makes them a tripwire against a revert or a
+ * careless rewrite. It does not make them a proof of behaviour, and they cannot show the value the
+ * keypad ends up with. A rewrite that keeps those tokens and still breaks the editor goes through.
+ * One example, not a list: a second assignment written with += or -= is invisible here, because
+ * "savingMoney -=" does not contain the "savingMoney =" the statement is found by.
  *
  * Invariant one: inside the branch that fills a new transaction from its intent, getItemId is
- * always the NEW_ITEM placeholder of -1, because that branch is the else of a
- * getMode() == EDIT_ITEM test. Loading the saving with getItemId matched no row, so the editor
- * opened with no wallet, the amount keypad had no currency to scale against, and a typed 2000 was
- * stored as 20.00.
+ * always -1, the value NewEditItemActivity assigns whenever it was not launched to edit an
+ * existing item, because that branch is the else of a getMode() == EDIT_ITEM test. A saving uri
+ * built from -1 is savings/-1, which matches no route in the content provider, so the query
+ * returned null without reaching the database. The editor opened with no wallet, the amount keypad
+ * had no currency to scale against, and a typed 2000 was stored as 20.00.
  *
  * Invariant two: the prefill that WITHDRAW EVERYTHING opens on is what the saving holds, which is
  * START_MONEY plus PROGRESS, the same sum SavingCursorAdapter draws its current amount from.
  * END_MONEY is the target. Reading END_MONEY there returns too little for any saving deposited
  * past its target and leaves the overshoot behind with the saving already marked complete.
  *
- * Invariant three: the same row builds the wallet the editor opens on, currency included. That
- * wallet is the whole point of the fix, so its construction has to stay: without it the wallet
- * field is empty, the keypad has no currency to scale against, and a typed 2000 is stored as
- * 20.00.
+ * Invariant three: the same row builds the wallet the editor opens on, currency included. Without
+ * that construction the wallet field is empty, the keypad has no currency to scale against, and a
+ * typed 2000 is stored as 20.00.
  */
 public class NewEditTransactionActivitySourceTest {
 
@@ -57,6 +58,10 @@ public class NewEditTransactionActivitySourceTest {
 
     private static final String SAVING_BRANCH_START = "} else if (mType == TYPE_SAVING) {";
     private static final String SAVING_BRANCH_END = "} else if (mType == TYPE_MODEL) {";
+
+    private static final String WITHDRAW_EVERYTHING_CASE = "case SAVING_WITHDRAW_EVERYTHING:";
+    private static final String WITHDRAW_CASE = "case SAVING_WITHDRAW:";
+    private static final String CATEGORY_QUERY_START = "uri = DataContentProvider.CONTENT_CATEGORIES;";
 
     @Test
     public void newItemBranchDoesNotReadTheItemId() throws IOException {
@@ -91,6 +96,51 @@ public class NewEditTransactionActivitySourceTest {
     }
 
     @Test
+    public void withdrawEverythingPrefillsOnlyItsOwnCase() throws IOException {
+        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
+        String everything = saving.substring(saving.indexOf(WITHDRAW_EVERYTHING_CASE));
+        int ownCaseEnd = everything.indexOf(WITHDRAW_CASE);
+        assertTrue("the prefill has to sit in the withdraw everything case: moved into the deposit "
+                + "case it offers the saving's whole balance every time a deposit is opened",
+                everything.substring(0, ownCaseEnd).contains("money = savingMoney;"));
+    }
+
+    @Test
+    public void withdrawEverythingFallsThroughToTheWithdrawCategory() throws IOException {
+        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
+        String everything = saving.substring(saving.indexOf(WITHDRAW_EVERYTHING_CASE));
+        String ownCase = everything.substring(0, everything.indexOf(WITHDRAW_CASE));
+        assertEquals("the withdraw everything case falls through on purpose to pick up the "
+                + "withdraw category below it. A break here, which is what an IDE inspection "
+                + "offers, leaves the category selection argument null, and the query below then "
+                + "crashes the editor as it opens: the bind value at index 1 is null",
+                -1, ownCase.indexOf("break"));
+    }
+
+    @Test
+    public void bothColumnsTheSumReadsAreInTheProjection() throws IOException {
+        // The saving branch builds two projections, one for the saving and one for its category,
+        // so this looks only at the part before the category query starts.
+        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
+        String projection = statementAssigning(
+                saving.substring(0, saving.indexOf(CATEGORY_QUERY_START)), "projection =");
+        assertTrue("a column read through getColumnIndex but left out of the projection returns "
+                + "index -1 and throws when it is read, so both have to be listed: " + projection,
+                projection.contains("Contract.Saving.START_MONEY")
+                        && projection.contains("Contract.Saving.PROGRESS"));
+    }
+
+    @Test
+    public void theSumReadsEachColumnOnce() throws IOException {
+        String computed = statementAssigning(
+                region(SAVING_BRANCH_START, SAVING_BRANCH_END), "savingMoney =");
+        assertEquals("START_MONEY has to be read once, or the prefill counts it twice: " + computed,
+                1, occurrences(computed, "Contract.Saving.START_MONEY"));
+        assertEquals("PROGRESS has to be read once: " + computed,
+                1, occurrences(computed, "Contract.Saving.PROGRESS"));
+    }
+
+    @Test
     public void savingWalletIsBuiltFromTheSavingRow() throws IOException {
         String built = statementAssigning(region(SAVING_BRANCH_START, SAVING_BRANCH_END), "wallet =");
         assertTrue("the editor has to open on the saving's own wallet, built from the row just "
@@ -102,10 +152,11 @@ public class NewEditTransactionActivitySourceTest {
     }
 
     /**
-     * Returns the statement that assigns to the given left hand side, skipping the declaration
-     * that only sets a default. Fails when the literal text passed in matches more than once, so a
-     * second plain assignment cannot slip past unread. Compound assignments do not contain that
-     * text: "savingMoney -=" does not contain "savingMoney =", so a later += or -= is not seen.
+     * Returns the statement that assigns to the given left hand side, skipping any long
+     * declaration of the same name, which is how the running total is declared before the block
+     * fills it. Fails when the literal text passed in matches more than once, so a second plain
+     * assignment cannot slip past unread. Compound assignments do not contain that text:
+     * "savingMoney -=" does not contain "savingMoney =", so a later += or -= is not seen.
      */
     private static String statementAssigning(String block, String assignment) {
         String found = null;
@@ -152,9 +203,9 @@ public class NewEditTransactionActivitySourceTest {
     }
 
     /**
-     * Removes comments and string literals, replacing each with a single space so that offsets
-     * never merge two tokens into one. Without this the assertions above could be satisfied, or
-     * broken, by prose that no compiler ever sees.
+     * Removes comments and string literals, replacing each with a single space so that the tokens
+     * on either side of a removed comment do not run together. Without this the assertions above
+     * could be satisfied, or broken, by prose that no compiler ever sees.
      */
     private static String stripCommentsAndStrings(String text) {
         StringBuilder out = new StringBuilder(text.length());
@@ -180,6 +231,14 @@ public class NewEditTransactionActivitySourceTest {
             }
         }
         return out.toString();
+    }
+
+    private static int occurrences(String text, String token) {
+        int count = 0;
+        for (int at = text.indexOf(token); at >= 0; at = text.indexOf(token, at + 1)) {
+            count++;
+        }
+        return count;
     }
 
     private static int skipTo(String text, int from, String token) {

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
@@ -14,47 +14,176 @@ import static org.junit.Assert.fail;
 /**
  * The block checked here runs inside an Activity, reads instance fields and talks to a content
  * resolver, so it cannot be driven from a JVM unit test: there is no Robolectric on the unit test
- * classpath, and the instrumented suite is configured with clearPackageData, which empties the
- * device it runs on. The invariant is pinned by reading the source instead.
+ * classpath. An automated check of what the editor actually opens with would take an instrumented
+ * test on a device or emulator, and none was written. The invariants are pinned by reading the
+ * source instead.
  *
- * The invariant: inside the branch that fills a new transaction from its intent, getItemId is
+ * Comments and string literals are stripped before anything is matched, so no assertion here can
+ * be satisfied or broken by the wording of a comment.
+ *
+ * What these assertions check is that specific token sequences are still present in the source:
+ * that getItemId appears nowhere in the intent branch, that the saving uri is built from
+ * mSavingId, that the statement assigning savingMoney reads START_MONEY and PROGRESS and adds
+ * them, and that the statement assigning wallet builds a Wallet from the saving's wallet columns.
+ * That makes them a tripwire against a revert or a careless rewrite. It does not make them a proof
+ * of behaviour, and they cannot show the value the keypad ends up with. A rewrite that keeps those
+ * tokens and still breaks the editor goes through: moving the prefill out of the withdraw
+ * everything case, dropping a column from the projection while the getColumnIndex call that names
+ * it stays, and adding a second assignment written with += or -= are all invisible here.
+ *
+ * Invariant one: inside the branch that fills a new transaction from its intent, getItemId is
  * always the NEW_ITEM placeholder of -1, because that branch is the else of a
- * getMode() == EDIT_ITEM test. Any row loaded there has to be keyed by an id the intent carried.
- * Loading the saving with getItemId matched no row, so the editor opened with no wallet, the amount
- * keypad had no currency to scale against, and a typed 2000 was stored as 20.00.
+ * getMode() == EDIT_ITEM test. Loading the saving with getItemId matched no row, so the editor
+ * opened with no wallet, the amount keypad had no currency to scale against, and a typed 2000 was
+ * stored as 20.00.
+ *
+ * Invariant two: the prefill that WITHDRAW EVERYTHING opens on is what the saving holds, which is
+ * START_MONEY plus PROGRESS, the same sum SavingCursorAdapter draws its current amount from.
+ * END_MONEY is the target. Reading END_MONEY there returns too little for any saving deposited
+ * past its target and leaves the overshoot behind with the saving already marked complete.
+ *
+ * Invariant three: the same row builds the wallet the editor opens on, currency included. That
+ * wallet is the whole point of the fix, so its construction has to stay: without it the wallet
+ * field is empty, the keypad has no currency to scale against, and a typed 2000 is stored as
+ * 20.00.
  */
 public class NewEditTransactionActivitySourceTest {
 
     private static final String SOURCE_PATH =
             "src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java";
 
-    private static final String REGION_START = "mType = intent.getIntExtra(TYPE, TYPE_STANDARD);";
-    private static final String REGION_END = "datetime = new Date();";
+    private static final String INTENT_BRANCH_START = "mType = intent.getIntExtra(TYPE, TYPE_STANDARD);";
+    private static final String INTENT_BRANCH_END = "datetime = new Date();";
+
+    private static final String SAVING_BRANCH_START = "} else if (mType == TYPE_SAVING) {";
+    private static final String SAVING_BRANCH_END = "} else if (mType == TYPE_MODEL) {";
 
     @Test
     public void newItemBranchDoesNotReadTheItemId() throws IOException {
-        assertEquals("getItemId() is read inside the branch that fills a new transaction from its "
-                + "intent, where it is always -1", -1, readIntentBranch().indexOf("getItemId()"));
+        assertEquals("getItemId is read inside the branch that fills a new transaction from its "
+                + "intent, where it is always -1", -1,
+                region(INTENT_BRANCH_START, INTENT_BRANCH_END).indexOf("getItemId"));
     }
 
     @Test
     public void savingIsLoadedByTheIdTheIntentCarried() throws IOException {
         assertTrue("the saving must be loaded with mSavingId, the id the launching intent put in "
-                + "SAVING_ID", readIntentBranch().contains("CONTENT_SAVINGS, mSavingId"));
+                + "SAVING_ID", region(SAVING_BRANCH_START, SAVING_BRANCH_END)
+                .contains("CONTENT_SAVINGS, mSavingId"));
     }
 
-    private static String readIntentBranch() throws IOException {
+    @Test
+    public void withdrawEverythingPrefillsWhatTheSavingHolds() throws IOException {
+        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
+        assertTrue("the withdraw everything prefill must be the savingMoney this block computes",
+                saving.contains("money = savingMoney;"));
+        String computed = statementAssigning(saving, "savingMoney =");
+        assertTrue("what a saving holds is START_MONEY plus PROGRESS, so both have to be read to "
+                + "compute the prefill, but the assignment is: " + computed,
+                computed.contains("Contract.Saving.START_MONEY")
+                        && computed.contains("Contract.Saving.PROGRESS"));
+        assertTrue("END_MONEY is the target, not what the saving holds, so it must not be part of "
+                + "the prefill, but the assignment is: " + computed,
+                !computed.contains("END_MONEY"));
+        assertTrue("the two columns have to be added, since a saving holds its start money plus "
+                + "everything deposited into it, but the assignment is: " + computed,
+                computed.contains("+") && !computed.contains("-"));
+    }
+
+    @Test
+    public void savingWalletIsBuiltFromTheSavingRow() throws IOException {
+        String built = statementAssigning(region(SAVING_BRANCH_START, SAVING_BRANCH_END), "wallet =");
+        assertTrue("the editor has to open on the saving's own wallet, built from the row just "
+                + "read, but the assignment is: " + built, built.contains("new Wallet("));
+        assertTrue("that wallet has to carry the saving's currency, or the amount keypad has "
+                + "nothing to scale a typed amount against, but the assignment is: " + built,
+                built.contains("Contract.Saving.WALLET_ID")
+                        && built.contains("Contract.Saving.WALLET_CURRENCY"));
+    }
+
+    /**
+     * Returns the statement that assigns to the given left hand side, skipping the declaration
+     * that only sets a default. Fails when the literal text passed in matches more than once, so a
+     * second plain assignment cannot slip past unread. Compound assignments do not contain that
+     * text: "savingMoney -=" does not contain "savingMoney =", so a later += or -= is not seen.
+     */
+    private static String statementAssigning(String block, String assignment) {
+        String found = null;
+        for (int at = block.indexOf(assignment); at >= 0; at = block.indexOf(assignment, at + 1)) {
+            if (block.lastIndexOf("long ", at) == at - "long ".length()) {
+                continue;
+            }
+            int end = block.indexOf(';', at);
+            if (end < 0) {
+                fail("the assignment to " + assignment + " has no end");
+            }
+            if (found != null) {
+                fail("more than one assignment to " + assignment + " in the saving branch, so "
+                        + "this test can no longer tell which one feeds the prefill");
+            }
+            found = block.substring(at, end);
+        }
+        if (found == null) {
+            fail("no assignment to " + assignment + " in the saving branch");
+        }
+        return found;
+    }
+
+    private static String region(String start, String end) throws IOException {
+        String text = stripCommentsAndStrings(readSource());
+        int from = text.indexOf(start);
+        int to = from < 0 ? -1 : text.indexOf(end, from + 1);
+        if (from < 0 || to < 0) {
+            fail("could not find the region between \"" + start + "\" and \"" + end + "\" in "
+                    + SOURCE_PATH + ", so this test can no longer check it");
+        }
+        return text.substring(from, to);
+    }
+
+    private static String readSource() throws IOException {
         File source = new File(SOURCE_PATH);
         if (!source.exists()) {
             source = new File("app/" + SOURCE_PATH);
         }
-        String text = new String(Files.readAllBytes(source.toPath()), StandardCharsets.UTF_8);
-        int start = text.indexOf(REGION_START);
-        int end = text.indexOf(REGION_END, start + 1);
-        if (start < 0 || end < 0) {
-            fail("could not find the branch that fills a new transaction from its intent in "
-                    + source.getAbsolutePath() + ", so this test can no longer check it");
+        if (!source.exists()) {
+            fail("could not find " + SOURCE_PATH + " from " + new File(".").getAbsolutePath());
         }
-        return text.substring(start, end);
+        return new String(Files.readAllBytes(source.toPath()), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Removes comments and string literals, replacing each with a single space so that offsets
+     * never merge two tokens into one. Without this the assertions above could be satisfied, or
+     * broken, by prose that no compiler ever sees.
+     */
+    private static String stripCommentsAndStrings(String text) {
+        StringBuilder out = new StringBuilder(text.length());
+        int i = 0;
+        while (i < text.length()) {
+            char c = text.charAt(i);
+            if (c == '/' && i + 1 < text.length() && text.charAt(i + 1) == '/') {
+                i = skipTo(text, i + 2, "\n");
+                out.append(' ');
+            } else if (c == '/' && i + 1 < text.length() && text.charAt(i + 1) == '*') {
+                i = skipTo(text, i + 2, "*/") + 2;
+                out.append(' ');
+            } else if (c == '"' || c == '\'') {
+                i++;
+                while (i < text.length() && text.charAt(i) != c) {
+                    i += text.charAt(i) == '\\' ? 2 : 1;
+                }
+                i++;
+                out.append(' ');
+            } else {
+                out.append(c);
+                i++;
+            }
+        }
+        return out.toString();
+    }
+
+    private static int skipTo(String text, int from, String token) {
+        int at = text.indexOf(token, from);
+        return at < 0 ? text.length() : at;
     }
 }


### PR DESCRIPTION
Fixes #111.

## The problem

Pressing DEPOSIT or WITHDRAW on a saving opened the transaction editor with an empty wallet field and no currency, so the amount keypad read the typed digits as minor units and 2000 became 20.00. WITHDRAW EVERYTHING opened at 0.00.

## The reported case, before and after

On an Android 16 emulator, on wallets whose currency has two decimals. A saving below its target offers DEPOSIT and WITHDRAW, and one at or past its target offers WITHDRAW EVERYTHING instead, so the first three rows and the last were run against two different savings:

| | master `79590e1` | this branch |
|---|---|---|
| DEPOSIT, wallet and currency | empty, `?` | the saving's wallet, `$` |
| DEPOSIT, then 2000 typed | 20.00 | 2,000.00 |
| WITHDRAW, wallet and currency | empty, `?` | the saving's wallet, `$` |
| WITHDRAW EVERYTHING on a saving holding 2,500.00 against a 2,000.00 target | 0.00, no wallet | 2,500.00, the saving's wallet |

## How it works

The editor did load the saving to find its wallet, but it built the uri from `getItemId()` rather than from the saving id the intent carried. `getItemId()` is the id of the transaction being edited, and that code only runs when there is no transaction yet, so it was always the `-1` the base activity assigns for a new item. The uri `savings/-1` matches no route in the content provider, so the query returned null without reaching the database, the wallet stayed null, and the wallet picker then reported no currency to the keypad. The debt branch beside it already keys its lookup on the id its own intent carried.

The second commit is the other half of the same screen, and the misread it fixes only becomes reachable once the first one lands: with a row to read at last, the WITHDRAW EVERYTHING prefill read `END_MONEY`, the saving's target, rather than the balance the saving holds. The savings list draws its current amount from `START_MONEY` plus `PROGRESS`, and WITHDRAW EVERYTHING appears only once the target is reached or passed, so the target equals the balance when a saving lands exactly on the target and understates the balance on any overshoot. A prefill that understates the balance returns less than the saving holds and still marks the saving complete, which hides its buttons until it is unarchived. The subquery behind `CONTENT_SAVINGS` already selects both columns, so reading the balance costs no extra query.

The third commit keeps the deliberate fall through in `SAVING_WITHDRAW_EVERYTHING`. A `break` there, which is what an IDE inspection offers, leaves the category selection argument null, and the query below then crashes the editor as it opens: `IllegalArgumentException: the bind value at index 1 is null`. Checked by adding the break and pressing WITHDRAW EVERYTHING.

## What this touches

One source file and its test.

The saving block cannot be reached from a JVM unit test, so the test added here pins its invariants by reading the source, with comments and string literals stripped first, so that no assertion can be satisfied or broken by the wording of a comment: two assertions would fail without that stripping, since the words they search for also appear in the comments beside the code. **It is a tripwire against a revert or a careless rewrite, not proof of behaviour:** it cannot show the value the keypad ends up with, and the class javadoc names a rewrite that would slip past it. The before and after above is what covers the behaviour. 147 unit tests, 0 failures, read from the result XML.

## Costs and limits

A saving's start money is stored as a column and never as a wallet transaction, so the wallet is never debited for it, while withdrawing from a saving is an income that credits the wallet. Returning the balance therefore credits the wallet with start money it never paid out. The target based prefill replaced here had the same property, and the reason to name it now is that this is the first build where any prefill on this screen arrives at a usable amount. Correcting the phantom credit means deciding what start money is meant to represent, and that is wider than this fix.

Changing the wallet in the editor after it opens rescales nothing: the prefilled amount stays the number it was, so moving a withdrawal from a currency with no decimals onto one with two changes what it means. That is how the editor already behaved on every other path that prefills an amount.
