### PR TITLE
Duplicate a transaction from the screen that shows it

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -89,6 +89,12 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     public static final String SAVING_ACTION = "NewEditTransactionActivity::SavingAction";
     public static final String MODEL_ID = "NewEditTransactionActivity::ModelId";
 
+    /**
+     * Id of a transaction a new one is being copied from. Only read in {@link Mode#NEW_ITEM},
+     * where it fills the editor from that transaction instead of from the arguments above.
+     */
+    public static final String DUPLICATE_ID = "NewEditTransactionActivity::DuplicateId";
+
     public static final int TYPE_STANDARD = 0;
     public static final int TYPE_TRANSFER = 1;
     public static final int TYPE_DEBT = 2;
@@ -344,8 +350,26 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         ArrayList<Attachment> attachments = null;
         if (savedInstanceState == null) {
             ContentResolver contentResolver = getContentResolver();
-            if (getMode() == Mode.EDIT_ITEM) {
-                Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS, getItemId());
+            // A copy opens on what the transaction it came from holds, so it reads that row
+            // through the same block the editor reads its own. Two things it does not take: the
+            // date, which starts at now because the copy is being entered now, and the
+            // attachments, since removing one in this editor deletes the attachment row and its
+            // file outright, with no check for anything else pointing at it, which would leave a
+            // copy holding nothing.
+            //
+            // Only a plain transaction is copied. The others each carry a link the editor does
+            // not draw: a leg belongs to a transfer, and a payment or a deposit belongs to a debt
+            // or a saving whose totals a second one would move with nothing on screen saying so.
+            // The action is not offered for them, and the kind is checked again here rather than
+            // trusted from the caller, since this activity is exported.
+            long duplicateId = getMode() == Mode.NEW_ITEM ? getIntent().getLongExtra(DUPLICATE_ID, 0L) : 0L;
+            boolean duplicating = duplicateId > 0L && isPlainTransaction(contentResolver, duplicateId);
+            if (duplicating) {
+                datetime = new Date();
+            }
+            if (getMode() == Mode.EDIT_ITEM || duplicating) {
+                Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS,
+                        duplicating ? duplicateId : getItemId());
                 String[] projection = new String[] {
                         Contract.Transaction.MONEY,
                         Contract.Transaction.DATE,
@@ -383,7 +407,9 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                 if (cursor != null) {
                     if (cursor.moveToFirst()) {
                         money = cursor.getLong(cursor.getColumnIndex(Contract.Transaction.MONEY));
-                        datetime = DateUtils.getDateFromSQLDateTimeString(cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE)));
+                        if (!duplicating) {
+                            datetime = DateUtils.getDateFromSQLDateTimeString(cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE)));
+                        }
                         mDescriptionEditText.setText(cursor.getString(cursor.getColumnIndex(Contract.Transaction.DESCRIPTION)));
                         category = new Category(
                                 cursor.getLong(cursor.getColumnIndex(Contract.Transaction.CATEGORY_ID)),
@@ -481,30 +507,32 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     cursor.close();
                 }
                 // load all attachments
