### PR TITLE
Leave transfer legs out of a CSV export

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/service/ImportExportIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/ImportExportIntentService.java
@@ -135,6 +135,15 @@ public class ImportExportIntentService extends IntentService {
                 selectionBuilder.append(" AND DATE (" + Contract.Transaction.DATE + ") >= DATE(?)");
                 selectionArguments.add(DateUtils.getSQLDateString(startDate));
             }
+            if (dataFormat == DataFormat.CSV) {
+                // CSV is the only format that can be imported back, and it carries nothing that
+                // pairs the two legs of a transfer, so importing them recreates each leg as an
+                // ordinary transaction. The fee stays: it is one expense, not half of anything.
+                selectionBuilder.append(" AND (" + Contract.Transaction.TYPE + " != ? OR " +
+                        Contract.Transaction.CATEGORY_TAG + " = ?)");
+                selectionArguments.add(String.valueOf(Contract.TransactionType.TRANSFER));
+                selectionArguments.add(Contract.CategoryTag.TRANSFER_TAX);
+            }
             String sortOrder = Contract.Transaction.DATE + " DESC";
             // check if we should create a unique wallet or if we can export each wallet
             // in a separate way

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/ImportExportActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/ImportExportActivity.java
@@ -74,6 +74,7 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
 
     private MaterialEditText mImportFormatEditText;
     private MaterialEditText mExportFormatEditText;
+    private View mExportCsvNoTransfersTextView;
     private MaterialEditText mStartDateEditText;
     private MaterialEditText mEndDateEditText;
     private MaterialEditText mWalletsEditText;
@@ -175,6 +176,7 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
         View view = inflater.inflate(R.layout.layout_panel_import_export, parent, true);
         mImportFormatEditText = view.findViewById(R.id.import_format_edit_text);
         mExportFormatEditText = view.findViewById(R.id.export_format_edit_text);
+        mExportCsvNoTransfersTextView = view.findViewById(R.id.export_csv_no_transfers_text_view);
         mStartDateEditText = view.findViewById(R.id.start_date_edit_text);
         mEndDateEditText = view.findViewById(R.id.end_date_edit_text);
         mWalletsEditText = view.findViewById(R.id.wallets_edit_text);
@@ -607,6 +609,7 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                     mExportFormatEditText.setText(R.string.hint_data_format_csv);
                     if (mMode == MODE_EXPORT) {
                         mExportColumnsEditText.setVisibility(View.VISIBLE);
+                        mExportCsvNoTransfersTextView.setVisibility(View.VISIBLE);
                     }
                     break;
                 case XLS:
@@ -614,6 +617,7 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                     mExportFormatEditText.setText(R.string.hint_data_format_xls);
                     if (mMode == MODE_EXPORT) {
                         mExportColumnsEditText.setVisibility(View.VISIBLE);
+                        mExportCsvNoTransfersTextView.setVisibility(View.GONE);
                     }
                     break;
                 case PDF:
@@ -621,6 +625,7 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                     mExportFormatEditText.setText(R.string.hint_data_format_pdf);
                     if (mMode == MODE_EXPORT) {
                         mExportColumnsEditText.setVisibility(View.VISIBLE);
+                        mExportCsvNoTransfersTextView.setVisibility(View.GONE);
                     }
                     break;
             }
@@ -628,6 +633,7 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
             mImportFormatEditText.setText(null);
             mExportFormatEditText.setText(null);
             mExportColumnsEditText.setVisibility(View.GONE);
+            mExportCsvNoTransfersTextView.setVisibility(View.GONE);
         }
         onFormatOrWalletChanged();
     }

--- a/app/src/main/res/layout/layout_panel_import_export.xml
+++ b/app/src/main/res/layout/layout_panel_import_export.xml
@@ -107,6 +107,17 @@
             android:text="@string/hint_export_unique_wallet"
             android:checked="true" />
 
+        <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
+            android:id="@+id/export_csv_no_transfers_text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/material_activity_body_check_box_start_end_margin"
+            android:layout_marginRight="@dimen/material_activity_body_check_box_start_end_margin"
+            android:layout_marginBottom="@dimen/material_activity_body_check_box_top_bottom_margin"
+            android:text="@string/hint_export_csv_no_transfers"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:visibility="gone" />
+
     </LinearLayout>
 
 </com.oriondev.moneywallet.ui.view.theme.ThemedScrollView>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -150,6 +150,7 @@
     <string name="hint_export_folder">"Export folder"</string>
     <string name="hint_export_optional_columns">"Optional columns"</string>
     <string name="hint_export_unique_wallet">"Join transactions from different wallets"</string>
