### PR TITLE
Let a person's screen start a transaction with that person attached

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -88,6 +88,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     public static final String DEBT_ACTION = "NewEditTransactionActivity::DebtAction";
     public static final String SAVING_ID = "NewEditTransactionActivity::SavingId";
     public static final String SAVING_ACTION = "NewEditTransactionActivity::SavingAction";
+    public static final String PERSON_ID = "NewEditTransactionActivity::PersonId";
     public static final String MODEL_ID = "NewEditTransactionActivity::ModelId";
 
     /**
@@ -588,6 +589,34 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             );
                         }
                         cursor.close();
+                    }
+                    // opened from a person, so that person is already attached and the user only
+                    // has to pick a category, which is what decides income or expense.
+                    //
+                    // Read here and nowhere else on purpose. An existing transaction must not have
+                    // its people rewritten by an intent, and the debt and saving branches load
+                    // people of their own that this would overwrite. Adding the extra to one of
+                    // those launches would be silently ignored, not wrong.
+                    if (intent.hasExtra(PERSON_ID)) {
+                        Uri personUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_PEOPLE, intent.getLongExtra(PERSON_ID, 0L));
+                        String[] personProjection = new String[] {
+                                Contract.Person.ID,
+                                Contract.Person.NAME,
+                                Contract.Person.ICON
+                        };
+                        Cursor personCursor = contentResolver.query(personUri, personProjection, null, null, null);
+                        if (personCursor != null) {
+                            if (personCursor.moveToFirst()) {
+                                people = new Person[] {
+                                        new Person(
+                                                personCursor.getLong(personCursor.getColumnIndex(Contract.Person.ID)),
+                                                personCursor.getString(personCursor.getColumnIndex(Contract.Person.NAME)),
+                                                IconLoader.parse(personCursor.getString(personCursor.getColumnIndex(Contract.Person.ICON)))
+                                        )
+                                };
+                            }
+                            personCursor.close();
+                        }
                     }
                 } else if (mType == TYPE_TRANSFER) {
                     // In this case the activity has been launched to insert a new transfer so we

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PersonItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PersonItemFragment.java
@@ -48,6 +48,7 @@ import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
 import com.oriondev.moneywallet.ui.activity.NewEditPersonActivity;
+import com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity;
 import com.oriondev.moneywallet.ui.activity.TransactionListActivity;
 import com.oriondev.moneywallet.ui.fragment.base.SecondaryPanelFragment;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
@@ -89,13 +90,18 @@ public class PersonItemFragment extends SecondaryPanelFragment implements Loader
 
     @Override
     protected int onInflateMenu() {
-        return R.menu.menu_list_edit_delete_item;
+        return R.menu.menu_person_item;
     }
 
     @Override
     public boolean onMenuItemClick(MenuItem item) {
         int itemId = item.getItemId();
-        if (itemId == R.id.action_show_transaction_list) {
+        if (itemId == R.id.action_new_transaction_for_person) {
+            Intent intent = new Intent(getActivity(), NewEditTransactionActivity.class);
+            intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.NEW_ITEM);
+            intent.putExtra(NewEditTransactionActivity.PERSON_ID, getItemId());
+            startActivity(intent);
+        } else if (itemId == R.id.action_show_transaction_list) {
             Intent intent = new Intent(getActivity(), TransactionListActivity.class);
             intent.putExtra(TransactionListActivity.PERSON_ID, getItemId());
             startActivity(intent);

--- a/app/src/main/res/menu/menu_person_item.xml
+++ b/app/src/main/res/menu/menu_person_item.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<menu
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <!--
+      never, not ifRoom. On a narrow toolbar the three actions below fit as icons only while there
+      is no overflow button; adding any fourth action brings one in and costs a slot, so one of
+      them moves into the overflow whatever this attribute says. Checked on a 1080 wide emulator:
+      with ifRoom the two that move are Edit and Delete, with never it is Delete alone. Keeping the
+      create action out of the running is what buys Edit its icon back.
+    -->
+    <item
+        android:id="@+id/action_new_transaction_for_person"
+        android:icon="@drawable/ic_add_24dp"
+        android:title="@string/menu_action_new_transaction_for_person"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_show_transaction_list"
+        android:icon="@drawable/ic_receipt_black_24dp"
+        android:title="@string/menu_action_show_transaction_list"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_edit_item"
+        android:icon="@drawable/ic_mode_edit_black_24dp"
+        android:title="@string/menu_action_edit_item"
+        app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_item"
+        android:icon="@drawable/ic_delete_black_24dp"
+        android:title="@string/menu_action_delete_item"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -238,6 +238,7 @@
     <string name="menu_action_save_changes">"Save changes"</string>
     <string name="menu_refresh_currency_rate">"Refresh currency rate"</string>
     <string name="menu_advanced_settings">"Advanced settings"</string>
+    <string name="menu_action_new_transaction_for_person">"New transaction"</string>
     <string name="menu_action_edit_item">"Edit"</string>
     <string name="menu_action_duplicate_item">"Duplicate"</string>
     <string name="menu_action_delete_item">"Delete"</string>


### PR DESCRIPTION
Fixes #80.

The screen for a person could show you their transactions, let you edit them and let you delete them. It could not record money going to or coming from them. Doing that meant leaving the screen, starting a transaction from somewhere else, and picking the person out of a list by hand.

There is now a New transaction action on that screen. It opens the ordinary transaction editor with the person already filled in and everything else left as usual.

It is one action, not the pair of send and receive the request asked for. Whether an entry counts as money in or money out follows from the category you pick, and the picker takes a starting category, not a direction, so offering two actions would mean first building a way to limit that picker to one side. What the request said was missing is the person, and the person is filled in either way.

Adding a fourth action to that screen costs an icon. The three already there only fit as icons while there is no overflow menu, and a fourth brings one in, so one of them moves into the overflow whichever way this is set up. The new action is the one put in the overflow, which leaves Edit where it was and moves only Delete. Checked against a build without the change, where all three are icons.

The person is filled in on a new transaction and nowhere else, on purpose. An existing transaction should not have its people rewritten by something outside it, and the screens for debts and savings fill in people of their own that this would overwrite.

It is reachable on a phone. Tapping a person there goes to their transactions, but holding a person opens the detail screen, which is already the only place in the app that can edit or delete one. The new action sits beside those.

Tested on an Android 16 emulator. Hold a person, tap New transaction, and the editor opens with them already attached. Starting one the ordinary way still opens with nobody attached.