-                attachments = new ArrayList<>();
-                Uri attachmentsUri = Uri.withAppendedPath(uri, "attachments");
-                projection = new String[] {
-                        Contract.Attachment.ID,
-                        Contract.Attachment.FILE,
-                        Contract.Attachment.NAME,
-                        Contract.Attachment.TYPE,
-                        Contract.Attachment.SIZE
-                };
-                cursor = contentResolver.query(attachmentsUri, projection, null, null, null);
-                if (cursor != null) {
-                    if (cursor.moveToFirst()) {
-                        for (int i = 0; cursor.moveToPosition(i) && i < cursor.getCount(); i++) {
-                            Attachment attachment = new Attachment(
-                                    cursor.getLong(cursor.getColumnIndex(Contract.Attachment.ID)),
-                                    cursor.getString(cursor.getColumnIndex(Contract.Attachment.FILE)),
-                                    cursor.getString(cursor.getColumnIndex(Contract.Attachment.NAME)),
-                                    cursor.getString(cursor.getColumnIndex(Contract.Attachment.TYPE)),
-                                    cursor.getLong(cursor.getColumnIndex(Contract.Attachment.SIZE))
-                            );
-                            attachments.add(attachment);
+                if (!duplicating) {
+                    attachments = new ArrayList<>();
+                    Uri attachmentsUri = Uri.withAppendedPath(uri, "attachments");
+                    projection = new String[] {
+                            Contract.Attachment.ID,
+                            Contract.Attachment.FILE,
+                            Contract.Attachment.NAME,
+                            Contract.Attachment.TYPE,
+                            Contract.Attachment.SIZE
+                    };
+                    cursor = contentResolver.query(attachmentsUri, projection, null, null, null);
+                    if (cursor != null) {
+                        if (cursor.moveToFirst()) {
+                            for (int i = 0; cursor.moveToPosition(i) && i < cursor.getCount(); i++) {
+                                Attachment attachment = new Attachment(
+                                        cursor.getLong(cursor.getColumnIndex(Contract.Attachment.ID)),
+                                        cursor.getString(cursor.getColumnIndex(Contract.Attachment.FILE)),
+                                        cursor.getString(cursor.getColumnIndex(Contract.Attachment.NAME)),
+                                        cursor.getString(cursor.getColumnIndex(Contract.Attachment.TYPE)),
+                                        cursor.getLong(cursor.getColumnIndex(Contract.Attachment.SIZE))
+                                );
+                                attachments.add(attachment);
+                            }
                         }
+                        cursor.close();
                     }
-                    cursor.close();
                 }
             } else {
                 Intent intent = getIntent();
@@ -836,6 +864,26 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         if (savedInstanceState == null) {
             fillFieldsFromIntent(getIntent());
         }
+    }
+
+    /**
+     * Whether this id names a transaction that stands on its own, which is the only kind that is
+     * copied. Asked before the load above rather than read out of it, because that load reaches
+     * for a leg's transfer with the id of the item being edited, which a new item does not have,
+     * so it would find nothing, leave the type saying transfer, and carry on filling the editor
+     * in from a half of something.
+     */
+    private static boolean isPlainTransaction(ContentResolver contentResolver, long transactionId) {
+        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS, transactionId);
+        Cursor cursor = contentResolver.query(uri, new String[] {Contract.Transaction.TYPE}, null, null, null);
+        boolean plain = false;
+        if (cursor != null) {
+            if (cursor.moveToFirst()) {
+                plain = cursor.getInt(cursor.getColumnIndex(Contract.Transaction.TYPE)) == TYPE_STANDARD;
+            }
+            cursor.close();
+        }
+        return plain;
     }
 
     private void fillFieldsFromIntent(Intent intent) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragment.java
@@ -125,7 +125,7 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
 
     @Override
     protected int onInflateMenu() {
-        return R.menu.menu_edit_delete_item;
+        return R.menu.menu_duplicate_edit_delete_item;
     }
 
     @Override
@@ -135,6 +135,11 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
             Intent intent = new Intent(getActivity(), NewEditTransactionActivity.class);
             intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.EDIT_ITEM);
             intent.putExtra(NewEditItemActivity.ID, getItemId());
