### PR TITLE
Draw a readable color when the chosen one matches what is behind it

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
@@ -25,7 +25,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
-import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
@@ -462,11 +461,13 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
         mCursor = cursor;
         mAccountHeader.clear();
         ITheme theme = ThemeEngine.getTheme();
-        int iconColor = theme.isDark() ? Color.parseColor("#8AFFFFFF") : Color.parseColor("#8A000000");
-        int selectedIconColor = theme.getColorPrimary();
-        int textColor = theme.isDark() ? Color.parseColor("#DEFFFFFF") : Color.parseColor("#DE000000");
-        int selectedTextColor = theme.getColorPrimary();
-        int selectedColor = theme.isDark() ? Color.parseColor("#202020") : Color.parseColor("#E8E8E8");
+        // applyNavigationDrawerBodyTheme runs against an empty profile list before the wallets
+        // load, and again on a theme change after they have, so the two write the same profiles
+        // in either order and have to agree on where the colors come from.
+        int iconColor = theme.getDrawerIconColor();
+        int textColor = theme.getDrawerTextColor();
+        int selectedTextColor = theme.getDrawerSelectedTextColor();
+        int selectedColor = theme.getDrawerSelectedItemColor();
         if (mCursor != null) {
             int indexWalletId = mCursor.getColumnIndex(Contract.Wallet.ID);
             int indexWalletName = mCursor.getColumnIndex(Contract.Wallet.NAME);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemeEngine.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemeEngine.java
@@ -340,7 +340,7 @@ public class ThemeEngine implements ITheme {
 
     @Override
     public int getDrawerSelectedIconColor() {
-        return getColorPrimary();
+        return drawerSelectedForeground();
     }
 
     @Override
@@ -350,7 +350,14 @@ public class ThemeEngine implements ITheme {
 
     @Override
     public int getDrawerSelectedTextColor() {
-        return getColorPrimary();
+        return drawerSelectedForeground();
+    }
+
+    // The opaque black or white, not the surface's own icon or text color: those are what the
+    // closed entries are already drawn in.
+    private int drawerSelectedForeground() {
+        int background = getDrawerSelectedItemColor();
+        return Util.visibleOr(getColorPrimary(), background, getBestColor(background));
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedCardButton.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedCardButton.java
@@ -43,6 +43,7 @@ public class ThemedCardButton extends CardButton implements ThemeEngine.ThemeCon
 
     @Override
     public void onApplyTheme(ITheme theme) {
-        setTextColor(theme.getColorAccent());
+        int background = theme.getColorCardBackground();
+        setTextColor(Util.visibleOr(theme.getColorAccent(), background, theme.getBestTextColor(background)));
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedCheckBox.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedCheckBox.java
@@ -42,7 +42,7 @@ public class ThemedCheckBox extends AppCompatCheckBox implements ThemeEngine.The
 
     @Override
     public void onApplyTheme(ITheme theme) {
-        TintHelper.applyTint(this, theme.getColorAccent(), theme.isDark());
+        TintHelper.applyTint(this, Util.accentAsIcon(theme), theme.isDark());
         setTextColor(theme.getTextColorPrimary());
         setHintTextColor(theme.getTextColorPrimary());
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedDialog.java
@@ -40,10 +40,12 @@ public class ThemedDialog {
         MaterialDialog.Builder builder = new MaterialDialog.Builder(context);
         ITheme theme = ThemeEngine.getTheme();
         builder.theme(theme.isDark() ? Theme.DARK : Theme.LIGHT);
-        builder.positiveColor(theme.getColorAccent());
-        builder.negativeColor(theme.getColorAccent());
-        builder.neutralColor(theme.getColorAccent());
-        builder.widgetColor(theme.getColorAccent());
+        int background = theme.getDialogBackgroundColor();
+        int accent = Util.visibleOr(theme.getColorAccent(), background, theme.getBestTextColor(background));
+        builder.positiveColor(accent);
+        builder.negativeColor(accent);
+        builder.neutralColor(accent);
+        builder.widgetColor(accent);
         return builder;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedMaterialEditText.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedMaterialEditText.java
@@ -66,13 +66,15 @@ public class ThemedMaterialEditText extends MaterialEditText implements ThemeEng
             setTextColor(theme.getBestTextColor(backgroundColor));
             setFloatingLabelColorNormal(theme.getBestHintColor(backgroundColor));
             setHintTextColor(theme.getBestHintColor(backgroundColor));
-            setFloatingLabelColorFocused(theme.getColorAccent());
+            int focused = Util.visibleOr(theme.getColorAccent(), backgroundColor,
+                    theme.getBestColor(backgroundColor));
+            setFloatingLabelColorFocused(focused);
             setLeftIconColorNormal(theme.getBestIconColor(backgroundColor));
-            setLeftIconColorFocused(theme.getColorAccent());
+            setLeftIconColorFocused(focused);
             setBottomLineColorNormal(theme.getBestIconColor(backgroundColor));
-            setBottomLineColorFocused(theme.getColorAccent());
+            setBottomLineColorFocused(focused);
             setBottomLineColorError(theme.getErrorColor());
-            TintHelper.setCursorTint(this, theme.getColorAccent());
+            TintHelper.setCursorTint(this, focused);
         }
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedMaterialProgressBar.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedMaterialProgressBar.java
@@ -47,7 +47,8 @@ public class ThemedMaterialProgressBar extends MaterialProgressBar implements Th
 
     @Override
     public void onApplyTheme(ITheme theme) {
-        setReachedBarColor(theme.getColorAccent());
+        int background = theme.getColorCardBackground();
+        setReachedBarColor(Util.visibleOr(theme.getColorAccent(), background, theme.getBestColor(background)));
         setUnreachedBarColor(theme.getIconColor());
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedMonthView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedMonthView.java
@@ -67,7 +67,7 @@ public class ThemedMonthView extends MonthView implements ThemeEngine.ThemeConsu
             int color = theme.getBestTextColor(background);
             setBackgroundColor(background);
             setDefaultColor(color);
-            setColorSelected(theme.getColorAccent());
+            setColorSelected(Util.visibleOr(theme.getColorAccent(), background, color));
             setColorBeforeSelection(color);
             EdgeGlowUtil.setEdgeGlowColor(this, theme.getColorPrimary(), null);
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedPatternLockView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedPatternLockView.java
@@ -57,7 +57,7 @@ public class ThemedPatternLockView extends PatternLockView implements ThemeEngin
     @Override
     public void onApplyTheme(ITheme theme) {
         int backgroundColor = getBackgroundColor(theme);
-        setCorrectStateColor(theme.getColorAccent());
+        setCorrectStateColor(Util.visibleOr(theme.getColorAccent(), backgroundColor, theme.getBestColor(backgroundColor)));
         setNormalStateColor(theme.getBestColor(backgroundColor));
         /* TODO: ensure this is visible over background color */
         setWrongStateColor(theme.getErrorColor());

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedProgressWheel.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedProgressWheel.java
@@ -39,15 +39,7 @@ public class ThemedProgressWheel extends ProgressWheel implements ThemeEngine.Th
 
     @Override
     public void onApplyTheme(ITheme theme) {
-        // This view is commonly used on the background color so we can
-        // double check if the color to use as bar-color is very similar
-        // to the color of the background. In this case we can dynamically
-        // calculate the best color to use instead of the color accent.
-        int barColor = theme.getColorAccent();
-        int windowBackground = theme.getColorWindowBackground();
-        if (!Util.isColorVisible(barColor, windowBackground)) {
-            barColor = theme.getBestIconColor(windowBackground);
-        }
-        setBarColor(barColor);
+        int background = theme.getColorWindowForeground();
+        setBarColor(Util.visibleOr(theme.getColorAccent(), background, theme.getBestIconColor(background)));
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedRadioButton.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedRadioButton.java
@@ -42,7 +42,7 @@ public class ThemedRadioButton extends AppCompatRadioButton implements ThemeEngi
 
     @Override
     public void onApplyTheme(ITheme theme) {
-        TintHelper.applyTint(this, theme.getColorAccent(), theme.isDark());
+        TintHelper.applyTint(this, Util.accentAsIcon(theme), theme.isDark());
         setTextColor(theme.getTextColorPrimary());
         setHintTextColor(theme.getHintTextColor());
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedSeekBar.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedSeekBar.java
@@ -42,6 +42,6 @@ public class ThemedSeekBar extends AppCompatSeekBar implements ThemeEngine.Theme
 
     @Override
     public void onApplyTheme(ITheme theme) {
-        TintHelper.applyTint(this, theme.getColorAccent(), theme.isDark());
+        TintHelper.applyTint(this, Util.accentAsIcon(theme), theme.isDark());
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedSwitchCompat.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedSwitchCompat.java
@@ -42,7 +42,7 @@ public class ThemedSwitchCompat extends SwitchCompat implements ThemeEngine.Them
 
     @Override
     public void onApplyTheme(ITheme theme) {
-        TintHelper.applyTint(this, theme.getColorAccent(), theme.isDark());
+        TintHelper.applyTint(this, Util.accentAsIcon(theme), theme.isDark());
         setTextColor(theme.getTextColorPrimary());
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedTabLayout.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedTabLayout.java
@@ -99,7 +99,8 @@ public class ThemedTabLayout extends TabLayout implements ThemeEngine.ThemeConsu
     }
 
     private void setSelectedTabIndicatorColor(ITheme theme) {
-        setSelectedTabIndicatorColor(theme.getColorAccent());
+        int background = getBackgroundColor(theme);
+        setSelectedTabIndicatorColor(Util.visibleOr(theme.getColorAccent(), background, theme.getBestTextColor(background)));
     }
 
     private int getBackgroundColor(ITheme theme) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedTextView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedTextView.java
@@ -79,7 +79,7 @@ public class ThemedTextView extends AppCompatTextView implements ThemeEngine.The
                     setTextColor(theme.getColorPrimary());
                     break;
                 case COLOR_ACCENT:
-                    setTextColor(theme.getColorAccent());
+                    setTextColor(Util.accentAsText(theme));
                     break;
                 case OVER_COLOR_PRIMARY:
                     setTextColor(theme.getBestTextColor(theme.getColorPrimary()));

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedViewPagerIndicator.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedViewPagerIndicator.java
@@ -47,7 +47,8 @@ public class ThemedViewPagerIndicator extends ViewPagerIndicator implements Them
 
     @Override
     public void onApplyTheme(ITheme theme) {
-        setSelectedDotColor(theme.getColorPrimary());
+        int background = theme.getColorWindowForeground();
+        setSelectedDotColor(Util.visibleOr(theme.getColorPrimary(), background, theme.getBestColor(background)));
         setUnselectedDotColor(theme.getIconColor());
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/Util.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/Util.java
@@ -22,6 +22,7 @@ package com.oriondev.moneywallet.ui.view.theme;
 import android.graphics.Color;
 import androidx.annotation.ColorInt;
 import androidx.annotation.FloatRange;
+import androidx.core.graphics.ColorUtils;
 
 /**
  * Created by andrea on 10/04/18.
@@ -67,11 +68,35 @@ import androidx.annotation.FloatRange;
         return isColorLight(color);
     }
 
-    /*package-local*/ static boolean isColorVisible(@ColorInt int color, @ColorInt int bgColor) {
-        int redOffset = Math.abs(Color.red(color) - Color.red(bgColor));
-        int greenOffset = Math.abs(Color.green(color) - Color.green(bgColor));
-        int blueOffset = Math.abs(Color.blue(color) - Color.blue(bgColor));
-        return redOffset + greenOffset + blueOffset > 50;
+    // A floor for seeing anything at all, under both numbers the accessibility guidelines give,
+    // 3:1 for a control and 4.5:1 for text. It has to be: several pairs the default theme itself
+    // draws sit between 2 and 3, so a higher floor would repaint the stock app.
+    private static final double MIN_CONTRAST = 2d;
+
+    private static boolean isColorVisible(@ColorInt int color, @ColorInt int bgColor) {
+        return ColorUtils.calculateContrast(color, bgColor) >= MIN_CONTRAST;
+    }
+
+    /*package-local*/ static int visibleOr(@ColorInt int color, @ColorInt int background, @ColorInt int fallback) {
+        return isColorVisible(color, background) ? color : fallback;
+    }
+
+    // These two serve classes that are used on a page and in a dialog, and onApplyTheme is given
+    // no way to tell which of the two an instance is on, so the accent has to hold up on both.
+    /*package-local*/ static int accentAsIcon(ITheme theme) {
+        return accentHoldsUpAnywhere(theme) ? theme.getColorAccent()
+                : theme.getBestColor(theme.getColorWindowForeground());
+    }
+
+    /*package-local*/ static int accentAsText(ITheme theme) {
+        return accentHoldsUpAnywhere(theme) ? theme.getColorAccent()
+                : theme.getBestTextColor(theme.getColorWindowForeground());
+    }
+
+    private static boolean accentHoldsUpAnywhere(ITheme theme) {
+        int accent = theme.getColorAccent();
+        return isColorVisible(accent, theme.getColorWindowForeground())
+                && isColorVisible(accent, theme.getDialogBackgroundColor());
     }
 
     /*package-local*/ static int stripAlpha(@ColorInt int color) {


### PR DESCRIPTION
Closes #161
Closes #162

The theme lets you pick the primary and the accent color, and about a dozen places paint one of them straight onto a surface whose color is fixed, with no check that the two differ.

Both reports are that bug. With a primary of black, the open entry in the navigation drawer is black on the `#202020` the drawer paints behind it, 1.29:1, in the two dark modes. With an accent of white in light mode, a dialog gets a white radio button, a white OK and a white CANCEL on a white dialog. That second one is not only cosmetic: a single choice list applies its selection when the positive button is pressed, so the theme cannot be changed except by tapping where OK would be. The same accent also erases every checkbox, switch and seek bar, every section header in Settings, and the underline and icon that mark a focused text field.

`Util.isColorVisible` already existed for this and had one caller. It added up the three channel differences and passed anything over 50, which black on `#202020` clears with 96, so it now uses the contrast ratio with a floor of 2. That floor is for seeing anything at all, under the 3:1 the accessibility guidelines ask of a control, and it has to be: the default accent on the default primary is 2.06:1, so a floor of 3 would repaint the stock app.

A substitute has to differ from whatever already marks the other state. `getBestIconColor(#202020)` is byte identical to the drawer's own unselected icon color, so the drawer takes the opaque black or white instead.

Tested on an emulator, one build pair. With the reported colors every site named above becomes visible. With the default colors the drawer, the tab indicator and the dialog are pixel identical in all three modes. One default changes: the chart pager dot in dark mode, 1.92:1 to 13.2:1.
