### PR TITLE
Refuse a saving withdraw larger than the saving holds

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -60,6 +60,7 @@ import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.AttachmentView;
 import com.oriondev.moneywallet.ui.view.text.MaterialEditText;
 import com.oriondev.moneywallet.ui.view.text.Validator;
+import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.DateFormatter;
 import com.oriondev.moneywallet.utils.DateUtils;
@@ -121,6 +122,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private static final String SS_DEBT_ID = "NewEditTransactionActivity::SavedState::DebtId";
     private static final String SS_SAVING_ID = "NewEditTransactionActivity::SavedState::SavingId";
     private static final String SS_SAVING_COMPLETED = "NewEditTransactionActivity::SavedState::SavingCompleted";
+    private static final String SS_SAVING_WITHDRAW_LIMIT = "NewEditTransactionActivity::SavedState::SavingWithdrawLimit";
+    private static final String SS_SAVING_WITHDRAW_CURRENCY = "NewEditTransactionActivity::SavedState::SavingWithdrawCurrency";
 
     private TextView mCurrencyTextView;
     private TextView mMoneyTextView;
@@ -150,6 +153,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private Long mDebtId = null;
     private Long mSavingId = null;
     private boolean mSavingCompleted = false;
+    private Long mSavingWithdrawLimit = null;
+    private String mSavingWithdrawCurrency = null;
 
     private MoneyFormatter mMoneyFormatter = MoneyFormatter.getInstance();
 
@@ -454,6 +459,22 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                         }
                         mConfirmedCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) == 1);
                         mCountInTotalCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.COUNT_IN_TOTAL)) == 1);
+                        // A withdraw already in the database is being opened. Without a limit
+                        // here it can simply be edited upwards, which is the same bug by another
+                        // route. What it can grow to is what the saving holds plus what this row
+                        // is already taking out, because the saving's progress counts this row.
+                        //
+                        // It only counts it while the row is confirmed and not dated ahead, which
+                        // is the same pair getSavings filters on, so the amount is added back only
+                        // when the stored row is one of those. Adding it back for a row the
+                        // progress never counted would hand out a ceiling too high by exactly that
+                        // amount.
+                        if (mSavingId != null && category != null
+                                && Contract.CategoryTag.SAVING_WITHDRAW.equals(category.getTag())) {
+                            boolean storedRowCounts = cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) == 1
+                                    && !DateUtils.getDateFromSQLDateTimeString(cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE))).after(new Date());
+                            loadSavingWithdrawLimit(contentResolver, mSavingId, storedRowCounts ? money : 0L);
+                        }
                     }
                     cursor.close();
                 }
@@ -744,6 +765,12 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             // crashes the editor as it opens: the bind value at index 1 is null.
                         case SAVING_WITHDRAW:
                             selectionArgs[0] = Contract.CategoryTag.SAVING_WITHDRAW;
+                            // The figure is already in hand from the query above, so this sets the
+                            // ceiling from it instead of reading the same row again. Nothing is
+                            // added back: this row does not exist yet, so the saving's progress
+                            // cannot already be counting it.
+                            setSavingWithdrawLimit(savingMoney, 0L,
+                                    wallet != null && wallet.getCurrency() != null ? wallet.getCurrency().getIso() : null);
                             break;
                     }
                     cursor = contentResolver.query(uri, projection, selection, selectionArgs, null);
@@ -841,6 +868,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             mDebtId = savedInstanceState.containsKey(SS_DEBT_ID) ? savedInstanceState.getLong(SS_DEBT_ID) : null;
             mSavingId = savedInstanceState.containsKey(SS_SAVING_ID) ? savedInstanceState.getLong(SS_SAVING_ID) : null;
             mSavingCompleted = savedInstanceState.getBoolean(SS_SAVING_COMPLETED, false);
+            mSavingWithdrawLimit = savedInstanceState.containsKey(SS_SAVING_WITHDRAW_LIMIT) ? savedInstanceState.getLong(SS_SAVING_WITHDRAW_LIMIT) : null;
+            mSavingWithdrawCurrency = savedInstanceState.getString(SS_SAVING_WITHDRAW_CURRENCY);
         }
         // depending on the type we must hide pickers that are now allowed to be changed
         switch (mType) {
@@ -918,6 +947,10 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             outState.putLong(SS_SAVING_ID, mSavingId);
         }
         outState.putBoolean(SS_SAVING_COMPLETED, mSavingCompleted);
+        if (mSavingWithdrawLimit != null) {
+            outState.putLong(SS_SAVING_WITHDRAW_LIMIT, mSavingWithdrawLimit);
+            outState.putString(SS_SAVING_WITHDRAW_CURRENCY, mSavingWithdrawCurrency);
+        }
     }
 
     @Override
