### PR TITLE
Say when a failure is what turned automatic backup off

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/service/AutoBackupJobService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/AutoBackupJobService.java
@@ -223,7 +223,7 @@ public class AutoBackupJobService extends JobService {
             BackupOperation.createAndUpload(context, backendServiceAPI, folder, BackendManager.getAutoBackupPassword(backendId), null);
         } catch (BackendException e) {
             if (!e.isRecoverable()) {
-                BackendManager.setAutoBackupEnabled(backendId, false);
+                BackendManager.disableAutoBackupAfterFailure(backendId);
             }
             throw e;
         }

--- a/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
@@ -159,7 +159,7 @@ public class BackupHandlerIntentService extends IntentService {
                 if (exception instanceof BackendException) {
                     if (!((BackendException) exception).isRecoverable()) {
                         // disable auto-backup for this backend id
-                        BackendManager.setAutoBackupEnabled(backendId, false);
+                        BackendManager.disableAutoBackupAfterFailure(backendId);
                         AutoBackupBroadcastReceiver.scheduleAutoBackupTask(this);
                     }
                 }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/BackendManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/BackendManager.java
@@ -40,11 +40,46 @@ public class BackendManager {
     private static final String BACKEND_AUTO_BACKUP_FOLDER = "auto_backup_folder_";
     private static final String BACKEND_AUTO_BACKUP_PASSWORD = "auto_backup_password_";
     private static final String BACKEND_AUTO_BACKUP_LAST_TIME = "auto_backup_last_time_";
+    private static final String BACKEND_AUTO_BACKUP_DISABLED_BY_FAILURE = "auto_backup_disabled_by_failure_";
 
     private static SharedPreferences mPreferences;
 
     public static void initialize(Context context) {
         mPreferences = context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE);
+    }
+
+    /**
+     * Turns automatic backup off for a backend because a backup, a restore or a listing failed in
+     * a way the app treats as not recoverable, and records that the app is the one that turned it
+     * off. Nothing else sets that flag, so a user switching the service off in the settings dialog
+     * is not mistaken for a failure.
+     *
+     * The sweep builds its backend before the block that calls this, so a backend that cannot be
+     * built at all, a released storage grant or a cleared server address, never gets here from
+     * the sweep, and stays enabled while its notification says otherwise. The manual backup,
+     * restore and browse path builds its backend inside the block, so the same failure does get
+     * here from there.
+     *
+     * The flag is what the settings dialog has to work with. The saved folder and password survive
+     * a failure, so the dialog reopens showing them, and without this it cannot tell the two
+     * states apart: a backend the user switched off and a backend a failure switched off look
+     * identical in these preferences.
+     *
+     * Only recorded for a backend that had automatic backup on. The manual backup, restore and
+     * browse paths share the caller in {@link
+     * com.oriondev.moneywallet.service.BackupHandlerIntentService}, and browsing a backend runs a
+     * listing every time that screen resumes, so without this a backend the user never turned
+     * automatic backup on for would report that a failure turned it off.
+     */
+    public static void disableAutoBackupAfterFailure(String backendId) {
+        if (isAutoBackupEnabled(backendId)) {
+            mPreferences.edit().putBoolean(BACKEND_AUTO_BACKUP_DISABLED_BY_FAILURE + backendId, true).apply();
+        }
+        setAutoBackupEnabled(backendId, false);
+    }
+
+    public static boolean isAutoBackupDisabledByFailure(String backendId) {
+        return mPreferences.getBoolean(BACKEND_AUTO_BACKUP_DISABLED_BY_FAILURE + backendId, false);
     }
 
     public static void setAutoBackupEnabled(String backendId, boolean enabled) {
@@ -55,11 +90,18 @@ public class BackendManager {
                 backendIdSet = new HashSet<>();
             }
             backendIdSet.add(backendId);
+            // Turning the service on is what forgets the failure that turned it off. The record
+            // describes a service that is off, so keeping it past this point would let it be
+            // shown against a service that is running.
+            mPreferences.edit()
+                    .remove(BACKEND_AUTO_BACKUP_DISABLED_BY_FAILURE + backendId)
+                    .apply();
         } else if (backendIdSet != null) {
             backendIdSet.remove(backendId);
-            // The folder and the password stay. Two of the three callers are failure paths that
-            // never write them back, so erasing them threw away what the user chose when a
-            // backup, a restore or a listing failed. The last run time still goes, because
+            // The folder and the password stay. This is reached from the failure path above as
+            // well as from the settings dialog, and the failure path never writes them back, so
+            // erasing them threw away what the user chose when a backup, a restore or a listing
+            // failed. The last run time still goes, because
             // AutoBackupJobService leans on it being cleared, skipping the write back for a
             // backend a failure has just disabled so that switching the backend on again does
             // not fire a backup at once.

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
@@ -31,6 +31,7 @@ import androidx.fragment.app.FragmentManager;
 import androidx.appcompat.widget.SwitchCompat;
 import android.view.View;
 import android.widget.CheckBox;
+import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.SeekBar;
 import android.widget.TextView;
@@ -72,6 +73,7 @@ public class AutoBackupSettingDialog extends DialogFragment {
     private TextView mOffsetTextView;
     private SeekBar mOffsetSeekBar;
     private TextView mFolderTextView;
+    private TextView mFailureTextView;
     private EditText mPasswordEditText;
 
     private IFile mFolder;
@@ -123,6 +125,7 @@ public class AutoBackupSettingDialog extends DialogFragment {
             mOffsetTextView = view.findViewById(R.id.auto_backup_offset_text_view);
             mOffsetSeekBar = view.findViewById(R.id.auto_backup_offset_seek_bar);
             mFolderTextView = view.findViewById(R.id.auto_backup_folder_text_view);
+            mFailureTextView = view.findViewById(R.id.auto_backup_failure_text_view);
             mPasswordEditText = view.findViewById(R.id.auto_backup_password_edit_text);
             // set listeners
             mOffsetSeekBar.setMax((OFFSET_MAX_HOURS - OFFSET_MIN_HOURS) / OFFSET_BETWEEN_HOURS);
@@ -141,6 +144,14 @@ public class AutoBackupSettingDialog extends DialogFragment {
                 @Override
                 public void onStopTrackingTouch(SeekBar seekBar) {
                     // not used
+                }
+
+            });
+            mServiceEnabledSwitchCompat.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+
+                @Override
+                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                    AutoBackupSettingDialog.this.onServiceEnabledChanged();
                 }
 
             });
