### PR TITLE
Accept a CSV date with no time, and say which line was refused

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Earlier work, all shipped: Android 14/15 compatibility on a modernized FOSS/Open
 
 Progress is tracked in this repository's [issues](https://github.com/herrerad85/moneywallet/issues).
 
+## The CSV import format
+The header row carries the raw column keys, and a file written by hand needs the same ones. Five columns are required on every row: `wallet`, `currency`, `category`, `datetime` and `money`. Five more are optional: `description`, `event`, `people`, `place` and `note`.
+
+`datetime` is `yyyy-MM-dd HH:mm:ss`, or `yyyy-MM-dd` for a row with no time of day. `currency` is the ISO code, and it has to be one the app already has. `money` is negative for an expense, and zero or above for income.
+
+```
+"wallet","currency","category","datetime","money","description"
+"Everyday","USD","Groceries","2026-08-12 09:30:00","-12.34","market"
+"Everyday","USD","Salary","2026-08-12","2000.00","august"
+```
+
+A row the importer will not read ends the import before anything from the file is saved, and the message names the line it stopped on. A row the CSV reader itself will not read, such as one with the wrong number of fields, ends it the same way but with the reader's own wording.
+
 ## Build from source
 The fully open-source variant uses OpenStreetMap and no proprietary services. Build the `floss` + `osm` flavors:
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
@@ -1,7 +1,6 @@
 package com.oriondev.moneywallet.storage.database.data.csv;
 
 import android.content.Context;
-import android.text.TextUtils;
 
 import com.opencsv.CSVReaderHeaderAware;
 import com.oriondev.moneywallet.model.CurrencyUnit;