@@ -958,11 +991,93 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private boolean validate() {
         if (mDateEditText.validate() && mCategoryEditText.validate() && mWalletEditText.validate()) {
             if (mAttachmentPicker.areAllAttachmentsReady()) {
-                return true;
+                return validateSavingWithdraw();
             } else {
                 // TODO show error: wait for attachment load competition
             }
         }
+        return false;
+    }
+
+    /**
+     * Reads what a saving holds, its start money plus its progress, which is the same sum the
+     * savings list draws its current amount from, and remembers the currency that figure is in.
+     *
+     * alreadyTaken is what the row being edited is itself withdrawing. The progress counts that
+     * row, so adding it back gives what the row is allowed to grow to. It is zero for a new row.
+     */
+    private void loadSavingWithdrawLimit(ContentResolver contentResolver, long savingId, long alreadyTaken) {
+        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, savingId);
+        String[] projection = new String[] {
+                Contract.Saving.START_MONEY,
+                Contract.Saving.PROGRESS,
+                Contract.Saving.WALLET_CURRENCY
+        };
+        Cursor cursor = contentResolver.query(uri, projection, null, null, null);
+        if (cursor != null) {
+            if (cursor.moveToFirst()) {
+                setSavingWithdrawLimit(
+                        cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY))
+                                + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS)),
+                        alreadyTaken,
+                        cursor.getString(cursor.getColumnIndex(Contract.Saving.WALLET_CURRENCY)));
+            }
+            cursor.close();
+        }
+    }
+
+    /**
+     * Never below what the row already takes. A saving that is under zero gives a negative
+     * ceiling, and the amount field cannot go negative, so that would refuse every save of the
+     * row, including lowering the amount or correcting the note. Holding it at what the row
+     * already takes lets the row be kept or reduced and still refuses raising it. For a new row
+     * that term is zero, so the floor is zero and a saving holding nothing allows no withdraw.
+     */
+    private void setSavingWithdrawLimit(long held, long alreadyTaken, String currencyIso) {
+        mSavingWithdrawLimit = Math.max(held + alreadyTaken, alreadyTaken);
+        mSavingWithdrawCurrency = currencyIso;
+    }
+
+    /**
+     * A withdraw cannot take out more than the saving holds. The ceiling is loaded whenever the
+     * editor opens on a withdraw, whether that is a new one from the savings list or one already
+     * in the database, and stays null everywhere else, so a deposit and an ordinary transaction
+     * are unaffected.
+     *
+     * The check applies only to a row that will count once saved. getSavings sums confirmed rows
+     * that are not dated ahead, so a row saved unconfirmed or into the future moves nothing and
+     * has nothing to be refused for. That is read from the fields as they stand now and not from
+     * the stored row, because it is the row about to be written that matters. What such a row does
+     * when it is later confirmed is the gap issue 175 covers.
+     */
+    private boolean validateSavingWithdraw() {
+        if (mSavingWithdrawLimit == null) {
+            return true;
+        }
+        if (!mConfirmedCheckBox.isChecked() || mDateTimePicker.getCurrentDateTime().after(new Date())) {
+            return true;
+        }
+        CurrencyUnit currency = mSavingWithdrawCurrency != null ? CurrencyManager.getCurrency(mSavingWithdrawCurrency) : null;
+        // The limit is in the saving's own currency. If the wallet on screen has been changed to
+        // another one the two are not comparable as they stand, and this screen converts nowhere
+        // else, so the check steps aside instead of comparing amounts that do not mean the same
+        // thing.
+        CurrencyUnit walletCurrency = mWalletPicker.getCurrentWallet().getCurrency();
+        if (currency == null || walletCurrency == null || !currency.getIso().equals(walletCurrency.getIso())) {
+            return true;
+        }
+        if (mMoneyPicker.getCurrentMoney() <= mSavingWithdrawLimit) {
+            return true;
+        }
+        String message = mSavingWithdrawLimit <= 0
+                ? getString(R.string.error_saving_withdraw_nothing_to_take)
+                : getString(R.string.error_saving_withdraw_over_balance,
+                        mMoneyFormatter.getNotTintedString(currency, mSavingWithdrawLimit));
+        ThemedDialog.buildMaterialDialog(this)
+                .title(R.string.title_error)
+                .content(message)
+                .positiveText(android.R.string.ok)
+                .show();
         return false;
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,6 +384,8 @@
     <string name="title_success">"Success"</string>
     <string name="title_failed">"Failed"</string>
     <string name="title_error">"Error"</string>
+    <string name="error_saving_withdraw_over_balance">"You cannot withdraw more than %1$s from this saving."</string>
+    <string name="error_saving_withdraw_nothing_to_take">"There is nothing in this saving to withdraw."</string>
     <string name="title_atm_search">"Search ATM"</string>
     <string name="title_bank_search">"Search bank"</string>
     <string name="title_changelog">"Changelog"</string>


### PR DESCRIPTION
Fixes #172.

Take more out of a savings goal than it holds and nothing stops you. The goal's current amount goes below zero and stays there, and the app also records money arriving in your wallet that was never put in.

The floor was missing on the way in. What a goal holds is worked out by adding up what went in and taking off what came out, with nothing to stop that going negative. Putting the floor in that sum would have been the wrong place, because it would hide a number the transaction list still shows.

A withdrawal larger than the goal holds is now refused, with a message saying what the limit is.

Both ways in are covered. Taking money out from the savings screen is the obvious one. The other is editing a withdrawal already saved, where the limit is what the goal holds plus what that entry already takes out, because the goal's total counts it. Without that second half the original problem stays two taps away: save a small withdrawal, reopen it, raise the amount.

The check is skipped for an entry that will not count once saved, which means one left unconfirmed or dated in the future. Those move the goal by nothing, so there is nothing to refuse them for, and refusing them would block a save somebody is entitled to make.

The limit never drops below what the entry already takes out. A goal that is already below zero would otherwise produce a limit no amount can satisfy, and since the amount cannot be negative that would freeze the entry completely, with no way to lower it or fix a typo.

Deposits and ordinary entries are untouched, and taking everything out still works.

What this does not close is filed separately. Entries left unconfirmed, dated ahead, or written by an import can still take a goal under, which is issue 175. A savings entry moved to a wallet in another currency is counted at face value, which is older than this and is issue 176.

Tested on an Android 16 emulator.
