### PR TITLE
Open the backup destination on a folder that can be written

### DIFF
--- a/app/src/floss/java/com/oriondev/moneywallet/api/BackendServiceFactory.java
+++ b/app/src/floss/java/com/oriondev/moneywallet/api/BackendServiceFactory.java
@@ -53,6 +53,11 @@ public class BackendServiceFactory {
         List<BackendDescriptor> descriptors = new ArrayList<>();
         descriptors.add(new BackendDescriptor(SERVICE_ID_EXTERNAL_MEMORY, R.drawable.ic_sd_24dp) {
             @Override
+            public IFile getDefaultFolder() {
+                return DiskBackendServiceAPI.getDefaultFolder();
+            }
+
+            @Override
             public AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
                 return new DiskBackendService(listener);
             }
@@ -140,12 +145,10 @@ public class BackendServiceFactory {
     }
 
     public static IFile getFile(String backendId, String encoded) {
-        if (encoded != null) {
-            BackendDescriptor descriptor = findDescriptor(backendId);
-            if (descriptor != null) {
-                return descriptor.createFile(encoded);
-            }
+        BackendDescriptor descriptor = findDescriptor(backendId);
+        if (descriptor == null) {
+            return null;
         }
-        return null;
+        return encoded != null ? descriptor.createFile(encoded) : descriptor.getDefaultFolder();
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/api/BackendDescriptor.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/BackendDescriptor.java
@@ -67,6 +67,11 @@ public abstract class BackendDescriptor {
         return true;
     }
 
+    /** Where a backup goes when no folder was chosen. Null when there is none to offer. */
+    public IFile getDefaultFolder() {
+        return null;
+    }
+
     public abstract AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener);
 
     public abstract IBackendServiceAPI createServiceApi(Context context) throws BackendException;

--- a/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendServiceAPI.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendServiceAPI.java
@@ -110,7 +110,12 @@ public class DiskBackendServiceAPI extends AbstractBackendServiceAPI<LocalFile> 
         return folder.getFile();
     }
 
-    public static LocalFile getRootFolder() {
-        return new LocalFile(Environment.getExternalStorageDirectory());
+    /** Not the root, which is unwritable from Android 11. Null if the folder cannot be made. */
+    public static LocalFile getDefaultFolder() {
+        File folder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS);
+        if (!folder.isDirectory() && !folder.mkdirs()) {
+            return null;
+        }
+        return new LocalFile(folder);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/BackendExplorerActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/BackendExplorerActivity.java
@@ -40,7 +40,7 @@ import android.view.ViewGroup;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
-import com.oriondev.moneywallet.api.disk.DiskBackendServiceAPI;
+import com.oriondev.moneywallet.api.BackendServiceFactory;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.IFile;
 import com.oriondev.moneywallet.service.BackendHandlerIntentService;
@@ -91,6 +91,11 @@ public class BackendExplorerActivity extends SinglePanelActivity implements Swip
         mBackendId = intent.getStringExtra(BACKEND_ID);
         mActivityMode = intent.getIntExtra(MODE, MODE_EXPLORER);
         mFileStack = new ArrayList<>();
+        // open where a backup would go, the same folder the backup screen opens on
+        IFile defaultFolder = BackendServiceFactory.getFile(mBackendId, null);
+        if (defaultFolder != null) {
+            mFileStack.add(defaultFolder);
+        }
         // attach the activity to the service
         IntentFilter intentFilter = new IntentFilter();
         intentFilter.addAction(LocalAction.ACTION_BACKEND_SERVICE_STARTED);
@@ -160,8 +165,8 @@ public class BackendExplorerActivity extends SinglePanelActivity implements Swip
             if (mActivityMode == MODE_FOLDER_PICKER) {
                 IFile folder = getCurrentFolder();
                 if (folder == null) {
-                    // return the root folder of the device instead of null
-                    folder = DiskBackendServiceAPI.getRootFolder();
+                    // this backend's own default, rather than a local path it cannot decode
+                    folder = BackendServiceFactory.getFile(mBackendId, null);
                 }
                 Intent intent = new Intent();
                 intent.putExtra(RESULT_FILE, folder);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
@@ -115,6 +115,7 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
             String backendId = arguments.getString(ARG_BACKEND_ID, null);
             mBackendService = BackendServiceFactory.getServiceById(backendId, this);
             mFileStack = new ArrayList<>();
+            openOnDefaultFolder();
         } else {
             throw new IllegalStateException("Arguments bundle is null, please instantiate the fragment using the newInstance() method instead.");
         }
@@ -424,10 +425,23 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
         if (enabled) {
             hideCoverView();
             if (isStackEmpty()) {
+                // asked again here: at onCreate the backend may not have been usable yet,
+                // and a default resolved then can have come back empty handed
+                openOnDefaultFolder();
                 loadCurrentFolder();
             }
         } else {
             showCoverView();
+        }
+    }
+
+    private void openOnDefaultFolder() {
+        if (!mFileStack.isEmpty() || mBackendService == null) {
+            return;
+        }
+        IFile defaultFolder = BackendServiceFactory.getFile(mBackendService.getId(), null);
+        if (defaultFolder != null) {
+            mFileStack.add(defaultFolder);
         }
     }
 

--- a/app/src/proprietary/java/com/oriondev/moneywallet/api/BackendServiceFactory.java
+++ b/app/src/proprietary/java/com/oriondev/moneywallet/api/BackendServiceFactory.java
@@ -93,6 +93,11 @@ public class BackendServiceFactory {
         });
         descriptors.add(new BackendDescriptor(SERVICE_ID_EXTERNAL_MEMORY, R.drawable.ic_sd_24dp) {
             @Override
+            public IFile getDefaultFolder() {
+                return DiskBackendServiceAPI.getDefaultFolder();
+            }
+
+            @Override
             public AbstractBackendServiceDelegate createDelegate(AbstractBackendServiceDelegate.BackendServiceStatusListener listener) {
                 return new DiskBackendService(listener);
             }
@@ -180,12 +185,10 @@ public class BackendServiceFactory {
     }
 
     public static IFile getFile(String backendId, String encoded) {
-        if (encoded != null) {
-            BackendDescriptor descriptor = findDescriptor(backendId);
-            if (descriptor != null) {
-                return descriptor.createFile(encoded);
-            }
+        BackendDescriptor descriptor = findDescriptor(backendId);
+        if (descriptor == null) {
+            return null;
         }
-        return null;
+        return encoded != null ? descriptor.createFile(encoded) : descriptor.getDefaultFolder();
     }
 }

--- a/app/src/test/java/com/oriondev/moneywallet/api/BackendServiceFactoryTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/api/BackendServiceFactoryTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNull;
+
+public class BackendServiceFactoryTest {
+
+    @Test
+    public void noFolderChosenStaysNullForABackendWithoutADefault() {
+        assertNull(BackendServiceFactory.getFile(BackendServiceFactory.SERVICE_ID_WEBDAV, null));
+    }
+
+    @Test
+    public void unknownBackendStaysNull() {
+        assertNull(BackendServiceFactory.getFile("no_such_backend", null));
+        assertNull(BackendServiceFactory.getFile("no_such_backend", "/storage/emulated/0"));
+    }
+}


### PR DESCRIPTION
Fixes #105.

## The cause in the issue is right, the scope is not

#105 traces the failure correctly, to `File.createNewFile` in `DiskBackendServiceAPI.upload` against `Environment.getExternalStorageDirectory()`. Where it goes wrong is how far that reaches: it concludes the destination itself cannot work, and offers gating the entry off or removing it.

The root is the part that fails. Through the same destination on the same Android 16 emulator, a backup into `Download` and a backup into `Documents` both succeed, and both folders already held backups from earlier sessions. Two folders on one device is not a proof about every folder, but it is enough to rule out the premise both of the issue's options rest on, so this fixes where the destination starts instead.

## What was wrong

With nothing opened, the backup screen listed the root and sent `null` as the folder, which the upload resolved to the root. A log added to the catch block, and removed again, named the call:

```
upload failed: dest=/storage/emulated/0/backup_2026-08-13_17-15-50.mwbx parentExists=true parentCanWrite=false legacy=false
java.io.IOException: Operation not permitted
	at java.io.UnixFileSystem.createFileExclusively0(Native Method)
	at java.io.File.createNewFile(File.java:1022)
	at com.oriondev.moneywallet.api.disk.DiskBackendServiceAPI.upload(DiskBackendServiceAPI.java:59)
```

`WRITE_EXTERNAL_STORAGE` is granted on that device, so the permission is not what was missing, and `Environment.isExternalStorageLegacy()` reports false because at `targetSdk 35` the manifest's `requestLegacyExternalStorage` stops applying from Android 11.

## The change

`BackendDescriptor` gains `getDefaultFolder()`, null by default. External memory returns the public `Documents` collection, or null if it cannot be created. All four places that used to resolve an unset folder to the root or to null now take that default:

- `BackupHandlerFragment` opens on it rather than the root,
- `BackendExplorerActivity` opens on it and returns it when the user presses select without opening anything,
- `AutoBackupSettingDialog` shows and stores it, where it used to show `Root` and store null,
- `AutoBackupJobService` backs up into it, instead of reporting the location as missing at every interval without attempting a backup.

The backup screen takes its upload target from the same stack it lists, so a backup lands in the folder being listed rather than somewhere the user is not looking. It asks for the default again when the backend becomes enabled, because at screen creation the storage permission may not have been granted yet and the answer then can be nothing.

Three things worth stating rather than leaving to be found:

- **A backup made before this change sits at the external root**, which is one level up from where these screens now open. Navigating up reaches it.
- **The root is no longer selectable** by pressing select at the top of the tree. Opening the root and backing up into it still fails exactly as before. Pressing select there returns the default instead of the root, so in that one state the picker returns a folder other than the one it is listing.
- **The picker used to hand a local path back for every backend**, including WebDAV and the storage access framework, which cannot decode one. It now asks the descriptor, so those keep answering null and keep reporting a missing location rather than storing something unusable.

Nothing else about browsing changed. The listing code is untouched, navigating up from the default reaches the root, and the root still lists its directories.

## What I tested

Android 16 emulator, floss debug build. Every row was seen on the device except the last, which is marked.

| Check | Before | After |
|---|---|---|
| The issue's own steps: open the destination, press backup | fails, Operation not permitted, nothing written | succeeds, written into `Documents` |
| Where the backup screen opens | external root, no files listed | `Documents`, listing the backups already there |
| The new backup in the list being viewed | not applicable, the backup failed | present, and present in `Documents` on disk |
| Navigate up from the default | not applicable | root listing, all directories, `Download` still reachable |
| Auto backup dialog folder row | `Root` | `Documents` |
| Folder picker, list against what select returns | listed the root, returned the root | lists `Documents`, returns `Documents` |
| Automatic backup with no folder ever chosen | logs `backup location missing or not decodable`, notifies, writes nothing | writes a backup |
| Backup into `Download` | succeeds | not retested; with a folder opened the resolved path is unchanged |

Unit test: `BackendServiceFactoryTest` pins that a backend without a default still answers null for one. Checked by mutation, making the base return a folder fails it. It does not cover the external memory default itself, which resolves a real storage directory that a JVM test here cannot.

## What this leaves

The storage access framework backend still presents an unset folder as `Root` and still lets an automatic backup be enabled that can never run, because there is no sensible default to fall back to there. That needs its own answer and is not in this change.
