### PR TITLE
Match the system category a CSV row names, when its direction agrees

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
@@ -8,6 +8,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import com.oriondev.moneywallet.model.Category;
 import com.oriondev.moneywallet.model.ColorIcon;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
@@ -21,14 +22,19 @@ import com.oriondev.moneywallet.utils.Utils;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 /**
  * Created by andrea on 23/12/18.
  */
 public abstract class AbstractDataImporter {
+
+    /*package-local*/ static final long NO_CATEGORY = -1L;
 
     private final Context mContext;
 
@@ -111,18 +117,19 @@ public abstract class AbstractDataImporter {
     private long getOrCreateCategory(ContentResolver contentResolver, String name, int direction) {
         Uri uri = DataContentProvider.CONTENT_CATEGORIES;
         Contract.CategoryType type = direction == Contract.Direction.INCOME ? Contract.CategoryType.INCOME : Contract.CategoryType.EXPENSE;
-        String[] projection = new String[] {Contract.Category.ID};
+        String[] projection = new String[] {Contract.Category.ID, Contract.Category.TYPE, Contract.Category.TAG};
         String selection = Contract.Category.NAME + " = ? AND (" + Contract.Category.TYPE + " = ? OR " + Contract.Category.TYPE + " = ?)";
         String[] selectionArgs = new String[] {name,
                 String.valueOf(type.getValue()),
-                String.valueOf(Contract.CategoryType.SYSTEM)
+                String.valueOf(Contract.CategoryType.SYSTEM.getValue())
         };
         String sortOrder = Contract.Category.ID + " DESC";
         Cursor cursor = contentResolver.query(uri, projection, selection, selectionArgs, sortOrder);
         if (cursor != null) {
             try {
-                if (cursor.moveToFirst()) {
-                    return cursor.getLong(cursor.getColumnIndex(Contract.Category.ID));
+                long categoryId = chooseCategory(cursor, direction);
+                if (categoryId != NO_CATEGORY) {
+                    return categoryId;
                 }
             } finally {
                 cursor.close();
@@ -140,6 +147,61 @@ public abstract class AbstractDataImporter {
             throw new RuntimeException("Failed to create the new category");
         }
         return ContentUris.parseId(result);
+    }
+
+    /**
+     * The system tags {@link Category#getDirection()} has a case for. It returns the same zero for
+     * a tag it does not name as it does for an expense, so a tag missing from here cannot be read
+     * as one. The transfer tag is absent because a transfer is written as two legs, one per
+     * wallet, so both directions appear under it.
+     */
+    private static final Set<String> TAGS_WITH_A_KNOWN_DIRECTION = new HashSet<>(Arrays.asList(
+            Contract.CategoryTag.CREDIT,
+            Contract.CategoryTag.PAID_DEBT,
+            Contract.CategoryTag.SAVING_DEPOSIT,
+            Contract.CategoryTag.TAX,
+            Contract.CategoryTag.TRANSFER_TAX,
+            Contract.CategoryTag.DEBT,
+            Contract.CategoryTag.PAID_CREDIT,
+            Contract.CategoryTag.SAVING_WITHDRAW
+    ));
+
+    /**
+     * The id of the first category in the cursor that can hold a row of this direction, or
+     * {@link #NO_CATEGORY} when none can. A candidate that cannot hold the row is passed over
+     * rather than ending the search, so a system category the guard refuses does not hide a
+     * category the user made behind it. The cursor is rewound first, so wrapping the call in the
+     * moveToFirst every other lookup in this class opens with does not skip a candidate.
+     */
+    /*package-local*/ static long chooseCategory(Cursor cursor, int direction) {
+        cursor.moveToPosition(-1);
+        while (cursor.moveToNext()) {
+            if (keepsDirection(cursor, direction)) {
+                return cursor.getLong(cursor.getColumnIndex(Contract.Category.ID));
+            }
+        }
+        return NO_CATEGORY;
+    }
+
+    /**
+     * Whether a category holds a row of this direction without the direction being rewritten
+     * later.
+     *
+     * An income or expense category is its direction, so it holds a row of that direction and no
+     * other. A system category is not: the transaction editor derives a direction from the
+     * category, and for a system category that means from its tag, through
+     * {@link Category#getDirection()}. It writes that over whatever the row held, on every save. A
+     * row given a system category whose tag implies the other direction would be flipped the first
+     * time it was opened and saved, moving the wallet total by twice its amount.
+     */
+    private static boolean keepsDirection(Cursor cursor, int direction) {
+        Contract.CategoryType type = Contract.CategoryType.fromValue(
+                cursor.getInt(cursor.getColumnIndex(Contract.Category.TYPE)));
+        String tag = cursor.getString(cursor.getColumnIndex(Contract.Category.TAG));
+        if (type == Contract.CategoryType.SYSTEM && !TAGS_WITH_A_KNOWN_DIRECTION.contains(tag)) {
+            return false;
+        }
+        return new Category(0, null, null, type, tag).getDirection() == direction;
     }
 
     private Long getEvent(ContentResolver contentResolver, String name) {

--- a/app/src/test/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporterTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporterTest.java
@@ -1,0 +1,288 @@
+package com.oriondev.moneywallet.storage.database.data;
+
+import android.database.Cursor;
+
+import com.oriondev.moneywallet.storage.database.Contract;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Two things are pinned here.
+ *
+ * The first is chooseCategory, run for real against a mocked cursor. It is the half of the lookup
+ * that decides which matched category an imported row is filed on. An income or expense category
+ * is its direction, but a system category is not: the transaction editor derives one from the
+ * category and writes it over the row on every save, so a row given a system category whose tag
+ * implies the other direction is flipped the first time it is opened and saved, and the wallet
+ * total moves by twice the amount.
+ *
+ * The second is the two statements of the query that this change altered, the projection and the
+ * arguments. The query cannot be run from a JVM test: entering getOrCreateCategory touches
+ * DataContentProvider.CONTENT_CATEGORIES, a static Uri, and there is no Robolectric on the unit
+ * test classpath, so a mocked resolver does not help. Those two are read out of the source, the
+ * way NewEditTransactionActivitySourceTest reads its own, and so is the pair of statements that
+ * carry what chooseCategory returns back to the caller. Text is a tripwire against a revert, not a
+ * proof of behaviour: it cannot see whether the query returns the right rows. Comments are not
+ * stripped, so a comment quoting the code being checked has to be reworded.
+ *
+ * Statements this change did not touch are left unpinned even where a mutation of them would be
+ * serious, since pinning them would fail on a reformat of code this branch has no opinion about.
+ */
+public class AbstractDataImporterTest {
+
+    private static final String SOURCE_PATH =
+            "src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java";
+
+    private static final int TYPE = 0;
+    private static final int TAG = 1;
+    private static final int ID = 2;
+
+    /**
+     * A cursor over the given rows, each an id, a type and a tag, in the order the query returns
+     * them. Position starts before the first row, and the rewind chooseCategory does is stubbed, so
+     * a test can hand over a cursor that has already been read.
+     */
+    private static Cursor cursorOver(Object[]... rows) {
+        Cursor cursor = mock(Cursor.class);
+        when(cursor.getColumnIndex(Contract.Category.TYPE)).thenReturn(TYPE);
+        when(cursor.getColumnIndex(Contract.Category.TAG)).thenReturn(TAG);
+        when(cursor.getColumnIndex(Contract.Category.ID)).thenReturn(ID);
+        final int[] at = {-1};
+        when(cursor.moveToNext()).thenAnswer(call -> ++at[0] < rows.length);
+        when(cursor.moveToFirst()).thenAnswer(call -> {
+            at[0] = 0;
+            return rows.length > 0;
+        });
+        when(cursor.moveToPosition(-1)).thenAnswer(call -> {
+            at[0] = -1;
+            return false;
+        });
+        when(cursor.getLong(ID)).thenAnswer(call -> (Long) rows[at[0]][0]);
+        when(cursor.getInt(TYPE)).thenAnswer(call -> ((Contract.CategoryType) rows[at[0]][1]).getValue());
+        when(cursor.getString(TAG)).thenAnswer(call -> (String) rows[at[0]][2]);
+        return cursor;
+    }
+
+    private static Object[] row(long id, Contract.CategoryType type, String tag) {
+        return new Object[] {id, type, tag};
+    }
+
+    @Test
+    public void anOrdinaryCategoryHoldsARowOfItsOwnDirection() {
+        assertEquals(7L, AbstractDataImporter.chooseCategory(
+                cursorOver(row(7L, Contract.CategoryType.EXPENSE, null)), Contract.Direction.EXPENSE));
+        assertEquals(7L, AbstractDataImporter.chooseCategory(
+                cursorOver(row(7L, Contract.CategoryType.INCOME, null)), Contract.Direction.INCOME));
+        assertEquals("an expense category cannot hold an income row",
+                AbstractDataImporter.NO_CATEGORY, AbstractDataImporter.chooseCategory(
+                        cursorOver(row(7L, Contract.CategoryType.EXPENSE, null)), Contract.Direction.INCOME));
+    }
+
+    @Test
+    public void aTagWithNoKnownDirectionIsRefusedForBoth() {
+        // A transfer is written as two legs, one per wallet, so both directions appear
+        // under the transfer tag and Category.getDirection has no case for it. What it returns
+        // there is the same zero it returns for an expense, which is why these are asserted
+        // rather than left to it.
+        for (int direction : new int[] {Contract.Direction.EXPENSE, Contract.Direction.INCOME}) {
+            assertEquals("the transfer tag has no direction of its own",
+                    AbstractDataImporter.NO_CATEGORY, AbstractDataImporter.chooseCategory(
+                            cursorOver(row(1L, Contract.CategoryType.SYSTEM, Contract.CategoryTag.TRANSFER)),
+                            direction));
+            assertEquals("a system row with no tag is not one this build seeded",
+                    AbstractDataImporter.NO_CATEGORY, AbstractDataImporter.chooseCategory(
+                            cursorOver(row(1L, Contract.CategoryType.SYSTEM, null)), direction));
+            assertEquals("nor is one carrying a tag this build does not know, which a restore can "
+                    + "write and a later version can introduce",
+                    AbstractDataImporter.NO_CATEGORY, AbstractDataImporter.chooseCategory(
+                            cursorOver(row(1L, Contract.CategoryType.SYSTEM, "system::tenth")), direction));
+            assertEquals("an empty tag is not null and must be refused the same way",
+                    AbstractDataImporter.NO_CATEGORY, AbstractDataImporter.chooseCategory(
+                            cursorOver(row(1L, Contract.CategoryType.SYSTEM, "")), direction));
+        }
+    }
+
+    @Test
+    public void everyKnownTagIsOneTheDirectionLookupAnswersFor() {
+        // Each tag is checked by being accepted for the direction it implies and refused for the
+        // other. For an income tag that also catches its case going missing from
+        // Category.getDirection, since the fall through zero is not the income the pair requires.
+        // For an expense tag it does not: the fall through zero and a real expense case are the
+        // same answer, and nothing here can tell them apart.
+        String[] expense = {Contract.CategoryTag.CREDIT, Contract.CategoryTag.PAID_DEBT,
+                Contract.CategoryTag.SAVING_DEPOSIT, Contract.CategoryTag.TAX,
+                Contract.CategoryTag.TRANSFER_TAX};
+        String[] income = {Contract.CategoryTag.DEBT, Contract.CategoryTag.PAID_CREDIT,
+                Contract.CategoryTag.SAVING_WITHDRAW};
+        for (String tag : expense) {
+            assertEquals(tag + " is an expense", 3L, AbstractDataImporter.chooseCategory(
+                    cursorOver(row(3L, Contract.CategoryType.SYSTEM, tag)), Contract.Direction.EXPENSE));
+            assertEquals(tag + " must not hold an income row",
+                    AbstractDataImporter.NO_CATEGORY, AbstractDataImporter.chooseCategory(
+                            cursorOver(row(3L, Contract.CategoryType.SYSTEM, tag)), Contract.Direction.INCOME));
+        }
+        for (String tag : income) {
+            assertEquals(tag + " is an income", 3L, AbstractDataImporter.chooseCategory(
+                    cursorOver(row(3L, Contract.CategoryType.SYSTEM, tag)), Contract.Direction.INCOME));
+            assertEquals(tag + " must not hold an expense row",
+                    AbstractDataImporter.NO_CATEGORY, AbstractDataImporter.chooseCategory(
+                            cursorOver(row(3L, Contract.CategoryType.SYSTEM, tag)), Contract.Direction.EXPENSE));
+        }
+    }
+
+    @Test
+    public void aRefusedCandidateIsPassedOverRatherThanEndingTheSearch() {
+        assertEquals("a system row the guard refuses must not hide a category the user made "
+                + "behind it",
+                40L, AbstractDataImporter.chooseCategory(cursorOver(
+                        row(8L, Contract.CategoryType.SYSTEM, Contract.CategoryTag.SAVING_DEPOSIT),
+                        row(40L, Contract.CategoryType.INCOME, null)), Contract.Direction.INCOME));
+        assertEquals("the first candidate that holds the row wins, and the query orders them "
+                + "newest first",
+                40L, AbstractDataImporter.chooseCategory(cursorOver(
+                        row(40L, Contract.CategoryType.EXPENSE, null),
+                        row(8L, Contract.CategoryType.SYSTEM, Contract.CategoryTag.SAVING_DEPOSIT)),
+                        Contract.Direction.EXPENSE));
+        assertEquals("an empty cursor finds nothing",
+                AbstractDataImporter.NO_CATEGORY,
+                AbstractDataImporter.chooseCategory(cursorOver(), Contract.Direction.EXPENSE));
+    }
+
+    /**
+     * Every other lookup in the importer opens with moveToFirst, so wrapping this one in the same
+     * call is the likeliest edit anyone makes to it. The scan rewinds, which keeps that edit from
+     * quietly dropping the first and best candidate.
+     */
+    @Test
+    public void aCursorSomebodyElseAlreadyMovedStillFindsTheFirstRow() {
+        Cursor cursor = cursorOver(row(40L, Contract.CategoryType.EXPENSE, null));
+        cursor.moveToFirst();
+        assertEquals(40L, AbstractDataImporter.chooseCategory(cursor, Contract.Direction.EXPENSE));
+    }
+
+    /**
+     * The two type arguments of the lookup have to be the integer the column holds. A CategoryType
+     * handed to String.valueOf becomes its constant name instead, which matches no row, and that
+     * is how the system argument was written, so that arm of the OR was dead and a CSV row naming a
+     * system category was matched or created as an ordinary category instead. The constant is named as well as the accessor,
+     * because reading getValue() off the wrong constant passes any check that looks only at the
+     * suffix and leaves the arm just as dead.
+     */
+    @Test
+    public void bothTypeArgumentsOfTheLookupAreIntegers() throws IOException {
+        String statement = statementIn("selectionArgs = ");
+        for (int at = statement.indexOf("String.valueOf("); at >= 0;
+             at = statement.indexOf("String.valueOf(", at + 1)) {
+            int from = at + "String.valueOf(".length();
+            assertTrue("every type argument has to read getValue(), or it is a CategoryType "
+                    + "stringified to its constant name: " + statement,
+                    statement.startsWith("type.getValue()", from)
+                            || statement.startsWith("Contract.CategoryType.SYSTEM.getValue()", from));
+        }
+        assertEquals("the lookup takes a name and two type arguments: " + statement,
+                2, occurrences(statement, "String.valueOf("));
+        assertTrue("the system argument has to read the SYSTEM value, since any other constant "
+                + "leaves that arm of the OR matching nothing: " + statement,
+                statement.contains("Contract.CategoryType.SYSTEM.getValue()"));
+        assertTrue("the name has to be bound first, or every argument binds to the wrong "
+                + "placeholder: " + statement, statement.contains("{name,"));
+    }
+
+    /**
+     * A column read through getColumnIndex but left out of the projection returns index -1 and
+     * throws when it is read. The same invariant NewEditTransactionActivitySourceTest pins for its
+     * own projection, and this change is what added the two columns the guard reads.
+     */
+    @Test
+    public void everyColumnTheGuardReadsIsInTheProjection() throws IOException {
+        String projection = statementIn("projection = ");
+        String source = readSource().replaceAll("\\s+", "");
+        for (int at = source.indexOf("getColumnIndex(Contract.Category."); at >= 0;
+             at = source.indexOf("getColumnIndex(Contract.Category.", at + 1)) {
+            int from = at + "getColumnIndex(".length();
+            String column = source.substring(from, source.indexOf(')', from));
+            assertTrue(column + " is read out of the cursor but is not in the projection, so its "
+                    + "index is -1 and reading it throws: " + projection,
+                    projection.contains(column));
+        }
+    }
+
+    /**
+     * The lines that carry the answer back. Reverting the first to take the row the query returned
+     * puts the whole direction guard back to sleep, and the rest decide what an imported row is
+     * filed on. None of them is visible to a test of chooseCategory, since none is inside it.
+     */
+    @Test
+    public void theLookupTakesTheGuardsAnswerAndReturnsIt() throws IOException {
+        String body = methodBody().replaceAll("\\s+", "");
+        assertTrue("getOrCreateCategory has to pick its row through chooseCategory, or the guard "
+                + "is dead code and an imported row can be filed on a category that rewrites its "
+                + "direction", body.contains("longcategoryId=chooseCategory(cursor,direction);"));
+        assertTrue("it has to return the id the guard chose, and only when the guard found one",
+                body.contains("if(categoryId!=NO_CATEGORY){returncategoryId;}"));
+    }
+
+    /** The named statement of getOrCreateCategory, whitespace stripped, without its semicolon. */
+    private static String statementIn(String assignment) throws IOException {
+        String body = methodBody();
+        int at = body.indexOf(assignment);
+        int end = at < 0 ? -1 : body.indexOf(';', at);
+        if (at < 0 || end < 0) {
+            fail("no \"" + assignment + "\" statement in getOrCreateCategory");
+        }
+        return body.substring(at, end).replaceAll("\\s+", "");
+    }
+
+    /**
+     * getOrCreateCategory, from its signature to its closing brace, found by counting braces so
+     * that whatever is written after it stays out.
+     */
+    private static String methodBody() throws IOException {
+        String source = readSource();
+        int at = source.indexOf(" getOrCreateCategory(");
+        if (at < 0) {
+            fail("getOrCreateCategory is gone from " + SOURCE_PATH + ", so this test no longer "
+                    + "checks anything. Point it at wherever the lookup moved to.");
+        }
+        int depth = 0;
+        for (int i = source.indexOf('{', at); i < source.length(); i++) {
+            if (source.charAt(i) == '{') {
+                depth++;
+            } else if (source.charAt(i) == '}' && --depth == 0) {
+                return source.substring(at, i);
+            }
+        }
+        fail("getOrCreateCategory has no closing brace");
+        return null;
+    }
+
+    private static int occurrences(String text, String token) {
+        int count = 0;
+        for (int at = text.indexOf(token); at >= 0; at = text.indexOf(token, at + 1)) {
+            count++;
+        }
+        return count;
+    }
+
+    private static String readSource() throws IOException {
+        File source = new File(SOURCE_PATH);
+        if (!source.exists()) {
+            source = new File("app/" + SOURCE_PATH);
+        }
+        if (!source.exists()) {
+            fail("could not find " + SOURCE_PATH + " from " + new File(".").getAbsolutePath());
+        }
+        return new String(Files.readAllBytes(source.toPath()), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
Fixes #107.

## What was wrong

`AbstractDataImporter.getOrCreateCategory` looks for an existing category by name and by either the row's own direction type or the system type:

```java
String[] selectionArgs = new String[] {name,
        String.valueOf(type.getValue()),
        String.valueOf(Contract.CategoryType.SYSTEM)
};
```

The third argument is the enum constant, not its value. `Contract.CategoryType` declares no `toString`, so `String.valueOf` returned the literal `SYSTEM`, and `category_type` holds an integer. That arm of the `OR` matched nothing, so a CSV row naming a system category never found the seeded row, and was matched or created as an ordinary category of its own direction instead. The second argument is unaffected, which is why ordinary categories were still reused.

The duplicate is a plain user category, so the picker the transaction editor opens offers it, and that picker is not given system categories.

## Why the one line is not the fix

Fixing only the argument opens a money bug, and I reproduced it on a device before writing the rest.

An income or expense category is its direction. A system category is not, and the editor does not treat it as one: `NewEditTransactionActivity` never reads `transaction_direction`. It derives a direction from the category through `Category.getDirection` and writes that over the row on every save. The importer takes direction from the sign of the amount, so an income row named `Deposit` lands on the saving deposit category, which implies an expense.

On a build with the argument fixed and nothing else, a 12.00 income filed that way became an expense the first time it was opened and saved. The wallet total moved by 24.00. The row was not edited: the editor was opened and the save button pressed.

## The change

A matched category is reused only when it holds the row's direction without rewriting it.

For a system category that means the tag has to be one `Category.getDirection` has a case for. Those eight are listed in the importer rather than inferred, because the zero it returns for a tag it does not know is the same zero it returns for an expense, so an unknown tag cannot be told apart from an expense tag at the point of the decision. The transfer tag is one it does not know, and belongs nowhere in such a list anyway: a transfer is written as two legs, one per wallet, so both directions appear under it.

A candidate the guard refuses is passed over rather than ending the search, so a system category cannot hide a category the user made behind it. A row with no acceptable candidate creates an ordinary category, which is what happened before this change.

## What it reaches, and what it costs

It reaches the system rows this app writes with a settled direction, read out of the database rather than assumed: a debt payment and a saving deposit are stored as expenses, a saving withdraw as an income, each matching its tag. A CSV export leaves the two legs of a transfer out but deliberately keeps the fee, and that row carries the transfer tax tag and is stored as an expense, so a round trip now returns it to the seeded category instead of building a duplicate.

The cost is the fix rather than a side effect, so it belongs here: a row that reaches a seeded category sits on one the editor's picker will not offer, so its category can be changed once and never set back. The seeded names are ordinary words, `Tax`, `Credit`, `Debt` and `Deposit` among them, so a user importing a file from another app can meet this without ever having used this one's export.

## What this does not fix

The guard contains the trap at the importer. It does not remove it. Three editors, for transactions, recurrences and models, discard a stored direction and recompute it from a category that cannot know the answer. They are left alone deliberately: the transaction one writes the direction of every debt payment and saving movement, on a path with no automated coverage.

## What I tested

Android 16 emulator, floss debug build. One file of five rows, run against `master` and against this branch from the same starting rows each time.

| Row | `master` | This branch |
|---|---|---|
| `Debt paid`, expense | new category, type expense | seeded category 5, tag `system::paid_debt` |
| `Deposit`, expense | new category, type expense | seeded category 8, tag `system::deposit` |
| `Deposit`, income | new category, type income | new ordinary category, the guard holding |
| `Transfer`, expense | new category, type expense | new ordinary category, the guard holding |
| `Travel`, expense | matched the existing `Travel` | matched the existing `Travel` |

Four categories created before, two after. `Travel` is the control: an ordinary category already present, matched by both builds, so the lookup itself was working and only the system argument was not. Read out of `categories` and `transactions` after each run.

Then the regression check: opening a row that had landed on a seeded category and saving it, which is the action that flipped a row on the build with the argument fixed and no guard, left its category, direction, amount and the wallet total unchanged.

## Tests

`chooseCategory` runs for real against a mocked cursor: ordinary categories, each of the eight tags in both directions, the transfer tag and a null, empty or unknown tag refused for both, a refused candidate passed over rather than ending the search, and a cursor somebody has already moved.

The query it reads from cannot be run in a JVM test, since entering the method touches a static `Uri` and there is no Robolectric on the unit test classpath. So the two statements of it this change altered, the projection and the arguments, are read out of the source, the way `NewEditTransactionActivitySourceTest` reads its own, and so are the two lines that carry the answer back to the caller. Statements this change does not touch are left unpinned, even where a mutation of one would be serious, because pinning them would fail on a reformat this branch has no opinion about.

Fourteen mutations of the lines this change does touch were run and every one fails a test. A fifteenth was run to confirm it does nothing: wrapping the lookup in the `moveToFirst` that every other lookup in this class opens with, which would otherwise have skipped the best candidate, and which the scan rewinding is what makes harmless.

## Two limits, neither addressed here

Duplicates an earlier import created are left where they are. The query sorts by id descending and every duplicate has a higher id than the row it duplicates, so a database that already holds one keeps filing onto it. Splitting those rows across two categories would be worse than leaving them together, and merging them is a data migration rather than a lookup fix.

The match is by name, and `SystemCategoryLocalizer` rewrites system category names to the device language, so whether a row reaches a seeded category now depends on the language of the importing device. Before this change it reached one in no language at all. The stable identifier is `category_tag`, which a CSV does not carry.