@@ -23,6 +22,9 @@ import java.util.Map;
  * Created by andrea on 23/12/18.
  */
 public class CSVDataImporter extends AbstractDataImporter {
+
+    /** The length of yyyy-MM-dd, which the date parse itself does not bound. */
+    private static final int SQL_DATE_LENGTH = 10;
 
     private final File mFile;
 
@@ -58,42 +60,108 @@ public class CSVDataImporter extends AbstractDataImporter {
     private void readRows(CSVReaderHeaderAware reader, boolean write) throws IOException {
         Map<String, String> lineMap = reader.readMap();
         while (lineMap != null) {
-            // extract required information from the csv file
-            String wallet = getTrimmedString(lineMap.get(Constants.COLUMN_WALLET));
-            String currency = getTrimmedString(lineMap.get(Constants.COLUMN_CURRENCY));
-            String category = getTrimmedString(lineMap.get(Constants.COLUMN_CATEGORY));
-            String datetimeString = getTrimmedString(lineMap.get(Constants.COLUMN_DATETIME));
-            String moneyString = getTrimmedString(lineMap.get(Constants.COLUMN_MONEY));
-            // if one of this information is missing, we should stop the import
-            // process because the file is not valid
-            if (TextUtils.isEmpty(wallet) || TextUtils.isEmpty(currency) || TextUtils.isEmpty(category) || TextUtils.isEmpty(datetimeString) || TextUtils.isEmpty(moneyString)) {
-                throw new RuntimeException("Invalid csv file: one or more required columns are missing");
-            }
-            // extract the optional information from the csv file
-            String description = getTrimmedString(lineMap.get(Constants.COLUMN_DESCRIPTION));
-            String event = getTrimmedString(lineMap.get(Constants.COLUMN_EVENT));
-            String people = getTrimmedString(lineMap.get(Constants.COLUMN_PEOPLE));
-            String place = getTrimmedString(lineMap.get(Constants.COLUMN_PLACE));
-            String note = getTrimmedString(lineMap.get(Constants.COLUMN_NOTE));
-            // try to build the internal transaction state starting from strings
-            CurrencyUnit currencyUnit = CurrencyManager.getCurrency(currency);
-            if (currencyUnit == null) {
-                throw new RuntimeException("Unknown currency unit (" + currency + ")");
-            }
-            BigDecimal moneyDecimal;
             try {
-                moneyDecimal = new BigDecimal(moneyString.replaceAll(",", "."));
-            } catch (NumberFormatException e) {
-                throw new RuntimeException("Invalid money amount (" + e.getMessage() + ")");
-            }
-            long money = MoneyScale.toMinorUnits(moneyDecimal, currencyUnit.getDecimals());
-            int direction = money < 0 ? Contract.Direction.EXPENSE : Contract.Direction.INCOME;
-            Date datetime = DateUtils.getDateFromSQLDateTimeString(datetimeString);
-            if (write) {
-                insertTransaction(wallet, currencyUnit, category, datetime, Math.abs(money), direction, description, event, place, people, note);
+                readRow(lineMap, write);
+            } catch (RuntimeException e) {
+                // Only the checking pass blames a line. The saving pass is where
+                // insertTransaction runs, and "Line 37: Failed to create the new wallet" would
+                // send the user to look at a row that is fine.
+                if (write) {
+                    throw e;
+                }
+                throw new RuntimeException("Line " + reader.getLinesRead() + ": " + e.getMessage(), e);
             }
             lineMap = reader.readMap();
         }
+    }
+
+    private void readRow(Map<String, String> lineMap, boolean write) {
+        // extract required information from the csv file
+        String wallet = required(lineMap, Constants.COLUMN_WALLET);
+        String currency = required(lineMap, Constants.COLUMN_CURRENCY);
+        String category = required(lineMap, Constants.COLUMN_CATEGORY);
+        String datetimeString = required(lineMap, Constants.COLUMN_DATETIME);
+        String moneyString = required(lineMap, Constants.COLUMN_MONEY);
+        // extract the optional information from the csv file
+        String description = getTrimmedString(lineMap.get(Constants.COLUMN_DESCRIPTION));
+        String event = getTrimmedString(lineMap.get(Constants.COLUMN_EVENT));
+        String people = getTrimmedString(lineMap.get(Constants.COLUMN_PEOPLE));
+        String place = getTrimmedString(lineMap.get(Constants.COLUMN_PLACE));
+        String note = getTrimmedString(lineMap.get(Constants.COLUMN_NOTE));
+        // try to build the internal transaction state starting from strings
+        CurrencyUnit currencyUnit = CurrencyManager.getCurrency(currency);
+        if (currencyUnit == null) {
+            throw new RuntimeException("Unknown currency unit (" + currency + ")");
+        }
+        BigDecimal moneyDecimal;
+        try {
+            moneyDecimal = new BigDecimal(moneyString.replaceAll(",", "."));
+        } catch (NumberFormatException e) {
+            throw new RuntimeException("Invalid money amount (" + e.getMessage() + ")");
+        }
+        long money = MoneyScale.toMinorUnits(moneyDecimal, currencyUnit.getDecimals());
+        int direction = money < 0 ? Contract.Direction.EXPENSE : Contract.Direction.INCOME;
+        Date datetime = parseDatetime(datetimeString);
+        if (write) {
+            insertTransaction(wallet, currencyUnit, category, datetime, Math.abs(money), direction, description, event, place, people, note);
+        }
+    }
+
+    /**
+     * The value of a column every row needs. A column the header does not have and a cell left
+     * empty are mistakes in different places, so they do not get the same message.
+     */
+    /*package-local*/ static String required(Map<String, String> lineMap, String column) {
+        String value = lineMap.get(column);
+        if (value == null) {
+            throw new RuntimeException("no " + column + " column was found. Check the header line");
+        }
+        value = value.trim();
+        if (value.isEmpty()) {
+            throw new RuntimeException("the " + column + " is empty, and every row needs one");
+        }
+        return value;
+    }
+
+    /**
+     * A datetime, or a date on its own. A date with no time is the obvious thing to write by
+     * hand, and it used to end the whole import.
+     *
+     * The datetime is tried first because that is what this app's own export writes. The order
+     * is not what makes this safe; the two checks below are, and they hold in either order.
+     */
+    /*package-local*/ static Date parseDatetime(String value) {
+        try {
+            return DateUtils.getDateFromSQLDateTimeString(value);
+        } catch (RuntimeException notADatetime) {
+            // fall through and read it as a date on its own
+        }
+        Date date;
+        try {
+            date = DateUtils.getDateFromSQLDateString(value);
+        } catch (RuntimeException notADate) {
+            throw notADate(value);
+        }
+        // What this parse does not throw for, it can still read as a different day than the one
+        // written down, so the answer is written back out and compared. That is what refuses
+        // anything still carrying a time, since the parse stops at the first character it cannot
+        // use and "2026-08-12T09:30:15" would come back as the 12th with the time gone, and
+        // anything naming a day past the end of its month, since it rolls those forward and
+        // "2026-02-30" would come back as March 2nd. The length covers the one thing the
+        // comparison cannot see. A year is padded out to four digits and never cut short, so a
+        // short year fails the comparison anyway, but a year past 9999 is written back at its own
+        // length: "12026-08-12" compares equal to itself and would land in the year 12026. Every
+        // value refused here was already refused before a date on its own was accepted at all.
+        // The length is tested first, so for most of these it is the check that fires.
+        if (value.length() != SQL_DATE_LENGTH || !DateUtils.getSQLDateString(date).equals(value)) {
+            throw notADate(value);
+        }
+        return date;
+    }
+
+    private static RuntimeException notADate(String value) {
+        return new RuntimeException("the datetime \"" + value + "\" is not a real date as "
+                + "yyyy-MM-dd HH:mm:ss or yyyy-MM-dd");
     }
 
     private String getTrimmedString(String source) {

--- a/app/src/test/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporterTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporterTest.java
@@ -1,0 +1,145 @@
+package com.oriondev.moneywallet.storage.database.data.csv;
+
+import com.oriondev.moneywallet.utils.DateUtils;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * The importer's row reading talks to a content resolver and to an Android static, so it cannot be
+ * driven from a JVM test. The two pieces that need neither are here. What is not covered, and was
+ * checked on an emulator instead: the line number the refusals are prefixed with.
+ */
+public class CSVDataImporterTest {
+
+    @Test
+    public void aDatetimeKeepsItsTime() {
+        assertEquals(at(2026, 8, 12, 9, 30, 15), CSVDataImporter.parseDatetime("2026-08-12 09:30:15"));
+    }
+
+    /**
+     * Midnight in the zone the device is in. On the handful of days a zone skips midnight for
+     * daylight saving, the lenient parse answers 01:00 on the same day instead.
+     */
+    @Test
+    public void aDateOnItsOwnIsMidnight() {
+        assertEquals(at(2026, 8, 12, 0, 0, 0), CSVDataImporter.parseDatetime("2026-08-12"));
+    }
+
+    /**
+     * A fact about DateUtils, not a check on the importer: nothing done to the importer can turn
+     * this red. It is here because it is the reason parseDatetime cannot just read the date and
+     * stop. The test that goes red if the comparison in parseDatetime is removed is
+     * aDayThatDoesNotExistIsRefusedWhenTheRowHasNoTime below, checked by removing it.
+     */
+    @Test
+    public void theDateParseDropsTheTimeFromAFullDatetime() {
+        assertEquals(at(2026, 8, 12, 0, 0, 0),
+                DateUtils.getDateFromSQLDateString("2026-08-12 09:30:15"));
+    }
+
+    /**
+     * The date parse stops at the first character it cannot use, so the first three of these
+     * would read as a date with whatever follows it dropped, and the fourth as August 1st. None
+     * is ten characters, so in practice the length refuses all four before the comparison is
+     * reached; take the length away and the comparison refuses all four on its own. All four were
+     * refused outright before a date on its own was accepted.
+     */
+    @Test
+    public void aDateWithAnythingElseOnItIsRefused() {
+        refuses("2026-08-12T09:30:15");
+        refuses("2026-08-12 09:30");
+        refuses("2026-08-12garbage");
+        refuses("2026-8-1");
+    }
+
+    /**
+     * Only when the row carries no time. A day past the end of its month is still rolled when a
+     * time is written after it, because that value goes through the datetime parse, which is
+     * untouched here and behaves as it always has: "2026-02-30 00:00:00" imports as March 2nd.
+     * Tightening that would stop files importing that import today.
+     */
+    @Test
+    public void aDayThatDoesNotExistIsRefusedWhenTheRowHasNoTime() {
+        refuses("2026-02-30");
+        refuses("2026-13-45");
+        refuses("2026-00-00");
+    }
+
+    /**
+     * A year past 9999 is written back out at its own length, so it compares equal to itself and
+     * the comparison alone lets it through. It is the one thing the length is there for. A short
+     * year is not: it is padded out to four digits, so "926-08-12" fails the comparison and is
+     * refused whether the length is checked or not.
+     */
+    @Test
+    public void aYearPastFourDigitsIsRefused() {
+        refuses("12026-08-12");
+        refuses("926-08-12");
+    }
+
+    @Test
+    public void aMissingColumnAndAnEmptyCellAreDifferentMessages() {
+        Map<String, String> row = new HashMap<>();
+        row.put("wallet", "Probe");
+        row.put("currency", "  ");
+        assertEquals("Probe", CSVDataImporter.required(row, "wallet"));
+        assertEquals("no money column was found. Check the header line",
+                messageFrom(row, "money"));
+        assertEquals("the currency is empty, and every row needs one", messageFrom(row, "currency"));
+    }
+
+    private static String messageFrom(Map<String, String> row, String column) {
+        try {
+            CSVDataImporter.required(row, column);
+            fail(column + " has to be refused");
+            return null;
+        } catch (RuntimeException e) {
+            return e.getMessage();
+        }
+    }
+
+    @Test
+    public void theMessageNamesTheValueAndBothFormats() {
+        try {
+            CSVDataImporter.parseDatetime("12/08/2026");
+            fail("a date in another format has to be refused");
+        } catch (RuntimeException e) {
+            assertEquals("this message is what the failure dialog is built around",
+                    "the datetime \"12/08/2026\" is not a real date as yyyy-MM-dd HH:mm:ss "
+                            + "or yyyy-MM-dd",
+                    e.getMessage());
+        }
+    }
+
+    /**
+     * Checks the whole message, not just that something was thrown. Checking only that the message
+     * names the value is not enough: the exception DateUtils throws names it too, so these tests
+     * would stay green with the date reading taken out altogether.
+     */
+    private static void refuses(String value) {
+        try {
+            Date parsed = CSVDataImporter.parseDatetime(value);
+            fail(value + " has to be refused, but it read as " + DateUtils.getSQLDateTimeString(parsed));
+        } catch (RuntimeException expected) {
+            assertEquals("refused, but not by the importer's own check",
+                    "the datetime \"" + value + "\" is not a real date as yyyy-MM-dd HH:mm:ss "
+                            + "or yyyy-MM-dd",
+                    expected.getMessage());
+        }
+    }
+
+    private static Date at(int year, int month, int day, int hour, int minute, int second) {
+        Calendar calendar = new GregorianCalendar(year, month - 1, day, hour, minute, second);
+        calendar.set(Calendar.MILLISECOND, 0);
+        return calendar.getTime();
+    }
+}


### PR DESCRIPTION
Fixes #109.

## What was broken

The importer read the datetime column with one pattern, `yyyy-MM-dd HH:mm:ss`. A date with no time is the obvious thing to write by hand, and it ended the import with only this:

> Failure during the import procedure. Message: java.text.ParseException: Unparseable date: "2026-08-12"

Nothing said which line, and the format was undocumented.

## The fix

The importer reads the file twice, checking then saving. A date with no time is now accepted, and a refusal during the checking read starts with the line number, counted in file lines. The README now states the format.

It gets two checks, because the parse behind it accepts more than it should. Writing the answer back out and comparing refuses anything reading as a different date than what was written: `2026-08-12T09:30:15` would import as the 12th with its time gone, `2026-02-30` as March 2nd. Requiring exactly ten characters covers what that misses, a year past 9999: `12026-08-12` writes back out as itself. Everything refused here was refused before too, so nothing that used to import stops importing.

A missing column and an empty cell now say which.

## What it does not cover

A value carrying a time that parses is untouched, so `2026-02-30 00:00:00` still imports as March 2nd. Checking that too would stop files importing that import today. The odd result: dropping the time can turn an accepted row into a refusal, since `2026-8-1 09:00:00` imports and `2026-8-1` does not.

Two failures carry no line number: one from the CSV reader, which keeps its own wording, and one during the saving read, which is not the file's fault. Whatever was saved before it stays, as it did before this branch.

## Tested

Android 16 emulator, same starting ledger of 50 on both builds. A date with no time fails on `master` with the exception above. On this branch it imports as `2026-08-12 00:00:00`, and the timed row keeps `09:00:00`.

Four refusals, all leaving the ledger at 50: a third data row reading `not a date` gives `Line 4`, and `2026-08-12T09:30:15`, `12026-08-12` and a header with no money column each give `Line 2`.

157 unit tests pass, eight of them new.
