### PR TITLE
Say when a list is empty only because its rows are dated ahead

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
@@ -105,8 +105,8 @@ public abstract class CursorListFragment extends Fragment implements SwipeRefres
     }
 
     /**
-     * Change the text shown when the list comes back with nothing in it. The list applies this
-     * when it next becomes empty, so it has to be set before the query it belongs to finishes.
+     * Change the text shown when the list comes back with nothing in it. The view takes it at
+     * once, so this reaches an empty list that is already on screen as well as the next one.
      */
     protected void setEmptyText(@StringRes int stringRes) {
         if (mAdvancedRecyclerView != null) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransactionListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransactionListFragment.java
@@ -27,6 +27,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.loader.app.LoaderManager;
 import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -45,6 +46,7 @@ import com.oriondev.moneywallet.ui.adapter.recycler.AbstractCursorAdapter;
 import com.oriondev.moneywallet.ui.adapter.recycler.TransactionCursorAdapter;
 import com.oriondev.moneywallet.ui.fragment.base.CursorListFragment;
 import com.oriondev.moneywallet.ui.view.AdvancedRecyclerView;
+import com.oriondev.moneywallet.utils.DateUtils;
 
 import java.util.Date;
 
@@ -52,6 +54,10 @@ import java.util.Date;
  * Created by andrea on 03/03/18.
  */
 public class TransactionListFragment extends CursorListFragment implements TransactionCursorAdapter.ActionListener {
+
+    private static final int HIDDEN_TRANSACTIONS_LOADER_ID = 60004;
+
+    private static final String[] HIDDEN_PROJECTION = new String[] {Contract.Transaction.DATE};
 
     @Override
     protected void onPrepareRecyclerView(AdvancedRecyclerView recyclerView) {
@@ -69,23 +75,97 @@ public class TransactionListFragment extends CursorListFragment implements Trans
         Activity activity = getActivity();
         if (activity != null) {
             Uri uri = DataContentProvider.CONTENT_TRANSACTIONS;
-            String selection;
-            String[] arguments;
             long currentWallet = PreferenceManager.getCurrentWallet();
-            if (currentWallet == PreferenceManager.TOTAL_WALLET_ID) {
-                selection = Contract.Transaction.WALLET_COUNT_IN_TOTAL + " = 1";
-                arguments = null;
-            } else {
-                selection = Contract.Transaction.WALLET_ID + " = ?";
-                arguments = new String[] {String.valueOf(currentWallet)};
-            }
-            selection += " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('now', 'localtime')";
+            String selection = walletSelection(currentWallet)
+                    + " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('now', 'localtime')";
             String sortOrder = Contract.Transaction.DATE + " DESC";
             Group groupType = PreferenceManager.getCurrentGroupType();
-            return new WrappedCursorLoader(activity, uri, null, selection, arguments,
+            return new WrappedCursorLoader(activity, uri, null, selection, null,
                     sortOrder, groupType, null, null);
         }
         return null;
+    }
+
+    /**
+     * The wallet this list is about. The date test is not in here on purpose: it is the clause
+     * the other query asks about, so that query is this selection on its own, and one method
+     * decides the wallet rule for both. The wallet id is written into the text rather than bound,
+     * so there are no arguments to keep in step with it either.
+     *
+     * On the Total wallet this selection hides rows of its own, from a wallet the user left out
+     * of the total. Those are hidden from both queries alike, so nothing here reports them and
+     * nothing here gets them wrong.
+     */
+    private static String walletSelection(long currentWallet) {
+        if (currentWallet == PreferenceManager.TOTAL_WALLET_ID) {
+            return Contract.Transaction.WALLET_COUNT_IN_TOTAL + " = 1";
+        }
+        return Contract.Transaction.WALLET_ID + " = " + currentWallet;
+    }
+
+    /**
+     * An empty list here reads the same whether this wallet has no transactions or has some that
+     * are all dated ahead of now, which the query hides without saying so. When it comes back
+     * empty, ask what it is hiding.
+     */
+    @Override
+    public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
+        boolean empty = cursor == null || cursor.getCount() == 0;
+        if (empty) {
+            // back to the plain message before the base makes it visible: a refined one from an
+            // earlier load would otherwise stand on screen while this load is being explained
+            setEmptyText(R.string.message_no_transaction_found);
+        }
+        super.onLoadFinished(loader, cursor);
+        if (empty) {
+            getLoaderManager().restartLoader(HIDDEN_TRANSACTIONS_LOADER_ID, null, mHiddenTransactionsCallbacks);
+        } else {
+            getLoaderManager().destroyLoader(HIDDEN_TRANSACTIONS_LOADER_ID);
+        }
+    }
+
+    private final LoaderManager.LoaderCallbacks<Cursor> mHiddenTransactionsCallbacks = new LoaderManager.LoaderCallbacks<Cursor>() {
+
+        @NonNull
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, @Nullable Bundle args) {
+            long currentWallet = PreferenceManager.getCurrentWallet();
+            // the same wallet, without the date test, newest first so the row most likely to be
+            // dated ahead is the one read
+            return new CursorLoader(getActivity(), DataContentProvider.CONTENT_TRANSACTIONS,
+                    HIDDEN_PROJECTION, walletSelection(currentWallet), null,
+                    Contract.Transaction.DATE + " DESC");
+        }
+
+        @Override
+        public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor data) {
+            setEmptyText(isDatedAhead(data) ? R.string.message_no_transaction_found_future
+                    : R.string.message_no_transaction_found);
+        }
+
+        @Override
+        public void onLoaderReset(@NonNull Loader<Cursor> loader) {
+            // the message is a resource id, and holds nothing of the cursor
+        }
+
+    };
+
+    /**
+     * Whether the newest row here is dated ahead of now. The message this decides is about the
+     * date, so the date is what it reads. A row is missing from the list whenever the query held
+     * it back, which is a wider question than the one being asked.
+     *
+     * Compared as text rather than parsed, because the column and this string are both
+     * yyyy-MM-dd HH:mm:ss in local time. That is the comparison the item screens make. A value
+     * the database cannot read is normalised by neither side, so it is compared as it was
+     * stored and can fall either side of now.
+     */
+    private static boolean isDatedAhead(@Nullable Cursor cursor) {
+        if (cursor == null || !cursor.moveToFirst()) {
+            return false;
+        }
+        String date = cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE));
+        return date != null && date.compareTo(DateUtils.getSQLDateTimeString(new Date())) > 0;
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransferListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransferListFragment.java
@@ -27,6 +27,7 @@ import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.loader.app.LoaderManager;
 import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -44,11 +45,18 @@ import com.oriondev.moneywallet.ui.adapter.recycler.AbstractCursorAdapter;
 import com.oriondev.moneywallet.ui.adapter.recycler.TransferCursorAdapter;
 import com.oriondev.moneywallet.ui.fragment.base.CursorListFragment;
 import com.oriondev.moneywallet.ui.view.AdvancedRecyclerView;
