### PR TITLE
Say on save that an entry dated ahead is not counted yet

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditItemActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditItemActivity.java
@@ -23,12 +23,16 @@ import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.CallSuper;
 import androidx.annotation.MenuRes;
+import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.ui.activity.base.SinglePanelActivity;
 import com.oriondev.moneywallet.ui.activity.base.SinglePanelScrollActivity;
+
+import java.util.Date;
 
 /**
  * This activity is an abstract implementation that act as a base for every
@@ -123,4 +127,26 @@ public abstract class NewEditItemActivity extends SinglePanelScrollActivity {
      * @param mode current mode of the activity.
      */
     protected abstract void onSaveChanges(Mode mode);
+
+    /**
+     * Ends a save, saying first that the item is not counted yet when the date it was saved with
+     * is ahead of now. The transaction and transfer lists, the per item lists, the overview and
+     * every balance all filter on DATETIME(date) <= DATETIME('now', 'localtime'), so a row dated
+     * ahead is written and then counts for nothing, and the save reads as though it did nothing.
+     *
+     * A toast rather than a dialog, because this activity is closing and a dialog would have to
+     * hold it open to be read.
+     *
+     * The wording says what the balance does rather than where the row is. The editor can close
+     * back to another application entirely, or to search, which carries no date filter and does
+     * list the row.
+     *
+     * @param date the date the item was saved with.
+     */
+    protected void finishSaveDatedAt(@Nullable Date date) {
+        if (date != null && date.after(new Date())) {
+            Toast.makeText(this, R.string.message_saved_dated_ahead, Toast.LENGTH_LONG).show();
+        }
+        finish();
+    }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -954,7 +954,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             }
             mAttachmentPicker.cleanUp(false);
             setResult(RESULT_OK);
-            finish();
+            finishSaveDatedAt(mDateTimePicker.getCurrentDateTime());
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferActivity.java
@@ -673,7 +673,7 @@ public class NewEditTransferActivity extends NewEditItemActivity  implements Cur
             }
             mAttachmentPicker.cleanUp(false);
             setResult(RESULT_OK);
-            finish();
+            finishSaveDatedAt(mDateTimePicker.getCurrentDateTime());
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransferListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransferListFragment.java
@@ -69,14 +69,19 @@ public class TransferListFragment extends CursorListFragment implements Transfer
             String selection;
             String[] arguments;
             long currentWallet = PreferenceManager.getCurrentWallet();
+            // A transfer touches two wallets, so both branches below select on a pair joined by
+            // OR. The brackets matter: AND binds tighter than OR, so without them the date test
+            // at the end read as "the first term matches, OR the second term matches and the
+            // date has passed". A transfer dated ahead was listed when it matched on its from
+            // side and hidden when it matched only on its to side.
             if (currentWallet == PreferenceManager.TOTAL_WALLET_ID) {
-                selection = Contract.Transfer.TRANSACTION_FROM_WALLET_COUNT_IN_TOTAL + " = 1 OR " +
-                        Contract.Transfer.TRANSACTION_TO_WALLET_COUNT_IN_TOTAL + " = 1";
+                selection = "(" + Contract.Transfer.TRANSACTION_FROM_WALLET_COUNT_IN_TOTAL + " = 1 OR " +
+                        Contract.Transfer.TRANSACTION_TO_WALLET_COUNT_IN_TOTAL + " = 1)";
                 arguments = null;
             } else {
                 String walletId = String.valueOf(currentWallet);
-                selection = Contract.Transfer.TRANSACTION_FROM_WALLET_ID + " = ? OR " +
-                Contract.Transfer.TRANSACTION_TO_WALLET_ID + " = ?";
+                selection = "(" + Contract.Transfer.TRANSACTION_FROM_WALLET_ID + " = ? OR " +
+                Contract.Transfer.TRANSACTION_TO_WALLET_ID + " = ?)";
                 arguments = new String[] {walletId, walletId};
             }
             selection += " AND DATETIME(" + Contract.Transfer.DATE + ") <= DATETIME('now', 'localtime')";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,6 +337,7 @@
     <string name="message_no_transaction_found">"No transaction found"</string>
     <string name="message_no_transaction_found_other_wallets">"No transaction found in the selected wallet. There are transactions in other wallets."</string>
     <string name="message_no_transaction_found_future">"No transaction found in the selected wallet. There are transactions dated in the future."</string>
+    <string name="message_saved_dated_ahead">"Saved. Its date is ahead of now, so the balance does not count it."</string>
     <string name="message_no_transaction_found_other_wallets_and_future">"No transaction found in the selected wallet. There are transactions in other wallets, and transactions dated in the future."</string>
     <string name="message_no_transfer_found">"No transfer found"</string>
     <string name="message_no_category_found">"No category found"</string>


### PR DESCRIPTION
Fixes #113.

## What happens

A transaction or transfer dated ahead of now is written and then counts for nothing: the transaction and transfer lists, the per item lists, the overview and every balance all filter on `DATETIME(date) <= DATETIME('now', 'localtime')`. The save said nothing about it, so it reads as though it failed. The upstream report this comes from concluded the entry had been refused, and someone who reaches that conclusion types it again and ends up with two.

## The change

Both editors now show a toast when the date they saved with is ahead of now. A toast rather than a dialog because the activity is closing and a dialog would have to hold it open to be read. The wording says what the balance does rather than where the row is, since the editor can close back to another application entirely, or to search, which carries no date filter and does list the row.

`TransferListFragment` was not applying that filter as written. A transfer touches two wallets, so its selection is a pair joined by OR, and the date test was appended without brackets. AND binds tighter than OR, so it read as "the first term matches, OR the second term matches and the date has passed": a transfer dated ahead was listed when it matched on its from side and hidden when it matched only on its to side.

## What it does not cover

The two primary lists each carry a single empty message, so a wallet whose only transfers are dated ahead now reads "No transfer found". `TransactionMultiPanelFragment` gained a message for that case in `af3f1fb`; the primary lists have not. Worth its own issue.

## What I tested

Android 16 emulator, clock on 14 August. Dated 20 August, a transaction and a transfer each land in the database, are absent from their list, and the message is on screen over that list. Dated today at a time already past, both appear in their list and no message. The future transfer was listed under its source wallet before this and is not now, while a transfer dated 11 August still is.