+            startActivity(intent);
+        } else if (itemId == R.id.action_duplicate_item) {
+            Intent intent = new Intent(getActivity(), NewEditTransactionActivity.class);
+            intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.NEW_ITEM);
+            intent.putExtra(NewEditTransactionActivity.DUPLICATE_ID, getItemId());
             startActivity(intent);
         } else if (itemId == R.id.action_delete_item) {
             showDeleteDialog(getActivity());
@@ -186,6 +191,9 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
 
     private void setLoadingScreen(boolean loading) {
         if (loading) {
+            // The toolbar sits above the part this hides, so it stays tappable. Whether a copy
+            // is offered is only known once the row has been read.
+            setMenuItemVisibility(R.id.action_duplicate_item, false);
             mMoneyTextView.setText(null);
             mCurrencyTextView.setText(null);
             mDescriptionTextView.setText(null);
@@ -247,6 +255,10 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
                 } else {
                     mCurrencyTextView.setText("?");
                 }
+                // Only a plain transaction is offered a copy, and the toolbar is tappable while
+                // this loads, so the item is hidden until the row says which kind this is.
+                setMenuItemVisibility(R.id.action_duplicate_item, cursor.getInt(
+                        cursor.getColumnIndex(Contract.Transaction.TYPE)) == NewEditTransactionActivity.TYPE_STANDARD);
                 long money = cursor.getLong(cursor.getColumnIndex(Contract.Transaction.MONEY));
                 mMoneyTextView.setText(mMoneyFormatter.getNotTintedString(currency, money, MoneyFormatter.CurrencyMode.ALWAYS_HIDDEN));
                 String description = cursor.getString(cursor.getColumnIndex(Contract.Transaction.DESCRIPTION));

--- a/app/src/main/res/menu/menu_duplicate_edit_delete_item.xml
+++ b/app/src/main/res/menu/menu_duplicate_edit_delete_item.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_duplicate_item"
+        android:title="@string/menu_action_duplicate_item"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_edit_item"
+        android:icon="@drawable/ic_mode_edit_black_24dp"
+        android:title="@string/menu_action_edit_item"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_item"
+        android:icon="@drawable/ic_delete_black_24dp"
+        android:title="@string/menu_action_delete_item"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -235,6 +235,7 @@
     <string name="menu_refresh_currency_rate">"Refresh currency rate"</string>
     <string name="menu_advanced_settings">"Advanced settings"</string>
     <string name="menu_action_edit_item">"Edit"</string>
+    <string name="menu_action_duplicate_item">"Duplicate"</string>
     <string name="menu_action_delete_item">"Delete"</string>
     <string name="menu_action_archive_item">"Archive"</string>
     <string name="menu_action_unarchive_item">"Unarchive"</string>


### PR DESCRIPTION
Closes #115.

## What it does

Asked for upstream in issue 27, which asks for transactions and categories. This is the transaction half. Models cover the repeat that is known in advance; this covers the one that is not, an unplanned second purchase matching one already entered.

The transaction screen gains a Duplicate action. It opens the editor as a new transaction, filled in from the one it came from, so the amount or anything else can be changed before it is saved. Nothing is written until Save, and the transaction it came from is not touched.

## How

The editor already knows how to fill itself in from a transaction, since that is what editing one does. A copy reads the same row through the same block and is then saved as a new transaction, which gives it its own id and its own uuid, minted by `insertTransaction`. Money, description, category, wallet, place, note, event, people, confirmed and show in total all come across, and the direction is worked out again from the category as it is for any save.

Only a plain transaction is offered a copy. A leg of a transfer is half of something the editor cannot open on its own, and a debt payment or a saving deposit carries a link to a debt or a saving that the editor draws no field for, so a second one would move that total with nothing on screen saying so. The action is hidden for all three, and hidden while the row is still loading, since the toolbar sits above the part that shows a spinner. The activity checks the kind again for itself, because it is exported.

A copy's date starts at now. It takes no attachments: removing one in this editor deletes the attachment row and its file outright, with no check for anything else pointing at it, so a copy sharing one would be left holding nothing.

## What I tested

Android 16 emulator. Duplicating a transaction of 10.01 dated yesterday writes a second row with the same amount, category, wallet and type, today's date, a different uuid and no debt or saving link, leaving the first row as it was. A transfer leg, a debt payment and a saving deposit each show Edit and Delete and no Duplicate. Duplicating a transaction that has an attachment opens the editor with none on it, and the saved copy has no attachment row while the original keeps its own.
