### PR TITLE
Read a CSV import in full before writing any of its rows

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
@@ -24,16 +24,40 @@ import java.util.Map;
  */
 public class CSVDataImporter extends AbstractDataImporter {
 
+    private final File mFile;
+
     private final CSVReaderHeaderAware mReader;
 
     public CSVDataImporter(Context context, File file) throws IOException {
         super(context, file);
+        mFile = file;
         mReader = new CSVReaderHeaderAware(new FileReader(file));
     }
 
+    /**
+     * Reads the whole file once without writing, then reads it again to write it. Writing a row as
+     * it was read left every row ahead of a refused one in the ledger, under an import the app
+     * reported as failed, and with no count of what had landed. Reading twice parses every row
+     * twice, which is the price of not holding the parsed rows: an import file has no ceiling, and
+     * a list of them would grow with it.
+     */
     @Override
     public void importData() throws IOException {
-        Map<String, String> lineMap = mReader.readMap();
+        try (CSVReaderHeaderAware check = new CSVReaderHeaderAware(new FileReader(mFile))) {
+            readRows(check, false);
+        }
+        readRows(mReader, true);
+    }
+
+    /**
+     * Reads every row, throwing on the first row that is refused, and writes each row as it is
+     * read when asked to. The caller runs a pass with writing off first, so that a refused file
+     * ends the import with nothing written. That does not make the writing pass
+     * itself safe: {@link #insertTransaction} can throw part way through, and what it wrote by then
+     * stays.
+     */
+    private void readRows(CSVReaderHeaderAware reader, boolean write) throws IOException {
+        Map<String, String> lineMap = reader.readMap();
         while (lineMap != null) {
             // extract required information from the csv file
             String wallet = getTrimmedString(lineMap.get(Constants.COLUMN_WALLET));
@@ -66,8 +90,10 @@ public class CSVDataImporter extends AbstractDataImporter {
             long money = MoneyScale.toMinorUnits(moneyDecimal, currencyUnit.getDecimals());
             int direction = money < 0 ? Contract.Direction.EXPENSE : Contract.Direction.INCOME;
             Date datetime = DateUtils.getDateFromSQLDateTimeString(datetimeString);
-            insertTransaction(wallet, currencyUnit, category, datetime, Math.abs(money), direction, description, event, place, people, note);
-            lineMap = mReader.readMap();
+            if (write) {
+                insertTransaction(wallet, currencyUnit, category, datetime, Math.abs(money), direction, description, event, place, people, note);
+            }
+            lineMap = reader.readMap();
         }
     }
 


### PR DESCRIPTION
Fixes #108.

## What was broken

`CSVDataImporter` saved each row as soon as it read it. When a row is bad the importer throws, and that error goes straight out to `ImportExportIntentService`, which tells the user the import failed. So every row before the bad one was already in the ledger, under a message saying nothing had happened. Fixing the file and importing again then duplicated those rows.

## The fix

Read the whole file once without saving anything, then read it again to save it. A bad row is found on the first read, so nothing is saved.

The first read catches everything that can reject a row: a required column missing or empty, a currency the app does not have, an amount that will not parse, a date that will not parse, and a row whose field count does not match the header.

## What it does not fix

Only the file is checked up front. Once saving starts, a failure partway still leaves the earlier rows behind. That happens if `insertTransaction` cannot create a wallet, category, place or person, or if the database errors. A transaction around the whole import would cover it, but the app uses no SQLite transactions anywhere and the content provider has no way to start one, so that is a much bigger change.

## Why read twice instead of keeping the rows

An import file can be any size, so keeping every parsed row uses memory in proportion to it. Running out throws `OutOfMemoryError`, which is an `Error`, not an `Exception`. The service catches only `Exception`, so the app would die with no message at all. Reading twice spends time instead.

## Tested

Android 16 emulator, same starting ledger of 50 transactions on both builds.

| File | Build | Result | Transactions after |
|---|---|---|---|
| 3 rows, middle one a date with no time | `master` at `00ff852` | Failed | 51 |
| the same file | this branch | Failed | 50 |
| the same 3 rows, date fixed | this branch | Success | 53 |

On `master` the first row saved, so the user was told the import failed and kept part of it. On this branch nothing saved and no category or wallet was created.

No unit test. The importer calls two Android statics, and the mocking needed to replace them breaks three existing tests on JDK 21. The instrumented tests do not build at all, on `androidx.test:core` 1.2.0. All 149 unit tests pass.