+import com.oriondev.moneywallet.utils.DateUtils;
+
+import java.util.Date;
 
 /**
  * Created by andrea on 03/03/18.
  */
 public class TransferListFragment extends CursorListFragment implements TransferCursorAdapter.ActionListener {
+
+    private static final int HIDDEN_TRANSFERS_LOADER_ID = 60003;
+
+    private static final String[] HIDDEN_PROJECTION = new String[] {Contract.Transfer.DATE};
 
     @Override
     protected void onPrepareRecyclerView(AdvancedRecyclerView recyclerView) {
@@ -66,31 +74,105 @@ public class TransferListFragment extends CursorListFragment implements Transfer
         Activity activity = getActivity();
         if (activity != null) {
             Uri uri = DataContentProvider.CONTENT_TRANSFERS;
-            String selection;
-            String[] arguments;
             long currentWallet = PreferenceManager.getCurrentWallet();
-            // A transfer touches two wallets, so both branches below select on a pair joined by
-            // OR. The brackets matter: AND binds tighter than OR, so without them the date test
-            // at the end read as "the first term matches, OR the second term matches and the
-            // date has passed". A transfer dated ahead was listed when it matched on its from
-            // side and hidden when it matched only on its to side.
-            if (currentWallet == PreferenceManager.TOTAL_WALLET_ID) {
-                selection = "(" + Contract.Transfer.TRANSACTION_FROM_WALLET_COUNT_IN_TOTAL + " = 1 OR " +
-                        Contract.Transfer.TRANSACTION_TO_WALLET_COUNT_IN_TOTAL + " = 1)";
-                arguments = null;
-            } else {
-                String walletId = String.valueOf(currentWallet);
-                selection = "(" + Contract.Transfer.TRANSACTION_FROM_WALLET_ID + " = ? OR " +
-                Contract.Transfer.TRANSACTION_TO_WALLET_ID + " = ?)";
-                arguments = new String[] {walletId, walletId};
-            }
-            selection += " AND DATETIME(" + Contract.Transfer.DATE + ") <= DATETIME('now', 'localtime')";
+            String selection = walletSelection(currentWallet)
+                    + " AND DATETIME(" + Contract.Transfer.DATE + ") <= DATETIME('now', 'localtime')";
             String sortOrder = Contract.Transfer.DATE + " DESC";
             Group groupType = PreferenceManager.getCurrentGroupType();
-            return new WrappedCursorLoader(activity, uri, null, selection, arguments,
+            return new WrappedCursorLoader(activity, uri, null, selection, null,
                     sortOrder, groupType);
         }
         return null;
+    }
+
+    /**
+     * The wallets this list is about. A transfer touches two, so both branches select on a pair
+     * joined by OR. The brackets matter: AND binds tighter than OR, so without them the date test
+     * the caller appends read as "the first term matches, OR the second term matches and the date
+     * has passed". A transfer dated ahead was listed when it matched on its from side and hidden
+     * when it matched only on its to side.
+     *
+     * The date test is not in here on purpose. It is the clause the other query asks about, so
+     * that query is this selection on its own, and one method decides the wallet rule for both.
+     * The wallet id is written into the text rather than bound, so there are no arguments to
+     * keep in step with it either.
+     *
+     * On the Total wallet this selection hides rows of its own, from a wallet the user left out
+     * of the total. Those are hidden from both queries alike, so nothing here reports them and
+     * nothing here gets them wrong.
+     */
+    private static String walletSelection(long currentWallet) {
+        if (currentWallet == PreferenceManager.TOTAL_WALLET_ID) {
+            return "(" + Contract.Transfer.TRANSACTION_FROM_WALLET_COUNT_IN_TOTAL + " = 1 OR " +
+                    Contract.Transfer.TRANSACTION_TO_WALLET_COUNT_IN_TOTAL + " = 1)";
+        }
+        return "(" + Contract.Transfer.TRANSACTION_FROM_WALLET_ID + " = " + currentWallet + " OR " +
+                Contract.Transfer.TRANSACTION_TO_WALLET_ID + " = " + currentWallet + ")";
+    }
+
+    /**
+     * An empty list here reads the same whether this wallet has no transfers or has some that are
+     * all dated ahead of now, which the query hides without saying so. When it comes back empty,
+     * ask what it is hiding.
+     */
+    @Override
+    public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
+        boolean empty = cursor == null || cursor.getCount() == 0;
+        if (empty) {
+            // back to the plain message before the base makes it visible: a refined one from an
+            // earlier load would otherwise stand on screen while this load is being explained
+            setEmptyText(R.string.message_no_transfer_found);
+        }
+        super.onLoadFinished(loader, cursor);
+        if (empty) {
+            getLoaderManager().restartLoader(HIDDEN_TRANSFERS_LOADER_ID, null, mHiddenTransfersCallbacks);
+        } else {
+            getLoaderManager().destroyLoader(HIDDEN_TRANSFERS_LOADER_ID);
+        }
+    }
+
+    private final LoaderManager.LoaderCallbacks<Cursor> mHiddenTransfersCallbacks = new LoaderManager.LoaderCallbacks<Cursor>() {
+
+        @NonNull
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, @Nullable Bundle args) {
+            long currentWallet = PreferenceManager.getCurrentWallet();
+            // the same wallets, without the date test, newest first so the row most likely to
+            // be dated ahead is the one read
+            return new CursorLoader(getActivity(), DataContentProvider.CONTENT_TRANSFERS,
+                    HIDDEN_PROJECTION, walletSelection(currentWallet), null,
+                    Contract.Transfer.DATE + " DESC");
+        }
+
+        @Override
+        public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor data) {
+            setEmptyText(isDatedAhead(data) ? R.string.message_no_transfer_found_future
+                    : R.string.message_no_transfer_found);
+        }
+
+        @Override
+        public void onLoaderReset(@NonNull Loader<Cursor> loader) {
+            // the message is a resource id, and holds nothing of the cursor
+        }
+
+    };
+
+    /**
+     * Whether the newest row here is dated ahead of now. The message this decides is about the
+     * date, so the date is what it reads. A row is missing from the list whenever the query held
+     * it back, which is a wider question than the one being asked.
+     *
+     * Compared as text rather than parsed, because the column and this string are both
+     * yyyy-MM-dd HH:mm:ss in local time. That is the comparison the item screens make. A value
+     * the database cannot read is normalised by neither side, so it is compared as it was
+     * stored and can fall either side of now.
+     */
+    private static boolean isDatedAhead(@Nullable Cursor cursor) {
+        if (cursor == null || !cursor.moveToFirst()) {
+            return false;
+        }
+        String date = cursor.getString(cursor.getColumnIndex(Contract.Transfer.DATE));
+        return date != null && date.compareTo(DateUtils.getSQLDateTimeString(new Date())) > 0;
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,6 +344,7 @@
     <string name="message_saved_dated_ahead">"Saved. Its date is ahead of now, so the balance does not count it."</string>
     <string name="message_no_transaction_found_other_wallets_and_future">"No transaction found in the selected wallet. There are transactions in other wallets, and transactions dated in the future."</string>
     <string name="message_no_transfer_found">"No transfer found"</string>
+    <string name="message_no_transfer_found_future">"No transfer found in the selected wallet. There are transfers dated in the future."</string>
     <string name="message_no_category_found">"No category found"</string>
     <string name="message_no_debt_found">"No debt found"</string>
     <string name="message_no_finished_debt_found">"No finished debt found"</string>


### PR DESCRIPTION
Fixes #150.

## The bug

The transfers tab read "No transfer found" for a wallet whose only transfer was dated in the future, which is word for word what it says for a wallet that never had one. The transactions tab did the same. Both queries end with a test that the date has passed, and a row it holds back leaves nothing on screen to say so.

## The fix

Each list now asks about that test. When the query comes back with nothing, a second one runs with the same wallet and without the date test, newest row first, and the message says so when that row is dated ahead of now.

The date is read rather than taken from the row being missing. A row is missing whenever the query held it back, which is a wider question than the one the message answers. It is compared as text, the comparison the item screens make, because both sides are `yyyy-MM-dd HH:mm:ss` in local time.

The wallet part of each query moved into one method, so one place decides the wallet rule for both, and the wallet id is written into the text instead of bound, so there is no argument list to keep in step with it.

The transaction message is the one the item screens already use, from the change that gave them this. Transfers had no equivalent and gain one.

## What this does not cover

On the Total wallet the same queries also hold back rows in a wallet the user left out of the total. Both queries hold those back alike, so they cannot be read as dated ahead; the message is absent rather than wrong.

## Tested

Android 16 emulator. A wallet holding one transfer dated 20 August with the clock on 14 August read "No transfer found", and now names the future rows on both tabs. Deleting the transfer puts both back to the plain message, and so does storing `1999-13-45 99:99:99`, which the database reads as nothing and which the message would have called a future date if it went by the row being missing.
