### PR TITLE
Point the child category elbow at the child in a right to left layout

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/CategoryChildIndicator.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/CategoryChildIndicator.java
@@ -79,6 +79,20 @@ public class CategoryChildIndicator extends View {
         if (width == 0 || height == 0) {
             return;
         }
+        // The row around this view is mirrored in a right to left layout and this canvas is not,
+        // so the child's icon ends up on the left while the arm below still runs to the right
+        // edge. Mirroring the canvas puts the arm on the side the icon is on.
+        //
+        // The pivot is the integer width / 2, which is what the strokes below are built around,
+        // not width / 2f. At an odd width those differ by half a pixel and the mirror would move
+        // the vertical stroke a pixel instead of mapping it onto itself.
+        //
+        // Saved and restored because onDrawForeground runs after this on the same canvas, so a
+        // foreground or a ripple added to this view later would otherwise be mirrored too.
+        int savedCanvas = c.save();
+        if (getLayoutDirection() == LAYOUT_DIRECTION_RTL) {
+            c.scale(-1f, 1f, width / 2, 0f);
+        }
         int startX = (width / 2) - (lineSize / 2);
         int endX = startX + lineSize;
         int startY = 0;
@@ -88,5 +102,6 @@ public class CategoryChildIndicator extends View {
         startY = (height / 2) + (lineSize / 2);
         endY = startY + lineSize;
         c.drawRect(startX, startY, endX, endY, mPaint);
+        c.restoreToCount(savedCanvas);
     }
 }

--- a/app/src/test/java/com/oriondev/moneywallet/ui/view/CategoryChildIndicatorSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/view/CategoryChildIndicatorSourceTest.java
@@ -1,0 +1,81 @@
+package com.oriondev.moneywallet.ui.view;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * The mirroring checked here happens inside onDraw on a real Canvas, so a JVM unit test cannot
+ * observe it: there is no Robolectric on the unit test classpath, and proving what is drawn takes
+ * a device. The invariant is pinned by reading the source instead, the same way
+ * NewEditTransactionActivitySourceTest does.
+ *
+ * What this asserts is that onDraw still asks the view for its layout direction and still mirrors
+ * the canvas when that direction is right to left. That makes it a tripwire against a revert or a
+ * rewrite that drops the branch. It is not a proof that the elbow lands on the child's icon, and a
+ * rewrite that keeps these tokens and still draws the arm on the wrong side goes through.
+ *
+ * Comments are stripped before anything is matched, so no assertion here can be satisfied by the
+ * wording of a comment describing the code it no longer has. String literals are NOT stripped,
+ * unlike the precedent. The file under test has none, and if one is ever added the literal half
+ * has to be added here at the same time, because a literal carrying one of the tokens below would
+ * satisfy its assertion with the code gone. That is the false pass the precedent strips literals
+ * to prevent.
+ *
+ * The assertions pin exact spellings, so a rewrite that behaves identically can still fail here:
+ * c.restore() for c.restoreToCount(), or (width / 2) for width / 2. A failure means read the
+ * source and decide, not that the view is broken.
+ *
+ * Why it is worth pinning: with the branch gone the elbow's horizontal arm runs to the right edge
+ * in every layout, so in a right to left language it runs away from the child icon into empty
+ * space and the two never meet. Nothing crashes and nothing logs, so the only signal is somebody
+ * looking at the screen in a right to left language.
+ */
+public class CategoryChildIndicatorSourceTest {
+
+    private static final Pattern COMMENTS = Pattern.compile("//.*?$|/[*].*?[*]/", Pattern.DOTALL | Pattern.MULTILINE);
+
+    private String readSource() {
+        String path = "src/main/java/com/oriondev/moneywallet/ui/view/CategoryChildIndicator.java";
+        File file = new File(path);
+        if (!file.exists()) {
+            // a runner rooted at the repo root instead of the module, which the precedent
+            // handles the same way
+            file = new File("app/" + path);
+        }
+        if (!file.exists()) {
+            fail("Cannot find CategoryChildIndicator.java at " + file.getAbsolutePath());
+        }
+        try {
+            String source = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            return COMMENTS.matcher(source).replaceAll(" ");
+        } catch (IOException e) {
+            fail("Cannot read CategoryChildIndicator.java: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Test
+    public void onDrawMirrorsTheCanvasInARightToLeftLayout() {
+        String source = readSource();
+        int onDraw = source.indexOf("public void onDraw(");
+        assertTrue("onDraw is gone", onDraw >= 0);
+        String body = source.substring(onDraw);
+        assertTrue("onDraw no longer reads the layout direction",
+                body.contains("getLayoutDirection() == LAYOUT_DIRECTION_RTL"));
+        assertTrue("onDraw no longer carries the exact call scale(-1f, 1f, width / 2, ...). Either the "
+                        + "mirror is gone, or the pivot is no longer the integer width / 2, which would "
+                        + "shift the elbow a pixel at odd widths, or it was respelled",
+                body.contains("scale(-1f, 1f, width / 2,"));
+        assertTrue("onDraw no longer carries the exact pair = c.save() and restoreToCount(. Either the "
+                        + "canvas is left mirrored for onDrawForeground, or it was respelled",
+                body.contains("= c.save()") && body.contains("restoreToCount("));
+    }
+}


### PR DESCRIPTION
Fixes #171.

Open the category list in a right to left language, on a parent category with a child under it, and the little elbow that joins the two runs the wrong way. It drops down from the parent and then heads right, into empty space, while the child's icon has moved over to the left. The two never meet.

The row itself mirrors correctly. What does not is the small piece of custom drawing inside it, which has no idea the layout was flipped and always draws its arm toward the right edge.

It now flips that drawing when the layout is right to left, and the drawing itself is untouched. The upright part of the elbow sits in the middle either way, so flipping leaves it exactly where it was and only moves the arm to the side the icon is on.

There is a test, of a limited kind. What is drawn on a screen cannot be checked without a screen, and there is nothing in this project's test setup that can stand in for one. So the test reads the source and fails if the flip is taken out, if the pivot it turns around is changed to the wrong one, or if the drawing is left flipped for anything that comes after it. Each of those three was tried and each one fails as it should. It cannot tell you where the arm ends up. Only a screen can.

While in there I found that the helper the two custom text fields use to ask the same question can never return true, so every right to left branch in both of them has never run. That is a bigger problem than this one and it is filed separately as issue 174. This deliberately does not use that helper.

Tested on an Android 16 emulator with the app language set to Persian, on a parent with one child. Before, the arm ran off into empty space. After, it reaches the icon. Checked in English on the same build, where nothing about the elbow changes.
