### PR TITLE
Turn automatic backup off when the backend cannot be built

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/service/AutoBackupJobService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/AutoBackupJobService.java
@@ -218,8 +218,17 @@ public class AutoBackupJobService extends JobService {
             notifyMessage(context, context.getString(R.string.notification_content_backup_error_wifi_network));
             return;
         }
-        IBackendServiceAPI backendServiceAPI = BackendServiceFactory.getServiceAPIById(context, backendId);
         try {
+            // Built inside the block, so a service API that throws a BackendException the app
+            // cannot recover from while it is built turns automatic backup off like any other
+            // such failure. Outside it, a backend that is not connected any more, a released
+            // grant or a cleared server address stayed switched on and failed the same way the
+            // next time a backup ran, while the failure notification said automatic backup had
+            // been disabled.
+            // BackupHandlerIntentService, which the backup screen uses, builds its backend
+            // inside the block that disables, so that failure already turned the service off
+            // there.
+            IBackendServiceAPI backendServiceAPI = BackendServiceFactory.getServiceAPIById(context, backendId);
             BackupOperation.createAndUpload(context, backendServiceAPI, folder, BackendManager.getAutoBackupPassword(backendId), null);
         } catch (BackendException e) {
             if (!e.isRecoverable()) {


### PR DESCRIPTION
## What happens now

The sweep builds its backend on the line before the block whose catch turns automatic backup off after a failure the app cannot recover from. A service API that throws a `BackendException` while it is built throws from there, past that catch, so the service stays on and the run reports the failure with the wording written for a failure that did turn it off. Nothing is turned off, the occurrence is consumed, and the next backup that runs does the same thing again.

## The change

The backend is built inside the block. Once the run reaches that point, a backup service that is not connected any more, one whose storage grant was released, one whose server address is gone, and an account whose token or sign in is gone, all turn automatic backup off. The folder check and the WiFi check still return before the backend is built, and neither of those turns anything off.

`BackupHandlerIntentService`, which the backup screen uses, builds its backend inside the block that disables, so that failure already turned the service off there. The sweep and the backup screen now do the same thing with it.

## Tested

Android 16 emulator, the Local folder backend, automatic backup enabled on a subfolder, then Disconnect, which leaves automatic backup on.

On a build without this change, a forced sweep logs `Auto backup failed for 'storage_access_framework': SAFBackendService not enabled`, posts a notification saying automatic backup has been disabled, and leaves `auto_backup_enabled_storage_access_framework` true on two separate runs. With this change, the same forced sweep logs the same line, and the backend goes to false and out of the enabled services set.

## What this costs

A backend the sweep turns off this way stays off. Connecting it again does not switch it back on, because nothing outside the Auto backup dialog ever switches it on. The folder and the password are kept. A user who denied the notification permission, which the app asks for once, is told nothing.

Closes #164
