### PR TITLE
Take a real backup so a restore brings the ledger back

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,10 +1,10 @@
 # Privacy Policy
 
-Tallybook is an offline first expense manager. Your records live on your device, this project runs no server, and the app collects nothing about you.
+Tallybook is an offline first expense manager. Your records live on your device, this project runs no server, and the app collects nothing about you. Android's own backup can take a copy of the database off the device, which is described below.
 
 This policy covers the open source build, the `floss` and `osm` flavor combination in this repository, which is what F-Droid and the GitHub releases both ship.
 
-Last updated: August 17, 2026.
+Last updated: August 20, 2026.
 
 ## What Tallybook collects
 
@@ -18,7 +18,7 @@ Nothing. There is no account, no sign up, no analytics, no crash reporting, and 
 
 **Exchange rates.** Downloading exchange rates uses openexchangerates.org. No key ships with the app, so the feature does nothing until you register there and enter your own under Settings, Utilities, Exchange rates, Custom api-key. The key travels inside the address of the request, so it lands in their logs.
 
-**Android's own cloud backup.** The app is declared eligible for Android's backup, but a rules file inside the app narrows what the system is allowed to take to the app's root folder, and your database, your settings and your attachments all sit outside it. Tested on Android 16: the backup captured nothing and the system declined it. Older Android versions were not tested.
+**Android's own cloud backup.** The app is declared eligible for Android's backup, and a rules file inside the app decides what the system may take. A cloud backup takes your database. Your settings stay out, and so do the WebDAV address, username and password, the automatic backup passwords, the exchange rate key, the tile server address and the PIN or pattern you set, all of which live in files the rules leave out. Whether it runs at all is a system setting, not anything this app asks you about. The rules also ask for a transport that reports it can encrypt what it takes, and on Google's that is what a screen lock gives you; a transport that reports nothing gets nothing from this app. On Android 12 and up a direct phone to phone transfer during setup carries your attachments as well, because it hands them to your next device instead of to a server, while a cloud backup leaves them behind; below Android 12 there is no way to tell those two apart, so neither carries attachments. Tested on Android 16 against Google's backup, on a build whose rules differed only in also offering attachments: the database is taken, no settings file is, and restoring brings the database back. Older Android versions were not tested.
 
 **Other apps on your phone.** Several buttons hand something to whatever app the device has for it, with no network request from Tallybook: Open on a saved place and the drawer's ATM and bank search pass coordinates or your typed text to a maps app, usually Google Maps; opening an attachment passes that file to whatever opens its file type; and the chooser offered after an export passes the exported file the same way. Once a file is in another app, that app's own policy governs it.
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         android:theme="@style/MoneyWalletAppTheme"
         android:requestLegacyExternalStorage="true"
         android:fullBackupContent="@xml/backup_rules"
+        android:dataExtractionRules="@xml/data_extraction_rules"
         tools:ignore="GoogleAppIndexingWarning">
         <activity android:name=".ui.activity.LauncherActivity"
             android:exported="true">

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,5 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  Names the database and nothing else.
+
+  Do not add <include domain="sharedpref">. The app can write six files there and four of them
+  hold a secret in the clear: webdav.xml has the server url, username and password, dropbox.xml
+  has an OAuth access token in the proprietary flavor, backend_preferences.xml has the automatic
+  backup passwords, and preferences.xml has current_lock_code and the user's exchange rate api
+  key. Naming paths one at a time also keeps a preference file added later out of the backup
+  until someone decides it is safe.
+
+  Attachments are out on purpose. Nothing caps their size, a cloud backup has a size quota, and
+  going over it fails the whole package instead of dropping the file that broke it, so a user
+  with enough receipt photos would lose the ledger backup too. There is one rules file for both
+  paths below Android 12, so nothing here carries them at all; data_extraction_rules.xml governs
+  Android 12 and up and does carry them on a device transfer.
+
+  Settings, theme, the automatic backup configuration and the app lock therefore do not come
+  back on a restore. None of them ever did, because the rule this one replaces captured nothing
+  at all.
+-->
 <full-backup-content>
-    <include domain="root" path="."
-             requireFlags="clientSideEncryption" />
+    <include domain="database" path="database.db" requireFlags="clientSideEncryption" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  See backup_rules.xml for why shared_prefs is absent.
+
+  The two blocks differ on attachments, on purpose. A cloud backup has a size quota and going
+  over it fails the whole package, so attachments stay out. A device transfer has no quota and
+  hands the data straight to the user's next phone, so it carries them there.
+
+  disableIfNoEncryptionCapabilities carries forward the requireFlags="clientSideEncryption" that
+  backup_rules.xml has had since 2021, so a cloud backup of the ledger only leaves the device on
+  a transport that can encrypt it there. The attribute is not valid on device-transfer, so a
+  direct handoff carries the data with no encryption gate of its own.
+-->
+<data-extraction-rules>
+    <cloud-backup disableIfNoEncryptionCapabilities="true">
+        <include domain="database" path="database.db" />
+    </cloud-backup>
+    <device-transfer>
+        <include domain="database" path="database.db" />
+        <include domain="external" path="attachments" />
+    </device-transfer>
+</data-extraction-rules>

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -25,7 +25,7 @@ Privacy and offline first:
 
 * Optional app lock with a PIN, a pattern, or your fingerprint
 * No account, no sign-up, and no ads
-* Your data stays on your device unless you choose to back it up or export it
+* Your data stays on your device unless you back it up, export it, or leave Android's own backup on
 * The open-source build uses OpenStreetMap and no Google services
 
 Tallybook is free software under the GNU General Public License v3.0.


### PR DESCRIPTION
Fixes #169.

Android's own backup was set up to take nothing. The rule that tells the system what it may copy pointed at a folder the app keeps no data in, so the backup came back empty every time, and restoring onto a new phone brought back an app with no wallets and no history. It has been that way since 2021.

The rule now names the ledger, the single file everything lives in.

Nothing else goes with it. The settings stay on the phone, and so do the things stored beside them: the address and login for a personal backup server, the automatic backup passwords, the exchange rate key, and the app lock code, which is kept exactly as it was typed. Including the settings folder and holding back only the one file that obviously holds a secret would have sent the other three to the cloud, so the rule names what goes instead of what stays.

Attachments go only on a direct phone to phone transfer during setup. A cloud backup leaves them behind on purpose, because there is a size limit on one, nothing in the app caps what a user can attach, and going over that limit throws away the whole backup instead of the file that broke it. Tested on a phone: forty megabytes of attachments turned the backup off and it stayed off, even after deleting them and reinstalling.

The 2021 requirement that a backup only happen where it can be encrypted is untouched. It was never the reason the backup was empty.

The privacy policy and the store listing change with it, because this makes both of them wrong.

Tested on a Galaxy S25 Ultra on Android 16 against Google's backup. The old build is refused, this one backs up and reports success, and clearing the app and restoring brings the ledger back with no settings file.

One thing it does not fix. With the settings out, the app no longer remembers being set up, so a restored app opens on its welcome screen with its data behind it. That is issue 173.
