### PR TITLE
Date a debt's master transaction to the debt, not to the moment it was saved

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,8 +179,8 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.6.28'
     // android test dependencies (on-device tests)
     androidTestImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:core:1.2.0'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test:rules:1.2.0'
-    androidTestUtil "androidx.test:orchestrator:1.2.0"
+    androidTestImplementation 'androidx.test:core:1.6.1'
+    androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
+    androidTestUtil "androidx.test:orchestrator:1.5.1"
 }

--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -1253,6 +1253,32 @@ public class SQLDatabaseTest {
     }
 
     @Test
+    public void debtMasterTransactionTakesTheDebtDate() throws Exception {
+        long walletId = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        // A past date, so a failure reads as a wrong month, not a wrong time of day. What
+        // actually left the existing insertDebt and updateDebt tests blind to this is that they
+        // never assert the transaction's date at all, only how many rows came back.
+        Date picked = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", picked, null, walletId, "note-1", null, 2000L, false, null, "tag-1", true);
+        assertEquals(DateUtils.getSQLDateTimeString(picked), masterTransactionDate(debtId));
+        // and it follows the debt when the date is edited
+        Date moved = DateUtils.getDateFromSQLDateString("2026-06-15");
+        assertEquals(1, updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", moved, null, walletId, "note-1", null, 2000L, false, null, "tag-1"));
+        assertEquals(DateUtils.getSQLDateTimeString(moved), masterTransactionDate(debtId));
+    }
+
+    private String masterTransactionDate(long debtId) {
+        Cursor cursor = mDatabase.getTransactions(new String[] {Contract.Transaction.DATE},
+                Contract.Transaction.DEBT_ID + " = ?", new String[] {String.valueOf(debtId)}, null);
+        assertNotNull(cursor);
+        assertEquals(1, cursor.getCount());
+        cursor.moveToFirst();
+        String date = cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE));
+        cursor.close();
+        return date;
+    }
+
+    @Test
     public void deleteDebt() throws Exception {
         long id1 = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
         long id2 = insertPlace("place-2", "encoded-icon-2", "fake-address-2", 7.3467, 8.364, "tag-2");

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -2198,6 +2198,25 @@ import java.util.UUID;
     }
 
     /**
+     * A debt and its master transaction are the same event, so the transaction takes the debt's
+     * own date at the start of that day. The debt editor writes the date with no time of day, so
+     * the value cannot be carried across as it stands. Debt.DATE is NOT NULL in the schema, so
+     * the null branch cannot fire today and is only there to keep a schema change from becoming
+     * a crash here.
+     *
+     * The parse is lenient, like every other getDateFromSQLDateString call in this app: a day
+     * past the end of its month rolls forward and a trailing time is dropped without complaint.
+     * NewEditDebtActivity is the only caller that writes this key and it always writes a plain
+     * valid date, so nothing here has to refuse those the way CSVDataImporter.parseDatetime does.
+     */
+    private static String masterTransactionDateFor(String debtDate) {
+        if (debtDate == null) {
+            return DateUtils.getSQLDateTimeString(System.currentTimeMillis());
+        }
+        return DateUtils.getSQLDateTimeString(DateUtils.getDateFromSQLDateString(debtDate));
+    }
+
+    /**
      * This method is called by the content provider when the user is inserting a new debt.
      *
      * contentValues bundle that contains the data from the content provider.
@@ -2240,7 +2259,7 @@ import java.util.UUID;
                 cv = new ContentValues();
                 Contract.DebtType type = Contract.DebtType.fromValue(contentValues.getAsInteger(Contract.Debt.TYPE));
                 cv.put(Contract.Transaction.MONEY, contentValues.getAsLong(Contract.Debt.MONEY));
-                cv.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(System.currentTimeMillis()));
+                cv.put(Contract.Transaction.DATE, masterTransactionDateFor(contentValues.getAsString(Contract.Debt.DATE)));
                 cv.put(Contract.Transaction.DESCRIPTION, contentValues.getAsString(Contract.Debt.DESCRIPTION));
                 cv.put(Contract.Transaction.CATEGORY_ID, getSystemCategoryId((type == Contract.DebtType.DEBT) ? Schema.CategoryTag.DEBT : Schema.CategoryTag.CREDIT));
                 cv.put(Contract.Transaction.DIRECTION, (type == Contract.DebtType.CREDIT) ? Contract.Direction.EXPENSE : Contract.Direction.INCOME);
@@ -2376,6 +2395,9 @@ import java.util.UUID;
                     }
                     if (contentValues.containsKey(Contract.Debt.DESCRIPTION)) {
                         cv.put(Contract.Transaction.DESCRIPTION, contentValues.getAsString(Contract.Debt.DESCRIPTION));
+                    }
+                    if (contentValues.containsKey(Contract.Debt.DATE)) {
+                        cv.put(Contract.Transaction.DATE, masterTransactionDateFor(contentValues.getAsString(Contract.Debt.DATE)));
                     }
                     if (contentValues.containsKey(Contract.Debt.TYPE)) {
                         Contract.DebtType type = Contract.DebtType.fromValue(contentValues.getAsInteger(Contract.Debt.TYPE));


### PR DESCRIPTION
Fixes #170.

Enter a debt for a month that has already passed and answer yes to recording the money, and the debt keeps the date you picked while the money lands on the day you typed it in. A debt entered in August for something that happened in July puts five hundred dollars into August. Every report, overview and period total that counts it is wrong by a month.

The money now takes the debt's own date, on both halves of this. Saving a new debt dates the money to the debt, and editing an existing debt's date moves the money with it. That second half was missing entirely, so a debt whose date was corrected left the money where it was.

There is a third way that date can move and this does not close it. The transaction list will open a debt's money in the ordinary editor like any other row, and saving there writes whatever date is on the screen without consulting the debt. That is older than this change and is filed separately as issue 177.

One consequence is worth saying out loud. A debt dated in the future no longer counts until that date arrives, where before it counted immediately. The wallet balance, budget progress, the overview, the period summary and the transaction list all leave future money out, so this is now consistent with every other future dated entry, and the date picker on a debt has never had an upper bound.

Debts entered before this keep the date they were given. Nothing rewrites them, because that would mean editing financial records nobody asked us to touch. Opening such a debt and saving it corrects it.

There is a test, and it fails if the fix is taken out. Getting it to run needed a separate commit first: the instrumented tests have never compiled in this repo, because their test libraries were pinned at versions from 2019 that break the build. Bumping those four is the whole of that commit.

Tested on an Android 16 emulator, same input on both builds.
