### PR TITLE
Refuse automatic backup with no folder, and say which folder problem it is

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/api/saf/SAFBackendServiceAPI.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/saf/SAFBackendServiceAPI.java
@@ -213,17 +213,23 @@ public class SAFBackendServiceAPI extends AbstractBackendServiceAPI<SAFFile> {
 
     @Override
     public SAFFile newFolder(SAFFile parent, String name) throws BackendException {
-        DocumentFile docParent = DocumentFile.fromTreeUri(mContext, parent.getUri());
+        // No parent means the top of the granted tree, which is where the explorer starts and
+        // is the only place a first folder can be made. Reading a uri off it threw instead, and
+        // BackendHandlerIntentService catches BackendException only, so it took the app down.
+        // upload and list already read a missing parent this way.
+        DocumentFile docParent = parent == null ? mRoot
+                : DocumentFile.fromTreeUri(mContext, parent.getUri());
+        String parentName = parent == null ? "root directory" : parent.getUri().toString();
         if (docParent == null) {
             throw new BackendException(
-                    String.format("Couldn't access parent '%s'", parent.getUri())
+                    String.format("Couldn't access parent '%s'", parentName)
             );
         }
         DocumentFile docFolder = docParent.createDirectory(name);
         if (docFolder == null) {
             throw new BackendException(
                     String.format(
-                            "Couldn't create folder '%s' under parent '%s'", name, parent.getUri()
+                            "Couldn't create folder '%s' under parent '%s'", name, parentName
                     )
             );
         }

--- a/app/src/main/java/com/oriondev/moneywallet/service/AutoBackupJobService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/AutoBackupJobService.java
@@ -192,14 +192,24 @@ public class AutoBackupJobService extends JobService {
     }
 
     private static void runBackend(Context context, String backendId) throws Exception {
-        IFile folder = BackendServiceFactory.getFile(backendId, BackendManager.getAutoBackupFolder(backendId));
+        String encodedFolder = BackendManager.getAutoBackupFolder(backendId);
+        IFile folder = BackendServiceFactory.getFile(backendId, encodedFolder);
         if (folder == null) {
             // Legacy or undecodable backup location (issue #177): skip this backend instead of
             // failing the sweep. The backend stays configured; the folder can be chosen again.
             // The occurrence is consumed either way, so tell the user rather than leaving a
             // backup that never runs to be discovered when it is needed.
-            Log.w(TAG, "Skipping auto backup for '" + backendId + "': backup location missing or not decodable");
-            notifyMessage(context, context.getString(R.string.notification_content_backup_error_location));
+            //
+            // Nothing stored is a different failure from something stored that will not decode.
+            // The settings dialog refuses to save the first, so what reaches here was written by
+            // a build before it. Telling that user the location is no longer available sends
+            // them looking for a folder that is not there to find.
+            boolean nothingStored = encodedFolder == null;
+            Log.w(TAG, "Skipping auto backup for '" + backendId + "': "
+                    + (nothingStored ? "no backup folder is set" : "backup location not decodable"));
+            notifyMessage(context, context.getString(nothingStored
+                    ? R.string.notification_content_backup_error_location_unset
+                    : R.string.notification_content_backup_error_location));
             return;
         }
         if (BackendManager.isAutoBackupOnWiFiOnly(backendId) && !isConnectedToWiFi(context)) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/BackendExplorerActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/BackendExplorerActivity.java
@@ -32,6 +32,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import android.text.InputType;
 import android.text.TextUtils;
+import android.widget.Toast;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -167,6 +168,13 @@ public class BackendExplorerActivity extends SinglePanelActivity implements Swip
                 if (folder == null) {
                     // this backend's own default, rather than a local path it cannot decode
                     folder = BackendServiceFactory.getFile(mBackendId, null);
+                }
+                if (folder == null) {
+                    // The top of the list is not a folder this backend can name. Choosing it used
+                    // to send back a result carrying no file, and the settings dialog read that as
+                    // the answer and dropped the folder it already held.
+                    Toast.makeText(this, R.string.message_backend_open_a_folder, Toast.LENGTH_LONG).show();
+                    return false;
                 }
                 Intent intent = new Intent();
                 intent.putExtra(RESULT_FILE, folder);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
@@ -34,6 +34,7 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.SeekBar;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
@@ -91,11 +92,25 @@ public class AutoBackupSettingDialog extends DialogFragment {
                 .customView(R.layout.dialog_auto_backup_setting, true)
                 .positiveText(android.R.string.ok)
                 .negativeText(android.R.string.cancel)
+                // OK does not close the dialog by itself, so a setting it refuses to save leaves
+                // the rest of what was typed on screen. Tapping outside and the back button are
+                // not affected and still cancel.
+                .autoDismiss(false)
                 .onPositive(new MaterialDialog.SingleButtonCallback() {
 
                     @Override
                     public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                        onSaveSetting();
+                        if (onSaveSetting()) {
+                            dialog.dismiss();
+                        }
+                    }
+
+                })
+                .onNegative(new MaterialDialog.SingleButtonCallback() {
+
+                    @Override
+                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        dialog.dismiss();
                     }
 
                 })
@@ -174,15 +189,40 @@ public class AutoBackupSettingDialog extends DialogFragment {
         mOffsetTextView.setText(getString(R.string.hint_auto_backup_every_n_hours, hours));
     }
 
+    /**
+     * A folder that is stored but cannot be read comes back from
+     * {@link BackendServiceFactory#getFile} as null, and so does one that is not stored when the
+     * backend has no default folder. The two do not get the same line. The notification the sweep
+     * posts already separates them, and a row reading "not chosen" under a notification saying
+     * the location is gone would be the app arguing with itself.
+     */
     private void onFolderChanged() {
         if (mFolder != null) {
             mFolderTextView.setText(mFolder.getName());
+        } else if (BackendManager.getAutoBackupFolder(mBackendId) != null) {
+            mFolderTextView.setText(R.string.hint_auto_backup_folder_unavailable);
         } else {
-            mFolderTextView.setText(R.string.hint_auto_backup_root_folder);
+            mFolderTextView.setText(R.string.hint_auto_backup_folder_not_chosen);
         }
     }
 
-    private void onSaveSetting() {
+    /**
+     * Saves the settings, or refuses and returns false. Nowhere else writes a backup folder.
+     * {@link BackendManager#setAutoBackupEnabled} erases one, and the two callers that reach it
+     * from outside this screen turn the backend off in the same call, so neither can leave a
+     * backend enabled with no folder.
+     *
+     * A backend with no usable folder is what the refusal is about. Some backends offer a default
+     * one and {@link BackendServiceFactory#getFile} hands it back for a folder that is not stored,
+     * which is what fills in {@code mFolder} when this dialog opens, so a null here means there is
+     * no folder to back up to and none to fall back on. Saved enabled, that backend can only fail:
+     * the sweep asks for the same file, gets null, and reports a failed backup instead.
+     */
+    private boolean onSaveSetting() {
+        if (mServiceEnabledSwitchCompat.isChecked() && mFolder == null) {
+            Toast.makeText(getContext(), R.string.message_auto_backup_folder_required, Toast.LENGTH_LONG).show();
+            return false;
+        }
         BackendManager.setAutoBackupEnabled(mBackendId, mServiceEnabledSwitchCompat.isChecked());
         BackendManager.setAutoBackupOnWiFiOnly(mBackendId, mOnlyWiFiCheckBox.isChecked());
         BackendManager.setAutoBackupWhenDataIsChangedOnly(mBackendId, mOnlyDataChangedCheckBox.isChecked());
@@ -202,6 +242,7 @@ public class AutoBackupSettingDialog extends DialogFragment {
                     new String[]{Manifest.permission.POST_NOTIFICATIONS},
                     REQUEST_CODE_NOTIFICATION_PERMISSION);
         }
+        return true;
     }
 
     @Override

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -320,7 +320,6 @@
     <string name="hint_auto_backup_every_n_hours">Alle %d Stunden</string>
     <string name="hint_auto_backup_folder">Ordner</string>
     <string name="hint_auto_backup_only_if_data_changed">Nur wenn die Daten verändert wurden</string>
-    <string name="hint_auto_backup_root_folder">Wurzel</string>
     <string name="hint_auto_backup_wifi_only">Nur über WLAN</string>
     <string name="hint_decimals">Anzahl der Nachkommastellen</string>
     <string name="hint_directory">Ordner</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -159,7 +159,6 @@
     <string name="hint_auto_backup_only_if_data_changed">"Μόνο αν άλλαξαν τα δεδομένα"</string>
     <string name="hint_auto_backup_every_n_hours">"Κάθε %d ώρες"</string>
     <string name="hint_auto_backup_folder">"Φάκελος"</string>
-    <string name="hint_auto_backup_root_folder">"Αρχικός φάκελος"</string>
 
     <string name="total_wallet_name">"Σύνολο"</string>
 

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -148,7 +148,6 @@
     <string name="hint_auto_backup_only_if_data_changed">"فقط اگر داده تغییر کند"</string>
     <string name="hint_auto_backup_every_n_hours">"هر %d ساعت"</string>
     <string name="hint_auto_backup_folder">"پوشه"</string>
-    <string name="hint_auto_backup_root_folder">"ریشه"</string>
 
     <string name="total_wallet_name">"جمع کل"</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -159,7 +159,6 @@
     <string name="hint_auto_backup_only_if_data_changed">"Seulement si les données ont changé"</string>
     <string name="hint_auto_backup_every_n_hours">"Toutes les %d heures"</string>
     <string name="hint_auto_backup_folder">"Dossier"</string>
-    <string name="hint_auto_backup_root_folder">"Racine"</string>
 
     <string name="total_wallet_name">Total</string>
 

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -150,7 +150,6 @@
     <string name="hint_auto_backup_every_n_hours">Minden %d órában</string>
     <string name="hint_auto_backup_folder">Mappa</string>
     <string name="hint_auto_backup_only_if_data_changed">Csak ha az adat változott</string>
-    <string name="hint_auto_backup_root_folder">Gyökér</string>
     <string name="hint_auto_backup_wifi_only">Csak Wifi hálózaton</string>
     <string name="hint_bank_name">Bank név</string>
     <string name="hint_category">Kategória</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -159,7 +159,6 @@
     <string name="hint_auto_backup_only_if_data_changed">"Solo quando i dati sono cambiati"</string>
     <string name="hint_auto_backup_every_n_hours">"Ogni %d ore"</string>
     <string name="hint_auto_backup_folder">"Cartella"</string>
-    <string name="hint_auto_backup_root_folder">"Radice"</string>
 
     <string name="total_wallet_name">"Totale"</string>
 

--- a/app/src/main/res/values-ml/strings.xml
+++ b/app/src/main/res/values-ml/strings.xml
@@ -146,7 +146,6 @@
     <string name="hint_auto_backup_only_if_data_changed">"ഡാറ്റ മാറ്റിയാൽ മാത്രം"</string>
     <string name="hint_auto_backup_every_n_hours">"ഓരോ %d മണിക്കൂറിലും"</string>
     <string name="hint_auto_backup_folder">"ഫോൾഡർ"</string>
-    <string name="hint_auto_backup_root_folder">"റൂട്ട്"</string>
 
     <string name="total_wallet_name">"ആകെ"</string>
 

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -160,7 +160,6 @@
     <string name="hint_auto_backup_only_if_data_changed">"Tylko gdy zmieniono dane"</string>
     <string name="hint_auto_backup_every_n_hours">"Co %d godzin"</string>
     <string name="hint_auto_backup_folder">"Folder"</string>
-    <string name="hint_auto_backup_root_folder">"Główny"</string>
 
     <string name="total_wallet_name">"W całości"</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -160,7 +160,6 @@
     <string name="hint_auto_backup_only_if_data_changed">"Apenas se os dados forem alterados"</string>
     <string name="hint_auto_backup_every_n_hours">"Toda %d horas"</string>
     <string name="hint_auto_backup_folder">"Pasta"</string>
-    <string name="hint_auto_backup_root_folder">"Raiz"</string>
 
     <string name="total_wallet_name">"Total"</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -155,7 +155,6 @@
     <string name="hint_auto_backup_only_if_data_changed"> "Yalnızca veriler değiştirilirse" </string>
     <string name="hint_auto_backup_every_n_hours"> "Her %d saat" </string>
     <string name="hint_auto_backup_folder"> "Klasör" </string>
-    <string name="hint_auto_backup_root_folder"> "Kök dizin" </string>
 
     <string name="total_wallet_name"> "Toplam" </string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -167,7 +167,10 @@
     <string name="hint_auto_backup_only_if_data_changed">"Only if data is changed"</string>
     <string name="hint_auto_backup_every_n_hours">"Every %d hours"</string>
     <string name="hint_auto_backup_folder">"Folder"</string>
-    <string name="hint_auto_backup_root_folder">"Root"</string>
+    <string name="hint_auto_backup_folder_not_chosen">"Not chosen"</string>
+    <string name="hint_auto_backup_folder_unavailable">"Not available"</string>
+    <string name="message_auto_backup_folder_required">"Choose a folder before turning automatic backup on."</string>
+    <string name="message_backend_open_a_folder">"Open a folder to choose it."</string>
 
     <string name="total_wallet_name">"Total"</string>
 
@@ -571,6 +574,7 @@
     <string name="notification_content_backup_error_backend">"There was an error with the backend and the auto backup has been disabled. Check if there is any problem."</string>
     <string name="notification_content_backup_error_internal">"There was an internal error during the operation, which is probably a bug. Please report this message to the developer: %s"</string>
     <string name="notification_content_backup_error_location">"The backup location is no longer available, so the automatic backup did not run. Open the backup settings and choose the folder again."</string>
+    <string name="notification_content_backup_error_location_unset">"No folder is set for this backup, so the automatic backup did not run. Open the backup settings and choose one."</string>
     <string name="notification_action_retry">"Retry"</string>
     <string name="message_error_network_connection">"network connection"</string>
     <string name="message_error_invalid_response">"invalid response"</string>


### PR DESCRIPTION
Fixes #140.

## The bug

Turning automatic backup on without opening the folder picker left the row on Root and stored nothing. No backup was ever written. The sweep skipped the backend, posted "The backup location is no longer available", and consumed the occurrence. Nothing on screen says a choice is still required.

## The fix

Nowhere else writes that folder, so the settings dialog is where this is refused. OK no longer closes the dialog by itself: with the switch on and no folder it says so and leaves the rest of what was typed on screen. Tapping outside and back still cancel, and turning the switch off still saves, so a backend already in this state can be turned off.

The row reads Not chosen when nothing is stored and Not available when something is stored that cannot be read, the same split the sweep's notification makes.

## Two holes on the way out

Choosing the top of the folder picker sent back a result carrying no file, and the dialog took that as the answer, so a folder already chosen was replaced by none. It now says to open a folder.

Making that first folder crashed the app. `SAFBackendServiceAPI.newFolder` read a uri off the parent, and at the top of a granted tree there is no parent. It takes the tree itself now, which is what `upload` and `list` already do. The `NullPointerException` was on the service thread and `BackendHandlerIntentService` catches `BackendException` only.

## Left alone

`DocumentFile.fromTreeUri` rebuilds any uri under a granted tree back to the top of that tree, so a chosen subfolder is not where a backup lands. Left for its own change, because fixing it moves where existing backups are read and written.

## Tested

Android 16 emulator. OK refused with the switch on and no folder, and an interval moved 48 to 128 hours on screen was not stored; switching off saved and closed and the 128 landed. Creating a folder at the top of the tree used to kill the process; it now returns to the picker with the folder made.
