### PR TITLE
Keep an income or expense color from disappearing into the page

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailSummaryLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailSummaryLoader.java
@@ -34,6 +34,8 @@ import com.oriondev.moneywallet.model.PeriodMoney;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.ui.view.theme.ITheme;
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.DateUtils;
 
@@ -122,6 +124,11 @@ public class PeriodDetailSummaryLoader extends AbstractGenericLoader<PeriodDetai
         // the total net income contains all the available currencies
         List<BarData> barDataList = new ArrayList<>();
         List<CurrencyUnit> barDataCurrencies = new ArrayList<>();
+        ITheme theme = ThemeEngine.getTheme();
+        int incomeColor = theme.getVisibleColor(PreferenceManager.getCurrentIncomeColor(),
+                PreferenceManager.getDefaultColorIncome());
+        int expenseColor = theme.getVisibleColor(PreferenceManager.getCurrentExpenseColor(),
+                PreferenceManager.getDefaultColorExpense());
         for (String currency : totalNetIncomes.getCurrencies()) {
             // for each currency we have to iterate the period money items and generate
             // the chart data set composed by two sub data sets:
@@ -137,8 +144,8 @@ public class PeriodDetailSummaryLoader extends AbstractGenericLoader<PeriodDetai
             }
             BarDataSet incomeDataSet = new BarDataSet(incomeBarEntries, getContext().getString(R.string.hint_incomes));
             BarDataSet expenseDataSet = new BarDataSet(expenseBarEntries, getContext().getString(R.string.hint_expenses));
-            incomeDataSet.setColor(PreferenceManager.getCurrentIncomeColor());
-            expenseDataSet.setColor(PreferenceManager.getCurrentExpenseColor());
+            incomeDataSet.setColor(incomeColor);
+            expenseDataSet.setColor(expenseColor);
             barDataList.add(new BarData(incomeDataSet, expenseDataSet));
             barDataCurrencies.add(currencyUnit);
         }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/legacy/LegacyUserPreferences.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/legacy/LegacyUserPreferences.java
@@ -21,7 +21,6 @@ package com.oriondev.moneywallet.storage.database.legacy;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.graphics.Color;
 
 import com.oriondev.moneywallet.model.Group;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
