### PR TITLE
Write a backup to the folder chosen on the Local folder backend

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,10 @@ dependencies {
     // fixed list and throws ProtocolException for both, so a real HTTP client is not optional here.
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'androidx.multidex:multidex:2.0.1'
+    // Without this line documentfile resolves to 1.0.0, by way of legacy-support-core-utils.
+    // In 1.0.0 fromTreeUri drops the document id, so every folder under a granted tree
+    // resolves to the top of the tree. 1.0.1 keeps the id when the uri is a document uri.
+    implementation 'androidx.documentfile:documentfile:1.0.1'
     implementation 'androidx.activity:activity:1.2.0-alpha08'
     implementation 'androidx.fragment:fragment:1.3.0-alpha08'
     implementation 'net.lingala.zip4j:zip4j:1.3.2'


### PR DESCRIPTION
Fixes #155.

On the Local folder backend a folder chosen inside the granted tree was ignored and the top of the tree used instead. Listing a subfolder showed the tree's own contents. A backup made while inside one was written at the top, and so was a folder created inside one. Automatic backup wrote to the top with a subfolder stored in its settings, and on this backend a subfolder is the only configuration the UI can produce, because the picker refuses the top of the tree and this backend has no default folder.

Every folder this backend is handed goes through `DocumentFile.fromTreeUri`. In androidx.documentfile 1.0.0 that method reads the tree id out of the uri and drops the document id, so a folder inside the tree comes back as the top of the tree. Nothing in the build declared a version for documentfile, so it arrived at 1.0.0 through `androidx.legacy:legacy-support-core-utils`. 1.0.1 keeps the document id when the uri is a document uri.

So this is a dependency declaration and no app code. It covers the three calls in `SAFBackendServiceAPI` that take a folder from the caller. The fourth, in the constructor, is on the granted tree itself and was already right. In `ImportExportActivity` the uri is the tree picker's own result, which is not a document uri, so export is unchanged.

Backups already written stay at the top of the granted folder, which is the folder the backup screen opens on. New backups go where they were asked to go, so an automatic backup configured on a subfolder is written there and no longer appears in the first listing the backup screen shows.

Tested on an Android 16 emulator against a build of the previous commit. A backup made from inside a subfolder of the granted tree, and a folder created from inside it, landed at the top on the old build and inside the subfolder on the new one. Automatic backup, configured on that subfolder and made due by backdating its stored last run time, went the same way. Every destination was read back from the file system.
