### PR TITLE
Round an imported amount to the currency scale, and say how many

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/model/MoneyScale.java
+++ b/app/src/main/java/com/oriondev/moneywallet/model/MoneyScale.java
@@ -20,6 +20,7 @@
 package com.oriondev.moneywallet.model;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 /**
  * Canonical conversions between a human readable decimal amount and the bare
@@ -27,9 +28,10 @@ import java.math.BigDecimal;
  * currency is 10^decimals, with decimals in the range 0..3.
  *
  * Every conversion shifts the decimal point with {@link BigDecimal} so the
- * arithmetic is exact, and truncates toward zero when narrowing back to a
- * {@code long} (the same rounding the individual call sites relied on before
- * this was consolidated). The class is intentionally free of Android
+ * arithmetic is exact. All of them but one truncate toward zero when narrowing
+ * back to a {@code long}, which is the rounding the individual call sites
+ * relied on before this was consolidated; {@link #toMinorUnitsRounded} is the
+ * exception and says why. The class is intentionally free of Android
  * dependencies so it can be unit tested on the JVM.
  */
 public final class MoneyScale {
@@ -47,6 +49,28 @@ public final class MoneyScale {
             return 0L;
         }
         return amount.movePointRight(decimals).longValue();
+    }
+
+    /**
+     * The same conversion for an amount that came from somewhere the currency scale was not
+     * known: the fraction the currency cannot hold is rounded to the nearest minor unit rather
+     * than dropped. Half goes to the even neighbour, the same rounding the amount keypad uses on
+     * an answer it computed, so a value the app works out and the same value read from a file
+     * land on the same minor unit. An amount typed by hand still drops its fraction, which is a
+     * separate decision this does not touch.
+     *
+     * Dropping the fraction instead loses up to a whole minor unit rather than half of one, and
+     * always toward zero, so every row of a file comes out smaller than it was written.
+     *
+     * A null amount maps to zero. Unlike {@link #toMinorUnits(BigDecimal, int)} this refuses an
+     * amount too large to hold, with an {@link ArithmeticException}, rather than keeping the low
+     * bits of it: rounding can carry a value over the edge that truncating left inside.
+     */
+    public static long toMinorUnitsRounded(BigDecimal amount, int decimals) {
+        if (amount == null) {
+            return 0L;
+        }
+        return amount.setScale(decimals, RoundingMode.HALF_EVEN).movePointRight(decimals).longValueExact();
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/service/ImportExportIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/ImportExportIntentService.java
@@ -48,6 +48,7 @@ public class ImportExportIntentService extends IntentService {
     public static final String RESULT_FILE_URI = "ImportExportIntentService::Results::FileUri";
     public static final String RESULT_FILE_TYPE = "ImportExportIntentService::Results::FileType";
     public static final String EXCEPTION = "ImportExportIntentService::Results::Exception";
+    public static final String ROUNDED_AMOUNTS = "ImportExportIntentService::Results::RoundedAmounts";
 
     public static final int MODE_EXPORT = 0;
     public static final int MODE_IMPORT = 1;
@@ -88,12 +89,14 @@ public class ImportExportIntentService extends IntentService {
             }
             // initialize the correct data importer
             AbstractDataImporter dataImporter = getDataImporter(dataFormat, file);
+            int roundedAmounts;
             try {
                 dataImporter.importData();
+                roundedAmounts = dataImporter.getRoundedAmounts();
             } finally {
                 dataImporter.close();
             }
-            notifyTaskFinished(LocalAction.ACTION_IMPORT_SERVICE_FINISHED);
+            notifyTaskFinished(LocalAction.ACTION_IMPORT_SERVICE_FINISHED, roundedAmounts);
         } catch (Exception e) {
             notifyTaskFailed(LocalAction.ACTION_IMPORT_SERVICE_FAILED, e);
         }
@@ -218,8 +221,10 @@ public class ImportExportIntentService extends IntentService {
         mReporter.broadcast(action);
     }
 
-    private void notifyTaskFinished(String action) {
-        mReporter.broadcast(action);
+    private void notifyTaskFinished(String action, int roundedAmounts) {
+        Bundle extras = new Bundle();
+        extras.putInt(ROUNDED_AMOUNTS, roundedAmounts);
+        mReporter.broadcast(action, extras);
     }
 
     private void notifyTaskFinished(String action, Uri resultUri, String resultType) {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
@@ -48,6 +48,13 @@ public abstract class AbstractDataImporter {
 
     public abstract void importData() throws IOException;
 
+    /**
+     * How many amounts this import had to round to fit the currency they were in, once
+     * {@link #importData()} has run, and zero before it. A format that cannot carry an amount
+     * the currency does not hold answers zero, but it has to say so rather than inherit it.
+     */
+    public abstract int getRoundedAmounts();
+
     protected void insertTransaction(String wallet, CurrencyUnit currencyUnit, String category,
                                      Date datetime, Long money, int direction, String description,
                                      String event, String place, String people, String note) {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
@@ -30,6 +30,8 @@ public class CSVDataImporter extends AbstractDataImporter {
 
     private final CSVReaderHeaderAware mReader;
 
+    private int mRoundedAmounts;
+
     public CSVDataImporter(Context context, File file) throws IOException {
         super(context, file);
         mFile = file;
@@ -99,12 +101,49 @@ public class CSVDataImporter extends AbstractDataImporter {
         } catch (NumberFormatException e) {
             throw new RuntimeException("Invalid money amount (" + e.getMessage() + ")");
         }
-        long money = MoneyScale.toMinorUnits(moneyDecimal, currencyUnit.getDecimals());
+        long money = toMinorUnitsCounting(moneyDecimal, moneyString, currencyUnit.getDecimals(), write);
         int direction = money < 0 ? Contract.Direction.EXPENSE : Contract.Direction.INCOME;
         Date datetime = parseDatetime(datetimeString);
         if (write) {
             insertTransaction(wallet, currencyUnit, category, datetime, Math.abs(money), direction, description, event, place, people, note);
         }
+    }
+
+    @Override
+    public int getRoundedAmounts() {
+        return mRoundedAmounts;
+    }
+
+    /**
+     * The amount of a row in minor units. Rounded rather than cut off, because a file written
+     * elsewhere carries whatever precision that place kept, and nothing here shows the amount
+     * for review before it is saved. The row's own currency column decides the scale.
+     *
+     * Rows the currency could not hold exactly are counted, so the screen that reports the
+     * import can say so. The test is the stored amount read back against what the row said, not
+     * the rounded amount against the cut off one: a row rounded down lands where cutting off
+     * would have left it, and its value moved just the same. Counted only on the pass that
+     * writes, since every row is read twice.
+     *
+     * @param cell  the money column as the row wrote it, which is what a refusal quotes.
+     * @param write true on the pass that saves, which is the one that counts.
+     */
+    private long toMinorUnitsCounting(BigDecimal amount, String cell, int decimals, boolean write) {
+        long money;
+        try {
+            money = MoneyScale.toMinorUnitsRounded(amount, decimals);
+        } catch (ArithmeticException e) {
+            throw new RuntimeException("Money amount is out of range (" + cell + ")");
+        }
+        // The one value abs cannot turn positive, which would otherwise reach the ledger as a
+        // negative amount sitting on an expense.
+        if (money == Long.MIN_VALUE) {
+            throw new RuntimeException("Money amount is out of range (" + cell + ")");
+        }
+        if (write && MoneyScale.toHumanAmount(money, decimals).compareTo(amount) != 0) {
+            mRoundedAmounts++;
+        }
+        return money;
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/ImportExportActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/ImportExportActivity.java
@@ -733,9 +733,15 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                             mProgressDialog.dismissAllowingStateLoss();
                             mProgressDialog = null;
                         }
+                        // An amount a file carries more precisely than its currency can hold is
+                        // rounded on the way in, so the screen that says the import worked says
+                        // that too rather than leaving the user to find it in the ledger.
+                        int roundedAmounts = intent.getIntExtra(ImportExportIntentService.ROUNDED_AMOUNTS, 0);
                         ThemedDialog.buildMaterialDialog(ImportExportActivity.this)
                                 .title(R.string.title_success)
-                                .content(R.string.message_data_import_success)
+                                .content(roundedAmounts > 0
+                                        ? getString(R.string.message_data_import_success_rounded, roundedAmounts)
+                                        : getString(R.string.message_data_import_success))
                                 .positiveText(android.R.string.ok)
                                 .show();
                         break;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,6 +451,7 @@
     <string name="message_data_import_failed">"Failure during the import procedure. Message: %s"</string>
     <string name="message_data_export_failed">"Failure during the export procedure. Message: %s"</string>
     <string name="message_data_import_success">"Data imported correctly."</string>
+    <string name="message_data_import_success_rounded">"Data imported correctly. Amounts the currency could not hold exactly were rounded to the nearest unit: %1$d."</string>
     <string name="message_data_export_success">"Data exported correctly. Do you want to open the created file?"</string>
 
     <string name="message_async_init">"Initialization …"</string>

--- a/app/src/test/java/com/oriondev/moneywallet/model/MoneyScaleTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/model/MoneyScaleTest.java
@@ -81,6 +81,53 @@ public class MoneyScaleTest {
         assertEquals(0L, MoneyScale.toMinorUnits(null, 2));
     }
 
+    // human amount -> long minor units rounded to the nearest, half to even, which is what an
+    // amount arriving from outside the app gets
+
+    @Test
+    public void toMinorUnitsRounded_roundsToTheNearestMinorUnit() {
+        assertEquals(1002L, MoneyScale.toMinorUnitsRounded(new BigDecimal("10.019"), 2));
+        assertEquals(1001L, MoneyScale.toMinorUnitsRounded(new BigDecimal("10.011"), 2));
+        assertEquals(-1002L, MoneyScale.toMinorUnitsRounded(new BigDecimal("-10.019"), 2));
+        assertEquals(65L, MoneyScale.toMinorUnitsRounded(new BigDecimal("64.9"), 0));
+    }
+
+    @Test
+    public void toMinorUnitsRounded_sendsAHalfToTheEvenNeighbour() {
+        // this one only says the half is not dropped: rounding every half up agrees with it
+        assertEquals(1002L, MoneyScale.toMinorUnitsRounded(new BigDecimal("10.015"), 2));
+        // these two are what tell this apart from rounding every half up, which would
+        // send them to 1003 and -1003
+        assertEquals(1002L, MoneyScale.toMinorUnitsRounded(new BigDecimal("10.025"), 2));
+        assertEquals(-1002L, MoneyScale.toMinorUnitsRounded(new BigDecimal("-10.025"), 2));
+    }
+
+    @Test
+    public void toMinorUnitsRounded_usesTheDecimalsItIsGiven() {
+        assertEquals(10016L, MoneyScale.toMinorUnitsRounded(new BigDecimal("10.0155"), 3));
+        // both halves go to the even neighbour, so one comes down and the other goes up
+        assertEquals(64L, MoneyScale.toMinorUnitsRounded(new BigDecimal("64.5"), 0));
+        assertEquals(66L, MoneyScale.toMinorUnitsRounded(new BigDecimal("65.5"), 0));
+    }
+
+    @Test(expected = ArithmeticException.class)
+    public void toMinorUnitsRounded_refusesAnAmountTooLargeToHold() {
+        // rounding carries this over the edge of a long, where truncating left it just inside
+        MoneyScale.toMinorUnitsRounded(new BigDecimal("92233720368547758.075"), 2);
+    }
+
+    @Test
+    public void toMinorUnitsRounded_leavesAnAmountTheCurrencyHoldsAlone() {
+        assertEquals(1001L, MoneyScale.toMinorUnitsRounded(new BigDecimal("10.01"), 2));
+        assertEquals(0L, MoneyScale.toMinorUnitsRounded(BigDecimal.ZERO, 2));
+        assertEquals(1234567L, MoneyScale.toMinorUnitsRounded(new BigDecimal("12345.67"), 2));
+    }
+
+    @Test
+    public void toMinorUnitsRounded_nullAmountIsZero() {
+        assertEquals(0L, MoneyScale.toMinorUnitsRounded(null, 2));
+    }
+
     // exchange rate conversion across differing decimal counts
 
     @Test


### PR DESCRIPTION
Fixes #137.

## The bug

A CSV can carry more decimals than the currency has, and the importer cut the rest off: 10.019, 10.015 and 10.011 all reached the ledger as 10.01 in a two decimal currency. The loss is up to a whole minor unit on every row that does not fit, and it always goes toward zero, so a file of expenses leaves the balance too high and a file of income too low.

## The fix

`MoneyScale.toMinorUnitsRounded` sets the scale with HALF_EVEN before narrowing to a `long`, and `CSVDataImporter` uses it. HALF_EVEN is what the keypad already uses on an answer it computed, so 20.03 divided by 2 and the same 10.015 read from a file now land on the same minor unit.

Rounding changes the user's number, so the import screen, which said only that it went correctly, now names the count too. A row counts when the amount stored is not the amount the row said.

The new method refuses an amount too large to store rather than keeping its low bits, and the importer refuses the one value that passes that and still cannot be stored: the bottom of the `long` range, which `Math.abs` cannot turn positive. Both are the same refusal a bad row already gets.

## One thing to know

An amount between half a minor unit and a whole one landed on zero, which reads as income because the sign is taken after scaling. It now rounds to one unit and keeps its sign: -0.006 becomes a one unit expense.

Left alone: the keypad, the legacy import through `MoneyScale.rescale` (shared with a migration over existing rows, so it needs its own change) and the transfer conversion through `MoneyScale.convert`.

## Tested

Android 16 emulator, one file of five rows against both builds from the same ledger. Before: 1001, 1001, 1001, 1002, 1001. After: 1002, 1001, 1002, 1002, 1002. 10.025 staying at 1002 is what says this is half to even and not half up, which would give 1003. The dialog reported five. Six unit tests on the new method, 26 in `MoneyScaleTest`.