@@ -88,11 +87,13 @@ public class LegacyUserPreferences {
     }
 
     public int getColorIn() {
-        return mPreferences.getInt(COLOR_INFLOW, Color.BLUE);
+        // The importer writes this in as a chosen color, so a legacy user who never chose one
+        // has to land on the same default as everybody else.
+        return mPreferences.getInt(COLOR_INFLOW, PreferenceManager.getDefaultColorIncome());
     }
 
     public int getColorOut() {
-        return mPreferences.getInt(COLOR_OUTFLOW, Color.RED);
+        return mPreferences.getInt(COLOR_OUTFLOW, PreferenceManager.getDefaultColorExpense());
     }
 
     public Group getGroupType() {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
@@ -102,7 +102,10 @@ public class PreferenceManager {
     public static final long NO_CURRENT_WALLET = -1L;
     public static final long TOTAL_WALLET_ID = 0L;
 
-    private static final int DEFAULT_COLOR_INCOME = Color.BLUE;
+    // Color.BLUE is 1.17:1 on a card, unreadable in both dark modes. These two are what a color
+    // that cannot be seen falls back to, and getVisibleColor returns a fallback unchecked, so
+    // each has to clear every surface an amount is drawn on by itself.
+    private static final int DEFAULT_COLOR_INCOME = 0xFF2196F3;
     private static final int DEFAULT_COLOR_EXPENSE = Color.RED;
 
     private static SharedPreferences mPreferences;
@@ -319,6 +322,14 @@ public class PreferenceManager {
             index = GROUP_TYPE_MONTHLY;
         }
         return Group.fromType(index);
+    }
+
+    public static int getDefaultColorIncome() {
+        return DEFAULT_COLOR_INCOME;
+    }
+
+    public static int getDefaultColorExpense() {
+        return DEFAULT_COLOR_EXPENSE;
     }
 
     public static int getCurrentIncomeColor() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ITheme.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ITheme.java
@@ -56,8 +56,6 @@ public interface ITheme {
 
     int getErrorColor();
 
-    int getDialogBackgroundColor();
-
     int getDrawerBackgroundColor();
 
     int getDrawerIconColor();
@@ -77,4 +75,6 @@ public interface ITheme {
     int getBestHintColor(int background);
 
     int getBestIconColor(int background);
+
+    int getVisibleColor(int color, int fallback);
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemeEngine.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemeEngine.java
@@ -106,12 +106,6 @@ public class ThemeEngine implements ITheme {
             Color.parseColor("#33ffffff") // OK
     };
 
-    private static final int[] DEFAULT_DIALOG_BACKGROUND_COLOR = new int[] {
-            Color.parseColor("#FFFFFF"), // OK
-            Color.parseColor("#424242"), // OK
-            Color.parseColor("#424242")  // OK
-    };
-
     private static final int[] DRAWER_BACKGROUND_COLOR = new int[] {
             Color.parseColor("#F9F9F9"),
             Color.parseColor("#303030"),
@@ -324,11 +318,6 @@ public class ThemeEngine implements ITheme {
     }
 
     @Override
-    public int getDialogBackgroundColor() {
-        return DEFAULT_DIALOG_BACKGROUND_COLOR[getMode().getIndex()];
-    }
-
-    @Override
     public int getDrawerBackgroundColor() {
         return DRAWER_BACKGROUND_COLOR[getMode().getIndex()];
     }
@@ -380,6 +369,11 @@ public class ThemeEngine implements ITheme {
     public int getBestHintColor(int background) {
         int index = Util.isColorLight(background) ? INDEX_MODE_LIGHT : INDEX_MODE_DARK;
         return DEFAULT_HINT_TEXT_COLOR[index];
+    }
+
+    @Override
+    public int getVisibleColor(int color, int fallback) {
+        return Util.holdsUpAnywhere(this, color) ? color : fallback;
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedDialog.java
@@ -40,7 +40,7 @@ public class ThemedDialog {
         MaterialDialog.Builder builder = new MaterialDialog.Builder(context);
         ITheme theme = ThemeEngine.getTheme();
         builder.theme(theme.isDark() ? Theme.DARK : Theme.LIGHT);
-        int background = theme.getDialogBackgroundColor();
+        int background = theme.getColorCardBackground();
         int accent = Util.visibleOr(theme.getColorAccent(), background, theme.getBestTextColor(background));
         builder.positiveColor(accent);
         builder.negativeColor(accent);
@@ -75,7 +75,7 @@ public class ThemedDialog {
     public static BottomSheetBuilder buildBottomSheet(Context context) {
         BottomSheetBuilder builder = new BottomSheetBuilder(context);
         ITheme theme = ThemeEngine.getTheme();
-        builder.setBackgroundColor(theme.getDialogBackgroundColor());
+        builder.setBackgroundColor(theme.getColorCardBackground());
         builder.setTitleTextColor(theme.getTextColorPrimary());
         builder.setItemTextColor(theme.getTextColorPrimary());
         builder.setIconTintColor(theme.getIconColor());

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/Util.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/Util.java
@@ -81,22 +81,21 @@ import androidx.core.graphics.ColorUtils;
         return isColorVisible(color, background) ? color : fallback;
     }
 
-    // These two serve classes that are used on a page and in a dialog, and onApplyTheme is given
-    // no way to tell which of the two an instance is on, so the accent has to hold up on both.
     /*package-local*/ static int accentAsIcon(ITheme theme) {
-        return accentHoldsUpAnywhere(theme) ? theme.getColorAccent()
+        return holdsUpAnywhere(theme, theme.getColorAccent()) ? theme.getColorAccent()
                 : theme.getBestColor(theme.getColorWindowForeground());
     }
 
     /*package-local*/ static int accentAsText(ITheme theme) {
-        return accentHoldsUpAnywhere(theme) ? theme.getColorAccent()
+        return holdsUpAnywhere(theme, theme.getColorAccent()) ? theme.getColorAccent()
                 : theme.getBestTextColor(theme.getColorWindowForeground());
     }
 
-    private static boolean accentHoldsUpAnywhere(ITheme theme) {
-        int accent = theme.getColorAccent();
-        return isColorVisible(accent, theme.getColorWindowForeground())
-                && isColorVisible(accent, theme.getDialogBackgroundColor());
+    // The surfaces a chosen color has to survive when nothing says which one it lands on. A
+    // dialog is a card, so this covers a tinted control in a dialog as well as an amount on a row.
+    /*package-local*/ static boolean holdsUpAnywhere(ITheme theme, @ColorInt int color) {
+        return isColorVisible(color, theme.getColorWindowForeground())
+                && isColorVisible(color, theme.getColorCardBackground());
     }
 
     /*package-local*/ static int stripAlpha(@ColorInt int color) {

--- a/app/src/main/java/com/oriondev/moneywallet/utils/MoneyFormatter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/MoneyFormatter.java
@@ -50,9 +50,6 @@ public class MoneyFormatter {
     private final static String EMPTY_TEXT = " --- ";
     private final static String DIVIDER_TEXT = " - ";
 
-    private int mColorIn;
-    private int mColorOut;
-    private int mColorNeutral;
     private boolean mCurrencyEnabled;
     private boolean mGroupDigitEnabled;
     private boolean mRoundDecimalsEnabled;
@@ -91,15 +88,22 @@ public class MoneyFormatter {
     }
 
     private MoneyFormatter() {
-        mColorIn = PreferenceManager.getCurrentIncomeColor();
-        mColorOut = PreferenceManager.getCurrentExpenseColor();
-        mColorNeutral = ThemeEngine.getTheme().getTextColorPrimary();
         mCurrencyEnabled = PreferenceManager.isCurrencyEnabled();
         mGroupDigitEnabled = PreferenceManager.isGroupDigitEnabled();
         mRoundDecimalsEnabled = PreferenceManager.isRoundDecimalsEnabled();
         mShowSymbolEnabled = PreferenceManager.isShowPlusMinusSymbolEnabled();
         mFormatter = DecimalFormat.getInstance();
         mFormatter.setMinimumIntegerDigits(DEFAULT_MIN_INTEGER_DIGITS);
+    }
+
+    private int colorIn() {
+        return ThemeEngine.getTheme().getVisibleColor(PreferenceManager.getCurrentIncomeColor(),
+                PreferenceManager.getDefaultColorIncome());
+    }
+
+    private int colorOut() {
+        return ThemeEngine.getTheme().getVisibleColor(PreferenceManager.getCurrentExpenseColor(),
+                PreferenceManager.getDefaultColorExpense());
     }
 
     public void setCurrencyEnabled(boolean enabled) {
@@ -201,14 +205,14 @@ public class MoneyFormatter {
         int numberOfCurrencies = money.getNumberOfCurrencies();
         if (numberOfCurrencies == 0) {
             SpannableString emptyString = new SpannableString(EMPTY_TEXT);
-            emptyString.setSpan(new ForegroundColorSpan(mColorNeutral), 0, emptyString.length(), 0);
+            emptyString.setSpan(new ForegroundColorSpan(ThemeEngine.getTheme().getTextColorPrimary()), 0, emptyString.length(), 0);
             builder.append(emptyString);
         } else {
             CurrencyMode currencyMode = money.getNumberOfCurrencies() > 1 ? CurrencyMode.ALWAYS_SHOWN : CurrencyMode.USER_PREFERENCE;
             for (Map.Entry<String, Long> entry : money.getCurrencyMoneys().entrySet()) {
                 if (builder.length() > 0) {
                     SpannableString divider = new SpannableString(DIVIDER_TEXT);
-                    divider.setSpan(new ForegroundColorSpan(mColorNeutral), 0, divider.length(), 0);
+                    divider.setSpan(new ForegroundColorSpan(ThemeEngine.getTheme().getTextColorPrimary()), 0, divider.length(), 0);
                     builder.append(divider);
                 }
                 CurrencyUnit currencyUnit = CurrencyManager.getCurrency(entry.getKey());
@@ -232,11 +236,11 @@ public class MoneyFormatter {
         String notTinted = getNotTintedString(currencyUnit, money, currencyMode, flowMode);
         SpannableString spannableString = new SpannableString(notTinted);
         if (tintMode == TintMode.AUTO_DETECT) {
-            spannableString.setSpan(new ForegroundColorSpan(money < 0L ? mColorOut : mColorIn), 0, notTinted.length(), 0);
+            spannableString.setSpan(new ForegroundColorSpan(money < 0L ? colorOut() : colorIn()), 0, notTinted.length(), 0);
         } else if (tintMode == TintMode.INCOME) {
-            spannableString.setSpan(new ForegroundColorSpan(mColorIn), 0, notTinted.length(), 0);
+            spannableString.setSpan(new ForegroundColorSpan(colorIn()), 0, notTinted.length(), 0);
         } else if (tintMode == TintMode.EXPENSE) {
-            spannableString.setSpan(new ForegroundColorSpan(mColorOut), 0, notTinted.length(), 0);
+            spannableString.setSpan(new ForegroundColorSpan(colorOut()), 0, notTinted.length(), 0);
         }
         return spannableString;
     }


### PR DESCRIPTION
Closes #167

Settings lets you pick a color for income and one for expenses, and every amount the app tints is painted in one of them with no check that it can be seen. Pick white in light mode and the amounts are gone.

The app shipped one of those colors itself. `Color.BLUE`, the default for income, is 1.17:1 on a card in both dark modes and 1.54:1 on the dark page, so the amounts it exists to mark could not be read there. The default is now `#2196F3`, which clears the floor on every surface an amount is drawn on, the worst of them 3.12:1. The legacy importer had its own copy of the old default and wrote it in as a chosen color, so it reads the same constant now.

Wherever one of the two is drawn as an amount it goes through a contrast test first, in `MoneyFormatter` and in the chart datasets `PeriodDetailSummaryLoader` builds. That test is the accent's, widened to any color and to the card background. `getDialogBackgroundColor` returned the same values and is deleted.

An amount lands on one of two surfaces and nothing tells the formatter which: the page for fifteen of the nineteen sites, a card for the debt row and the transaction model row. Those are one color in light mode and two in the dark ones, so a color is kept only if it holds up on both. The price is that a color readable on the dark page and not on a card, Purple 500 at 2.09:1 and 1.59:1, is replaced on the page rows too.

A color that fails falls back to the default for its own role, so two colors failing at once still leaves an income looking different from an expense.

Tested on an emulator. A white income color in light mode: the amount on a transaction row goes from no pixel that is not white to 1886.