@@ -168,6 +179,7 @@ public class AutoBackupSettingDialog extends DialogFragment {
             }
             onProgressChanged(mOffsetSeekBar.getProgress());
             onFolderChanged();
+            onServiceEnabledChanged();
         }
         return dialog;
     }
@@ -190,6 +202,17 @@ public class AutoBackupSettingDialog extends DialogFragment {
     }
 
     /**
+     * Shows the message about a failure having turned the service off when the switch reads off
+     * and a failure is on record for this backend. The switch on screen decides it and not the
+     * stored setting, so the message is never shown while the switch reads on.
+     */
+    private void onServiceEnabledChanged() {
+        boolean show = !mServiceEnabledSwitchCompat.isChecked()
+                && BackendManager.isAutoBackupDisabledByFailure(mBackendId);
+        mFailureTextView.setVisibility(show ? View.VISIBLE : View.GONE);
+    }
+
+    /**
      * A folder that is stored but cannot be read comes back from
      * {@link BackendServiceFactory#getFile} as null, and so does one that is not stored when the
      * backend has no default folder. The two do not get the same line. The notification the sweep
@@ -207,9 +230,10 @@ public class AutoBackupSettingDialog extends DialogFragment {
     }
 
     /**
-     * Saves the settings, or refuses and returns false. Nowhere else writes a backup folder. The
-     * two callers of {@link BackendManager#setAutoBackupEnabled} outside this screen only ever
-     * pass false, so neither can leave a backend enabled with no folder.
+     * Saves the settings, or refuses and returns false. Nowhere else writes a backup folder, and
+     * the only other way a backend's enabled state changes is
+     * {@link BackendManager#disableAutoBackupAfterFailure}, which turns it off, so nothing outside
+     * this screen can leave a backend enabled with no folder.
      *
      * A backend with no usable folder is what the refusal is about. Some backends offer a default
      * one and {@link BackendServiceFactory#getFile} hands it back for a folder that is not stored,

--- a/app/src/main/res/layout/dialog_auto_backup_setting.xml
+++ b/app/src/main/res/layout/dialog_auto_backup_setting.xml
@@ -73,6 +73,18 @@
         android:layout_marginTop="@dimen/material_dialog_seek_bar_top_bottom_margin"
         android:layout_marginBottom="@dimen/material_dialog_seek_bar_top_bottom_margin"/>
 
+    <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
+        android:id="@+id/auto_backup_failure_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/material_dialog_text_view_start_end_margin"
+        android:layout_marginRight="@dimen/material_dialog_text_view_start_end_margin"
+        android:layout_marginTop="@dimen/material_dialog_text_view_top_bottom_margin"
+        android:visibility="gone"
+        android:text="@string/message_auto_backup_disabled_after_failure"
+        app:theme_textColor="colorAccent"
+        tools:visibility="visible" />
+
     <com.oriondev.moneywallet.ui.view.theme.ThemedMaterialTextView
         android:id="@+id/auto_backup_folder_text_view"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -170,6 +170,7 @@
     <string name="hint_auto_backup_folder_not_chosen">"Not chosen"</string>
     <string name="hint_auto_backup_folder_unavailable">"Not available"</string>
     <string name="message_auto_backup_folder_required">"Choose a folder before turning automatic backup on."</string>
+    <string name="message_auto_backup_disabled_after_failure">"Automatic backup was turned off after this backup service failed. Check it before turning automatic backup back on."</string>
     <string name="message_backend_open_a_folder">"Open a folder to choose it."</string>
 
     <string name="total_wallet_name">"Total"</string>


### PR DESCRIPTION
## What happens now

The backup screen and the automatic backup sweep both turn automatic backup off for a backend when an operation fails in a way the app treats as not recoverable. Since `a61c382` the folder and the password it was using stay, so the Auto backup dialog reopens looking exactly like a service the user switched off themselves. Nothing there says the app is the one that turned it off.

## The change

`BackendManager.disableAutoBackupAfterFailure` records that and then turns the service off. The two failure sites call it instead of `setAutoBackupEnabled(id, false)`.

It records only for a backend that had automatic backup on. The manual backup, restore and browse paths share one of those callers, and browsing runs a listing every time that screen resumes, so otherwise a backend nobody turned automatic backup on for would carry it.

The dialog shows a line above the folder row while the record is stored and the switch reads off. It names neither the folder nor the operation, since an auth failure leaves the folder exactly where it was. Turning the service on forgets the record, and a save that leaves it off keeps it.

## Tested

Android 16 emulator, External Memory backend, its stored folder deleted underneath it. The forced sweep logs `No such file or directory`, the backend goes off and the record is written. The dialog carries the line, toggling the switch on removes it, and saving then clears the record. Saving with the service left off keeps it and the line returns on reopen. A manual backup failure on a backend with automatic backup off writes no record.

## What is not here

The sweep builds its backend outside the block that turns the service off, so a backend that cannot be built at all never reaches this record from the sweep. Separate bug.

The folder is still not checked for existence when the service is switched back on. Checking it is backend I/O, a network call on WebDAV, and a folder can go missing a minute after a check passes.

Closes #160
