### PR TITLE
Mirror the toolbar back arrow in right to left layouts

### DIFF
--- a/app/src/main/res/drawable/ic_arrow_back_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_arrow_back_black_24dp.xml
@@ -20,6 +20,7 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
         android:width="24dp"
         android:height="24dp"
+        android:autoMirrored="true"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0">
     <path


### PR DESCRIPTION
Fixes #104.

## What was wrong

`app/src/main/res/drawable/ic_arrow_back_black_24dp.xml` did not set `android:autoMirrored`. With the app language set to a right to left language the toolbar mirrored, the title moved to the right and the arrow moved to the right edge, but the glyph itself kept pointing left.

## The change

One attribute on the vector, the same treatment AppCompat gives its own back arrow drawable `abc_ic_ab_back_material.xml`, which sets `android:autoMirrored="true"`.

The attribute sits on the drawable rather than on any one screen, so every screen that uses the drawable as the navigation icon is covered: `SinglePanelActivity`, `MultiPanelActivity`, `SecondaryPanelFragment`, `SettingMultiPanelFragment`, `BackupListActivity`, `BackupHandlerFragment` and `SearchActivity`. The project has no `drawable-ldrtl` variant of this icon.

## What I tested

Debug build on an Android 16 emulator, Calculator screen, app language switched with `adb shell cmd locale set-app-locales`. All four cells below were seen on the device, before on a build of `master` and after on a build of this branch.

| App language | Before | After |
|---|---|---|
| Persian (`fa`) | arrow at the right edge, glyph pointing left | arrow at the right edge, glyph pointing right |
| English (`en-US`) | arrow at the left edge, glyph pointing left | arrow at the left edge, glyph pointing left |
