### PR TITLE
Keep the backup folder and password when a backend is turned off

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/BackendManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/BackendManager.java
@@ -57,9 +57,13 @@ public class BackendManager {
             backendIdSet.add(backendId);
         } else if (backendIdSet != null) {
             backendIdSet.remove(backendId);
+            // The folder and the password stay. Two of the three callers are failure paths that
+            // never write them back, so erasing them threw away what the user chose when a
+            // backup, a restore or a listing failed. The last run time still goes, because
+            // AutoBackupJobService leans on it being cleared, skipping the write back for a
+            // backend a failure has just disabled so that switching the backend on again does
+            // not fire a backup at once.
             mPreferences.edit()
-                    .remove(BACKEND_AUTO_BACKUP_FOLDER + backendId)
-                    .remove(BACKEND_AUTO_BACKUP_PASSWORD + backendId)
                     .remove(BACKEND_AUTO_BACKUP_LAST_TIME + backendId)
                     .apply();
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
@@ -207,10 +207,9 @@ public class AutoBackupSettingDialog extends DialogFragment {
     }
 
     /**
-     * Saves the settings, or refuses and returns false. Nowhere else writes a backup folder.
-     * {@link BackendManager#setAutoBackupEnabled} erases one, and the two callers that reach it
-     * from outside this screen turn the backend off in the same call, so neither can leave a
-     * backend enabled with no folder.
+     * Saves the settings, or refuses and returns false. Nowhere else writes a backup folder. The
+     * two callers of {@link BackendManager#setAutoBackupEnabled} outside this screen only ever
+     * pass false, so neither can leave a backend enabled with no folder.
      *
      * A backend with no usable folder is what the refusal is about. Some backends offer a default
      * one and {@link BackendServiceFactory#getFile} hands it back for a folder that is not stored,


### PR DESCRIPTION
Fixes #158.

BackendManager.setAutoBackupEnabled has three callers. Passed false, with an enabled services set stored, it erased the folder that backend backed up to, the password it used and its last run time.

The sweep in AutoBackupJobService turns a backend off when the backup itself throws an error it treats as not recoverable. BackupHandlerIntentService is wider: it turns the backend off when any error it treats that way reaches it, from a manual backup, a restore or a listing. So one failed operation took away the folder the user chose and the password the backups in it are encrypted with, and on none of those paths was the erase mentioned.

The folder and the password now stay. No backup path reads them while the backend is off: outside the dialog the only reader of either key is the sweep, and it walks only the enabled set. The refusal that stops a backend being enabled with no folder does not rest on the erase either: the two callers outside the dialog only ever pass false, so neither can leave one enabled and empty.

The last run time is still erased, on purpose. The sweep skips writing a timestamp back for a backend that a failure has just disabled, and the reason recorded there is that a stored timestamp left behind fires a backup the moment the user switches the backend on again.

What this does not fix: a folder that is kept is never checked for existence before it is used again. A backend that a missing folder disabled now opens on that same folder and accepts it, and the next backup that comes due fails the same way.

Tested on an Android 16 emulator against a build without this change, on the External Memory backend. Automatic backup was pointed at a folder inside Documents with a password set, the folder was deleted, and the sweep was made due by backdating the backend's stored last run time and then run. Before, the stored folder and password were gone afterwards. Now both are still there and only the timestamp is gone.
