### PR TITLE
Let a category's children be hidden behind an arrow on its row

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/AbstractBackupImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/AbstractBackupImporter.java
@@ -27,11 +27,13 @@ import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.database.ImportException;
 import com.oriondev.moneywallet.storage.database.SQLDatabaseImporter;
 import com.oriondev.moneywallet.storage.database.SyncContentProvider;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Created by andrea on 25/10/18.
@@ -60,6 +62,11 @@ public abstract class AbstractBackupImporter {
         File temporary = createBackupCopyOfCurrentDatabase(databaseFolder);
         try {
             importDatabase(temporaryFolder);
+            // The categories the user had hidden are remembered by id, and the database that
+            // knew those ids has just been replaced. The rows that went into the new one were
+            // given fresh ids in the order they were read, so the remembered ones now name other
+            // categories. Forgetting them leaves every category showing, where the list starts.
+            PreferenceManager.setCollapsedCategories(Collections.<String>emptySet());
         } catch (ImportException e) {
             restoreBackupCopyOfDatabase(databaseFolder, temporary);
             throw e;

--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
@@ -35,6 +35,9 @@ import com.oriondev.moneywallet.model.Group;
 import com.oriondev.moneywallet.model.LockMode;
 
 import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Created by andrea on 24/01/18.
@@ -68,6 +71,7 @@ public class PreferenceManager {
     private static final String CONVERTER_LAST_CURRENCY_2 = "converter_currency_iso_2";
 
     private static final String MAP_TILE_SERVER = "map_tile_server";
+    private static final String COLLAPSED_CATEGORIES = "collapsed_categories";
 
     private static final String LAST_DATA_CHANGE_TIME = "last_data_change_time";
 
@@ -128,6 +132,23 @@ public class PreferenceManager {
         } else {
             mPreferences.edit().putString(MAP_TILE_SERVER, url).apply();
         }
+    }
+
+    /**
+     * @return the ids, as text, of the categories whose children the user has hidden in the
+     *          category list and the category picker. Nothing stored means nothing hidden,
+     *          which is how the list has always been drawn. Stored once rather than held per
+     *          list, so that two lists cannot write each other's hiding away. Each list still
+     *          has to re-read it to redraw, which CategoryListFragment does when it resumes.
+     */
+    public static Set<String> getCollapsedCategories() {
+        // A copy, because getStringSet is documented as returning a set the caller must not
+        // modify, and the callers here are building the next value out of this one.
+        return new HashSet<>(mPreferences.getStringSet(COLLAPSED_CATEGORIES, Collections.<String>emptySet()));
+    }
+
+    public static void setCollapsedCategories(Set<String> categoryIds) {
+        mPreferences.edit().putStringSet(COLLAPSED_CATEGORIES, categoryIds).apply();
     }
 
     public static void setCurrentWallet(Context context, long walletId) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/CategoryCursorAdapter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/CategoryCursorAdapter.java
@@ -31,8 +31,14 @@ import android.widget.TextView;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.CategoryChildIndicator;
 import com.oriondev.moneywallet.utils.IconLoader;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by andrea on 12/02/18.
@@ -47,6 +53,27 @@ public class CategoryCursorAdapter extends AbstractCursorAdapter<CategoryCursorA
     private int mIndexCategoryName;
     private int mIndexCategoryParentId;
 
+    /**
+     * Cursor row of each row on screen, in order. Hiding a category's children leaves their
+     * cursor rows out of this list, so every position this adapter is asked about is read
+     * through it.
+     */
+    private final List<Integer> mVisibleRows = new ArrayList<>();
+
+    /**
+     * Ids of the categories whose children are hidden, as of the last rebuild. Read from the
+     * preference every time rather than kept, because the pager holds one adapter per tab and
+     * the picker opens over the category screen, so several of these are alive at once over one
+     * stored set. An adapter that trusted its own copy would write the others' hiding away.
+     */
+    private final Set<Long> mCollapsedCategories = new HashSet<>();
+
+    /**
+     * Ids of the categories that have at least one child in the current cursor. Only these get
+     * an arrow drawn, which is what says a category has children at all.
+     */
+    private final Set<Long> mCategoriesWithChildren = new HashSet<>();
+
     private final CategoryActionListener mListener;
 
     public CategoryCursorAdapter(CategoryActionListener listener) {
@@ -60,33 +87,143 @@ public class CategoryCursorAdapter extends AbstractCursorAdapter<CategoryCursorA
         mIndexCategoryIcon = cursor.getColumnIndex(Contract.Category.ICON);
         mIndexCategoryName = cursor.getColumnIndex(Contract.Category.NAME);
         mIndexCategoryParentId = cursor.getColumnIndex(Contract.Category.PARENT);
+        // The superclass calls this from two places: when it takes a new cursor, after that
+        // cursor is in place and before it tells the list anything changed, and from its own
+        // constructor. The constructor call cannot land here, because this adapter is always
+        // built with no cursor and the fields the walk below needs do not exist until super
+        // returns.
+        rebuildVisibleRows();
+    }
+
+    private void rebuildVisibleRows() {
+        mVisibleRows.clear();
+        mCategoriesWithChildren.clear();
+        mCollapsedCategories.clear();
+        for (String categoryId : PreferenceManager.getCollapsedCategories()) {
+            mCollapsedCategories.add(Long.valueOf(categoryId));
+        }
+        Cursor cursor = getCursor();
+        if (cursor == null) {
+            return;
+        }
+        Set<Long> categoriesAbove = new HashSet<>();
+        for (int position = 0; position < cursor.getCount(); position++) {
+            cursor.moveToPosition(position);
+            if (cursor.isNull(mIndexCategoryParentId)) {
+                categoriesAbove.add(cursor.getLong(mIndexCategoryId));
+                mVisibleRows.add(position);
+                continue;
+            }
+            long parentId = cursor.getLong(mIndexCategoryParentId);
+            mCategoriesWithChildren.add(parentId);
+            // A child whose category is not above it in this cursor has no arrow that could
+            // bring it back, so it is shown rather than hidden. Two things leave one: the query
+            // drops a category marked deleted out of its join while keeping the children that
+            // name it, and SyncContentProvider inserts rows straight onto the table, past the
+            // check that refuses a child of a category of another type.
+            if (!mCollapsedCategories.contains(parentId) || !categoriesAbove.contains(parentId)) {
+                mVisibleRows.add(position);
+            }
+        }
+    }
+
+    /**
+     * Draws the rows again against what is stored now. The list this adapter is in is not the
+     * only one reading that store, so a list coming back to the front has to ask again rather
+     * than draw what it last built.
+     */
+    public void reloadCollapsedCategories() {
+        rebuildVisibleRows();
+        notifyDataSetChanged();
+    }
+
+    private void toggleChildren(long categoryId) {
+        // Read, change, write, so that the tabs and screens this adapter shares the stored set
+        // with keep their own hiding.
+        Set<String> stored = PreferenceManager.getCollapsedCategories();
+        if (!stored.remove(String.valueOf(categoryId))) {
+            stored.add(String.valueOf(categoryId));
+        }
+        PreferenceManager.setCollapsedCategories(stored);
+        rebuildVisibleRows();
+        notifyDataSetChanged();
+    }
+
+    /**
+     * The cursor row an on screen position stands for, or -1 when there is none. Everything that
+     * takes an on screen position goes through this, and so does every read of the cursor from a
+     * click.
+     */
+    private int cursorPosition(int position) {
+        return position >= 0 && position < mVisibleRows.size() ? mVisibleRows.get(position) : -1;
+    }
+
+    @Override
+    public int getItemCount() {
+        // Guarded rather than returned outright: a cursor swapped away for null leaves the rows
+        // built for it behind, since the superclass only walks a cursor it actually has.
+        return isDataValid() ? mVisibleRows.size() : 0;
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return super.getItemId(cursorPosition(position));
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull CategoryViewHolder holder, int position) {
+        super.onBindViewHolder(holder, cursorPosition(position));
     }
 
     @Override
     public void onBindViewHolder(CategoryViewHolder holder, Cursor cursor) {
         Icon icon = IconLoader.parse(cursor.getString(mIndexCategoryIcon));
         IconLoader.loadInto(icon, holder.mIconImageView);
-        holder.mNameTextView.setText(cursor.getString(mIndexCategoryName));
+        String name = cursor.getString(mIndexCategoryName);
+        holder.mNameTextView.setText(name);
         if (holder.getItemViewType() == TYPE_CHILD) {
             holder.mChildIndicator.setLast(isLastChild(cursor.getPosition()));
+        } else {
+            bindChildrenToggle(holder, cursor.getLong(mIndexCategoryId), name);
         }
     }
 
-    private boolean isLastChild(int position) {
-        int nextCategoryPosition = position + 1;
-        if (nextCategoryPosition < getItemCount()) {
-            Cursor cursor = getCursor();
-            cursor.moveToPosition(nextCategoryPosition);
-            boolean hasParent = !cursor.isNull(mIndexCategoryParentId);
-            cursor.moveToPosition(position);
-            return !hasParent;
+    private void bindChildrenToggle(CategoryViewHolder holder, long categoryId, String name) {
+        boolean hasChildren = mCategoriesWithChildren.contains(categoryId);
+        holder.mChildrenToggle.setVisibility(hasChildren ? View.VISIBLE : View.GONE);
+        if (hasChildren) {
+            boolean collapsed = mCollapsedCategories.contains(categoryId);
+            holder.mChildrenToggle.setRotation(collapsed ? 0f : 180f);
+            // Named, because a screen reader reaches the arrow on its own and every one of them
+            // would otherwise read the same words.
+            holder.mChildrenToggle.setContentDescription(holder.itemView.getContext().getString(
+                    collapsed ? R.string.description_show_subcategories
+                            : R.string.description_hide_subcategories, name));
+        }
+    }
+
+    /**
+     * Whether the child at this cursor row is the last one drawn under its category, which is
+     * what tells the indicator to stop its line half way. The rule is the one that was here
+     * before, and only its bound moved, from the count of rows on screen to the count of rows
+     * in the cursor. Hiding does not disturb the rule: a category's children are hidden or shown
+     * all together, so a shown child is never followed by a hidden sibling.
+     */
+    private boolean isLastChild(int cursorPosition) {
+        Cursor cursor = getCursor();
+        int nextPosition = cursorPosition + 1;
+        if (nextPosition < cursor.getCount()) {
+            cursor.moveToPosition(nextPosition);
+            boolean nextIsChild = !cursor.isNull(mIndexCategoryParentId);
+            cursor.moveToPosition(cursorPosition);
+            return !nextIsChild;
         }
         return true;
     }
 
     @Override
     public int getItemViewType(int position) {
-        Cursor cursor = getSafeCursor(position);
+        Cursor cursor = getSafeCursor(cursorPosition(position));
         return cursor.isNull(mIndexCategoryParentId) ? TYPE_PARENT : TYPE_CHILD;
     }
 
@@ -107,20 +244,37 @@ public class CategoryCursorAdapter extends AbstractCursorAdapter<CategoryCursorA
 
         private CategoryChildIndicator mChildIndicator;
         private ImageView mIconImageView;
+        private ImageView mChildrenToggle;
         private TextView mNameTextView;
 
         /*package-local*/ CategoryViewHolder(View itemView) {
             super(itemView);
             mChildIndicator = itemView.findViewById(R.id.category_child_indicator);
             mIconImageView = itemView.findViewById(R.id.icon_image_view);
+            mChildrenToggle = itemView.findViewById(R.id.children_toggle_image_view);
             mNameTextView = itemView.findViewById(R.id.name_text_view);
             itemView.setOnClickListener(this);
+            if (mChildrenToggle != null) {
+                // Its own listener, because a tap on the row still means what it always did:
+                // pick this category, or open it for editing.
+                mChildrenToggle.setOnClickListener(new View.OnClickListener() {
+
+                    @Override
+                    public void onClick(View view) {
+                        Cursor cursor = getSafeCursor(cursorPosition(getAdapterPosition()));
+                        if (cursor != null) {
+                            toggleChildren(cursor.getLong(mIndexCategoryId));
+                        }
+                    }
+
+                });
+            }
         }
 
         @Override
         public void onClick(View v) {
             if (mListener != null) {
-                Cursor cursor = getSafeCursor(getAdapterPosition());
+                Cursor cursor = getSafeCursor(cursorPosition(getAdapterPosition()));
                 if (cursor != null) {
                     mListener.onCategoryClick(cursor.getLong(mIndexCategoryId));
                 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/CategoryListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/CategoryListFragment.java
@@ -50,6 +50,7 @@ public class CategoryListFragment extends CursorListFragment implements Category
     private static final String ARG_SHOW_CHILDREN = "CategoryListFragment::Arguments::ShowChildren";
 
     private Controller mController;
+    private CategoryCursorAdapter mAdapter;
 
     public static CategoryListFragment newInstance(Contract.CategoryType type, boolean showChildren) {
         Bundle arguments = new Bundle();
@@ -68,7 +69,21 @@ public class CategoryListFragment extends CursorListFragment implements Category
 
     @Override
     protected AbstractCursorAdapter onCreateAdapter() {
-        return new CategoryCursorAdapter(this);
+        mAdapter = new CategoryCursorAdapter(this);
+        return mAdapter;
+    }
+
+    /**
+     * Which categories have their children hidden is stored once for the whole application, and
+     * this list is not the only one reading it: the picker opens over the category screen and
+     * both draw the same categories. Asking again here is what stops the one underneath drawing
+     * a state the other has already changed, which would make its next arrow tap do nothing. The
+     * rows themselves need no reloading, since the loader is watching the categories already.
+     */
+    @Override
+    public void onResume() {
+        super.onResume();
+        mAdapter.reloadCollapsedCategories();
     }
 
     @NonNull

--- a/app/src/main/res/drawable/ic_expand_more_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_expand_more_black_24dp.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M16.59,8.59L12,13.17 7.41,8.59 6,10l6,6 6,-6z"/>
+</vector>

--- a/app/src/main/res/layout/adapter_category_item.xml
+++ b/app/src/main/res/layout/adapter_category_item.xml
@@ -50,8 +50,25 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toEndOf="@+id/icon_image_view"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/children_toggle_image_view"
         app:theme_textColor="textColorPrimary"
         tools:text="Euro" />
+
+    <com.oriondev.moneywallet.ui.view.theme.ThemedImageView
+        android:id="@+id/children_toggle_image_view"
+        android:layout_width="48dp"
+        android:layout_height="0dp"
+        android:layout_marginRight="@dimen/material_component_lists_one_line_action_icon_end_margin"
+        android:layout_marginEnd="@dimen/material_component_lists_one_line_action_icon_end_margin"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:padding="12dp"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_expand_more_black_24dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:theme_backgroundColor="colorWindowForeground"
+        tools:visibility="visible" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/descriptions.xml
+++ b/app/src/main/res/values/descriptions.xml
@@ -41,4 +41,6 @@
     <string name="description_calculator_equals">"Calculate"</string>
     <string name="description_place_picker_icon">"Place picker icon"</string>
     <string name="description_setting_category_icon">"Setting category icon"</string>
+    <string name="description_show_subcategories">"Show subcategories of %1$s"</string>
+    <string name="description_hide_subcategories">"Hide subcategories of %1$s"</string>
 </resources>


### PR DESCRIPTION
Closes #114.

## What happens

Children were always drawn and there was no way to fold them away, so a tree of any size meant scrolling past every child to reach the next category. Asked for twice upstream, in issues 13 and 204, and 13 also asked for a marker that a category has children at all.

## The change

A category with children now carries an arrow. Tapping it hides that category's children and turns the arrow over, and tapping again brings them back.

Which categories are hidden is stored once for the whole app rather than held per list, and a tap reads it, changes it and writes it back. The pager keeps one list per tab alive and the picker opens over the category screen, so a list that trusted its own copy would write the other lists' hiding away. A list asks the store again when it resumes, which stops the one underneath drawing a state the picker has already changed and turning its next arrow tap into a tap that does nothing.

Nothing hidden is the starting state, so the list opens as it always has and no child goes missing on anyone who does not want this. Both upstream requests ask to see only the top level, which is one tap per category away and then stays that way.

`CategoryPickerActivity` and the category screen share `CategoryListFragment` and `CategoryCursorAdapter`, so one change covers both. Restoring a backup forgets what was hidden, since the restored database mints new ids.

## What it does not do

A subcategory added under a hidden category is hidden too, with nothing said. Hiding one announces nothing to a screen reader, since the whole list is rebound rather than the one span.

## What I tested

Android 16 emulator, a child under one expense category and one under an income category. Both screens open with the children showing and an arrow on those two categories and on no others. Tapping an arrow hides them and turns it over. Hiding one on each tab keeps both, which is the case that fails if the set is held per list. Both survive a force stop and a rotation. Hiding one in the picker then returning to the category screen it opened over shows it hidden there too, and the next tap brings the children back rather than doing nothing. A row tap still picks the category, a child row picks the child.
