### PR TITLE
Refuse a negative amount from the keypad, except a wallet starting balance

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/picker/MoneyPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/MoneyPicker.java
@@ -41,6 +41,7 @@ public class MoneyPicker extends Fragment {
     private static final String SS_CURRENT_MONEY = "MoneyPicker::SavedState::CurrentMoney";
     private static final String ARG_DEFAULT_CURRENCY = "MoneyPicker::Arguments::DefaultCurrency";
     private static final String ARG_DEFAULT_MONEY = "MoneyPicker::Arguments::DefaultMoney";
+    private static final String ARG_ALLOW_NEGATIVE = "MoneyPicker::Arguments::AllowNegative";
 
     private static final int REQUEST_MONEY_PICKER = 4546;
 
@@ -49,15 +50,32 @@ public class MoneyPicker extends Fragment {
     private CurrencyUnit mCurrentCurrency;
     private long mCurrentMoney;
 
+    /**
+     * Creates a picker whose keypad will not confirm a negative amount. A transaction takes its
+     * direction from the category it is filed under, so a typed minus is a second direction that
+     * contradicts it, and a wallet total then moves the wrong way. Elsewhere the amount is a
+     * magnitude with no direction to contradict: a budget target and a debt amount are the ceiling
+     * a progress bar is drawn against, where a negative is a target nothing can reach.
+     */
     public static MoneyPicker createPicker(FragmentManager fragmentManager, String tag, CurrencyUnit currency, long money) {
+        return createPicker(fragmentManager, tag, currency, money, false);
+    }
+
+    public static MoneyPicker createPicker(FragmentManager fragmentManager, String tag, CurrencyUnit currency, long money, boolean allowNegative) {
         MoneyPicker moneyPicker = (MoneyPicker) fragmentManager.findFragmentByTag(tag);
         if (moneyPicker == null) {
             Bundle arguments = new Bundle();
             arguments.putParcelable(ARG_DEFAULT_CURRENCY, currency);
             arguments.putLong(ARG_DEFAULT_MONEY, money);
+            arguments.putBoolean(ARG_ALLOW_NEGATIVE, allowNegative);
             moneyPicker = new MoneyPicker();
             moneyPicker.setArguments(arguments);
             fragmentManager.beginTransaction().add(moneyPicker, tag).commit();
+        } else if (moneyPicker.getArguments() != null) {
+            // A picker found by tag keeps the arguments it was created with, so one that was saved
+            // by a build older than this flag comes back without it. The screen asks for the same
+            // picker every time it is created, so write the current answer in.
+            moneyPicker.getArguments().putBoolean(ARG_ALLOW_NEGATIVE, allowNegative);
         }
         return moneyPicker;
     }
@@ -157,6 +175,11 @@ public class MoneyPicker extends Fragment {
         intent.putExtra(CalculatorActivity.ACTIVITY_MODE, CalculatorActivity.MODE_KEYPAD);
         intent.putExtra(CalculatorActivity.CURRENCY, mCurrentCurrency);
         intent.putExtra(CalculatorActivity.MONEY, mCurrentMoney);
+        // Read at the point of use rather than kept in a field, so that the answer written in by
+        // createPicker above reaches the keypad even when the picker itself was already there.
+        Bundle arguments = getArguments();
+        intent.putExtra(CalculatorActivity.ALLOW_NEGATIVE,
+                arguments != null && arguments.getBoolean(ARG_ALLOW_NEGATIVE));
         startActivityForResult(intent, REQUEST_MONEY_PICKER);
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/CalculatorActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/CalculatorActivity.java
@@ -30,6 +30,7 @@ import android.widget.TextView;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.ui.activity.base.SinglePanelActivity;
+import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.EquationSolver;
 
 /**
@@ -40,6 +41,7 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
     public static final String ACTIVITY_MODE = "CalculatorActivity::Parameters::ActivityMode";
     public static final String CURRENCY = "CalculatorActivity::Parameters::Currency";
     public static final String MONEY = "CalculatorActivity::Parameters::Money";
+    public static final String ALLOW_NEGATIVE = "CalculatorActivity::Parameters::AllowNegative";
 
     public static final int MODE_CALCULATOR = 0;
     public static final int MODE_KEYPAD = 1;
@@ -69,6 +71,7 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
     private EquationSolver mSolver;
 
     private boolean mKeypadMode;
+    private boolean mAllowNegative;
 
     @Override
     protected void onCreatePanelView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
@@ -101,6 +104,7 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
     protected void onViewCreated(Bundle savedInstanceState) {
         Intent intent = getIntent();
         mKeypadMode = intent.getIntExtra(ACTIVITY_MODE, MODE_CALCULATOR) == MODE_KEYPAD;
+        mAllowNegative = intent.getBooleanExtra(ALLOW_NEGATIVE, false);
         if (savedInstanceState == null) {
             CurrencyUnit currency = intent.getParcelableExtra(CURRENCY);
             long money = intent.getLongExtra(MONEY, 0L);
@@ -170,8 +174,20 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
                 // TODO: show error!
             }
         } else if (mKeypadMode) {
+            long money = mSolver.getResult();
+            // The screen that opened the keypad says whether a negative belongs in the field it is
+            // filling. Where it does not, an amount below zero is not handed back, and is left on
+            // the display so it can be corrected.
+            if (money < 0 && !mAllowNegative) {
+                ThemedDialog.buildMaterialDialog(this)
+                        .title(R.string.title_error)
+                        .content(R.string.message_error_negative_amount)
+                        .positiveText(android.R.string.ok)
+                        .show();
+                return;
+            }
             Intent intent = new Intent();
-            intent.putExtra(MONEY, mSolver.getResult());
+            intent.putExtra(MONEY, money);
             setResult(RESULT_OK, intent);
             finish();
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditWalletActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditWalletActivity.java
@@ -192,7 +192,9 @@ public class NewEditWalletActivity extends NewEditItemActivity implements IconPi
         FragmentManager fragmentManager = getSupportFragmentManager();
         mIconPicker = IconPicker.createPicker(fragmentManager, TAG_ICON_PICKER, icon);
         mCurrencyPicker = CurrencyPicker.createPicker(fragmentManager, TAG_CURRENCY_PICKER, currencyUnit);
-        mMoneyPicker = MoneyPicker.createPicker(fragmentManager, TAG_MONEY_PICKER, currencyUnit, startMoney);
+        // A wallet is the one place a negative belongs: a credit card or an overdrawn account
+        // starts below zero, and the balance is drawn with its sign.
+        mMoneyPicker = MoneyPicker.createPicker(fragmentManager, TAG_MONEY_PICKER, currencyUnit, startMoney, true);
         // configure pickers
         mIconPicker.listenOn(mNameEditText);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -415,6 +415,7 @@
     <string name="message_action_archive_saving">"Are you sure you want to archive this saving?"</string>
     <string name="message_action_unarchive_saving">"Are you sure you want to unarchive this saving?"</string>
     <string name="message_error_activity_not_found">"No application found on this device to handle the request."</string>
+    <string name="message_error_negative_amount">"The amount cannot be negative. The minus key is for subtracting."</string>
     <string name="message_delete_currency">"Are you sure you want to delete this currency?"</string>
     <string name="message_error_delete_currency">"This currency cannot be deleted because it is in use."</string>
     <string name="message_delete_wallet">"Are you sure you want to delete this wallet? All the related data will be removed."</string>


### PR DESCRIPTION
Fixes #112.

## What happens

The subtraction key is accepted before any number is typed, so 0, minus, 10, equals reads -10 on the amount keypad. Saving that as an expense stored -1000 with an expense direction. A wallet total is summed as `SUM(((transaction_direction * 2) - 1) * transaction_money)`, where an expense counts with a factor of -1, so the total rose by 10 instead of falling by it. The list draws the sign from the category and the amount through `Math.abs`, so the row looked like any other.

## The change

A transaction takes its direction from the category it is filed under, so a typed minus is a second direction that contradicts it. Elsewhere the amount is a magnitude with no direction to contradict: a budget target and a debt amount are the ceiling a progress bar is drawn against, where a negative is a target nothing can reach.

`MoneyPicker` now tells `CalculatorActivity` whether the field it is filling accepts a negative. In keypad mode an amount below zero is left on the display with an error instead of being handed back. A wallet starting balance is the exception, since a credit card starts below zero, so that picker opts in and the other thirteen take the default. The calculator opened from the navigation drawer runs in `MODE_CALCULATOR` and never reaches that branch.

## What it does not cover

Entry only. A row that already holds a negative is loaded into the picker and written back unchanged on save, and restore, recurrence generation and insert from a model copy stored amounts without the keypad. Withdraw everything on a saving that already sits below zero preloads that negative, and the keypad now refuses it while Save still writes it.

## What I tested

Android 16 emulator. Before, 0 minus 10 filed against an expense category stored -1000, and summing that wallet's confirmed counted rows with the factor above moved the result up by 10.00 rather than down. After, the same keys leave the keypad open with the error and write no row, a plain 10 stores 1000 and moves the same sum down by 10.00, and a wallet still takes -3.00 as a starting balance, including after a rotation.

Corrected after merge: this section first gave that sum as a running balance of -5128.44 going to -5118.44. It was not the balance the app draws, because the query I ran left out the `DATETIME(...) <= DATETIME('now', 'localtime')` clause the wallet total carries, and this wallet holds rows dated ahead. The direction and size of the change are what was tested and they are unchanged.