+    <string name="hint_export_csv_no_transfers">"The two sides of a transfer are left out of a CSV file, because nothing in it marks which two rows were one transfer. A transfer fee is still written, and the other formats include transfers in full."</string>
     <string name="hint_data_format_csv" translatable="false">"CSV"</string>
     <string name="hint_data_format_xls" translatable="false">"XLS"</string>
     <string name="hint_data_format_pdf" translatable="false">"PDF"</string>


### PR DESCRIPTION
Fixes #106.

## What was wrong

A transfer is stored as two legs, plus a third row for the fee when one is set. The CSV carries `wallet`, `currency`, `category`, `datetime`, `money` and `description`, plus up to four optional columns (`event`, `people`, `place`, `note`). A leg is recognisable in the file: its category cell reads `Transfer`, and the two legs share a datetime, a description, a note, a place and an event. What is missing is a key. Every one of those values can be shared by two different transfers, and a user category named `Transfer` is written the same way as the system one, so any pairing built on them is a guess.

Importing a file that contains the legs creates two ordinary transactions instead of restoring the transfer. The transfer itself is what goes: the rows come back unrelated and the Transfers tab no longer holds it. The money is not safe either, because `insertTransaction` writes every row confirmed and counted in total, so a transfer that was pending, or deliberately kept out of totals, returns as money that counts from its date.

Both halves check out in the code, on `master`:

- the export selection in `ImportExportIntentService` filtered on date and wallet only, and `SQLDatabase.getTransactions` adds no type restriction of its own, so transfer legs went out with everything else,
- `AbstractDataImporter.insertTransaction` writes `Contract.TransactionType.STANDARD` and `CSVDataImporter` calls nothing else, so there is no transfer path on the way back in.

## The change

The export leaves transfer legs out, and the export screen says so while CSV is the chosen format.

**The fee row stays.** A transfer fee is written with the same `TRANSFER` type, but it is a single expense against one wallet under the system `transfer_tax` category, not half of anything. It is kept by matching that category tag rather than dropped with the legs. On import it comes back with the same amount, wallet, date and description, and takes the losses every imported row takes, starting with the type being written `STANDARD`, the category being resolved by name rather than to the system one, and the row returning confirmed and counted in total whatever it was before.

**Only CSV.** XLS and PDF are reports, neither can be imported back, and a statement that silently dropped the money moving out of a wallet would be worse than one that shows it. Both still include transfers.

**Debt and saving rows are left in.** Not because they survive a round trip intact, they do not: the importer sets no debt, saving or recurrence link on anything it writes, so a debt payment comes back as an ordinary transaction, the same way a leg does. The difference is that each of those is one movement that comes back as the same one movement, while a transfer is one object spread across two rows with no key tying them together.

## Why not the pairing column

A column that pairs the legs plus an importer that rebuilds the transfer is a format change and a new import path, and it still has to decide what to do with a leg whose partner is not in the file, which happens whenever the user exports one of the two wallets. That decision is this change.

## What this costs

The file no longer accounts for every movement in the range it covers, because a transfer out of a wallet is a real movement that the file no longer contains. That is the trade, and it is why the note on the export screen names it rather than leaving it to be discovered. Anyone who needs the movement can export the same range as PDF or XLS, and `.mwbx` remains the format meant for restoring a ledger.

## What I tested

Android 16 emulator, floss debug build, two wallets holding one transfer with no fee.

| Check | Result |
|---|---|
| Same export selection, filtered against unfiltered | 40 rows against 42, the two removed being the legs |
| The written CSV | 40 rows, no transfer leg |
| PDF export, same wallets and range | 42 rows, transfers kept |
| Export screen with CSV chosen | note shown |
| Export screen with PDF chosen | note hidden |
| The note in the Deep dark theme | white on black, legible |

The counts came from a log placed on the export query, and removed again. The fee row is traced through the query rather than exercised: the transfer on the device had no fee.

Two things that read like failures and are not:

- The written file still contains two rows whose category is `Transfer`. Those are ordinary transactions that the round trip in this issue created on an earlier run, so they are standard rows now and belong in the export. The 42 against 40 count is what separates them from the legs.
- The note is a `ThemedTextView` rather than a plain one. A plain `TextView` is not repainted by the theme engine, and on the dark themes it rendered near black on a near black background, which would have hidden the very disclosure it exists to make.
