### PR TITLE
Import a CSV file that starts with a byte order mark

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
@@ -12,11 +12,15 @@ import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.DateUtils;
 
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PushbackReader;
+import java.io.Reader;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
+import java.util.TreeSet;
 
 /**
  * Created by andrea on 23/12/18.
@@ -25,6 +29,9 @@ public class CSVDataImporter extends AbstractDataImporter {
 
     /** The length of yyyy-MM-dd, which the date parse itself does not bound. */
     private static final int SQL_DATE_LENGTH = 10;
+
+    /** What a file saved as Unicode text can carry in front of its first character. */
+    private static final char BYTE_ORDER_MARK = '\uFEFF';
 
     private final File mFile;
 
@@ -35,7 +42,77 @@ public class CSVDataImporter extends AbstractDataImporter {
     public CSVDataImporter(Context context, File file) throws IOException {
         super(context, file);
         mFile = file;
-        mReader = new CSVReaderHeaderAware(new FileReader(file));
+        mReader = openReader();
+    }
+
+    /**
+     * The one place in this class that opens the file. What was reported was not a fault in the
+     * reader on its own, it was a file reaching a reader that had not dropped the byte order mark
+     * the file starts with, and this class opens the file twice. Opening it in one place is what
+     * keeps the second pass from drifting away from the first.
+     */
+    private CSVReaderHeaderAware openReader() throws IOException {
+        Reader reader = openFile(mFile);
+        try {
+            return new CSVReaderHeaderAware(reader);
+        } catch (IOException | RuntimeException failed) {
+            closeQuietly(reader);
+            throw failed;
+        }
+    }
+
+    /**
+     * The file, with any byte order mark it starts with dropped. Some tools write one in front of
+     * the first character of a file they save as UTF-8, and the character has no width, so
+     * anything that decodes the file as UTF-8 shows a header that reads correctly. It is a
+     * character like any other to the reader, so it joins the first header cell: the file names a
+     * column nobody will ever look up, and every row is then refused for having no wallet column.
+     *
+     * More than one can pile up when a file that already carries one goes back through a tool
+     * that adds one, and every one of them has to come off for the same reason the first does.
+     *
+     * The charset is named here so the mark decodes to the same character on a desktop as it does
+     * on a device. Android's default is already UTF-8, so nothing about an import changes. A test
+     * running on a host whose default is something else would otherwise read the mark as
+     * characters of its own and fail for a reason that has nothing to do with the file.
+     *
+     * A file with nothing left after the mark is refused here, with a message a person can read.
+     * The reader this hands the file to asks the header for its length without checking whether
+     * there was a header at all, so a file with nothing in it has always reached the failure
+     * dialog as a null pointer message. Dropping the mark put the file that holds only a mark
+     * into that same case, which is why the check belongs here. It is a check for no characters
+     * and not for no header line: a file holding one line ending and nothing else still reports a
+     * successful import of nothing, exactly as it did before.
+     */
+    /*package-local*/ static Reader openFile(File file) throws IOException {
+        PushbackReader reader = new PushbackReader(
+                new InputStreamReader(new FileInputStream(file), "UTF-8"));
+        try {
+            int first = reader.read();
+            while (first == BYTE_ORDER_MARK) {
+                first = reader.read();
+            }
+            if (first == -1) {
+                throw new RuntimeException("the file has no header line in it");
+            }
+            reader.unread(first);
+            return reader;
+        } catch (IOException | RuntimeException failed) {
+            closeQuietly(reader);
+            throw failed;
+        }
+    }
+
+    /**
+     * Closes a reader that is being abandoned. A failure closing it would otherwise replace the
+     * failure that made it worth abandoning, which is the one the person needs to read.
+     */
+    private static void closeQuietly(Reader reader) {
+        try {
+            reader.close();
+        } catch (IOException closing) {
+            // nothing useful to do with it, and it is not the failure being reported
+        }
     }
 
     /**
@@ -47,7 +124,7 @@ public class CSVDataImporter extends AbstractDataImporter {
      */
     @Override
     public void importData() throws IOException {
-        try (CSVReaderHeaderAware check = new CSVReaderHeaderAware(new FileReader(mFile))) {
+        try (CSVReaderHeaderAware check = openReader()) {
             readRows(check, false);
         }
         readRows(mReader, true);
@@ -149,11 +226,24 @@ public class CSVDataImporter extends AbstractDataImporter {
     /**
      * The value of a column every row needs. A column the header does not have and a cell left
      * empty are mistakes in different places, so they do not get the same message.
+     *
+     * The refusal lists the columns the row was read into, because the header a person is looking
+     * at and the columns the reader built out of it are not always the same thing. A file
+     * separated by semicolons reads as one column named after the whole line, and without the
+     * list there is nothing on screen a person could use to see that.
+     *
+     * Sorted, and the message says so. The reader keeps these in a hash table, so their own order
+     * has nothing to do with the file, and a list that looks like an order invites a person to
+     * compare it against their header and conclude the app moved their columns around. Sorted by
+     * character and not by any language's alphabet, which is why the message does not call it
+     * alphabetical: a capital letter sorts before every lowercase one, and an accented letter
+     * sorts after all of them.
      */
     /*package-local*/ static String required(Map<String, String> lineMap, String column) {
         String value = lineMap.get(column);
         if (value == null) {
-            throw new RuntimeException("no " + column + " column was found. Check the header line");
+            throw new RuntimeException("no " + column + " column was found. The columns read out "
+                    + "of the header line, sorted, are " + new TreeSet<>(lineMap.keySet()));
         }
         value = value.trim();
         if (value.isEmpty()) {

--- a/app/src/test/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporterTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporterTest.java
@@ -1,9 +1,15 @@
 package com.oriondev.moneywallet.storage.database.data.csv;
 
+import com.opencsv.CSVReaderHeaderAware;
 import com.oriondev.moneywallet.utils.DateUtils;
 
 import org.junit.Test;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -14,9 +20,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
- * The importer's row reading talks to a content resolver and to an Android static, so it cannot be
- * driven from a JVM test. The two pieces that need neither are here. What is not covered, and was
- * checked on an emulator instead: the line number the refusals are prefixed with.
+ * Saving a row talks to a content resolver, and reading a currency out of a row talks to a static
+ * the app sets up at startup, so neither can be driven from a JVM test. What is here reaches
+ * neither, including a refusal that fires before the currency is read, which is enough to drive a
+ * real import as far as its first row.
+ *
+ * What is not covered: saving a row, anything past the currency lookup in a row that is otherwise
+ * good, and therefore the reader the saving pass uses, which is the one the constructor opens.
  */
 public class CSVDataImporterTest {
 
@@ -86,15 +96,148 @@ public class CSVDataImporterTest {
         refuses("926-08-12");
     }
 
+    /**
+     * The sorted list in the expected message is load bearing, not decoration. A hash table hands
+     * these two back as wallet then currency, so an assertion written the other way around goes
+     * red the moment the sort is taken out of the refusal.
+     */
     @Test
     public void aMissingColumnAndAnEmptyCellAreDifferentMessages() {
         Map<String, String> row = new HashMap<>();
         row.put("wallet", "Probe");
         row.put("currency", "  ");
         assertEquals("Probe", CSVDataImporter.required(row, "wallet"));
-        assertEquals("no money column was found. Check the header line",
+        assertEquals("no money column was found. The columns read out of the header line, sorted, are [currency, wallet]",
                 messageFrom(row, "money"));
         assertEquals("the currency is empty, and every row needs one", messageFrom(row, "currency"));
+    }
+
+    /**
+     * The whole point of listing the columns: the person reading the message is looking at a
+     * header that says wallet, and this is the only thing that tells them what the reader made
+     * of it. A semicolon separated file is the case that reaches this, and the map it builds
+     * carries one key holding the whole header line.
+     */
+    @Test
+    public void aMissingColumnSaysWhatTheColumnsWereReadAs() {
+        Map<String, String> row = new HashMap<>();
+        row.put("wallet\";\"currency\";\"category", "Probe");
+        assertEquals("no wallet column was found. The columns read out of the header line, sorted, are [wallet\";\"currency\";\"category]",
+                messageFrom(row, "wallet"));
+    }
+
+    /**
+     * A file that opens with a byte order mark. Leave the mark in place and it joins the first
+     * header cell, so the wallet column is named something no lookup will ever ask for and every
+     * row is refused. It reads the header through the same reader the importer opens the file
+     * with, because that reader is the piece under test here. Driving a whole import over the
+     * same file is a separate test below.
+     */
+    @Test
+    public void aByteOrderMarkDoesNotHideTheFirstColumn() throws IOException {
+        File file = write("\uFEFF\"wallet\",\"currency\"\n\"Probe\",\"EUR\"\n");
+        try (CSVReaderHeaderAware reader = new CSVReaderHeaderAware(CSVDataImporter.openFile(file))) {
+            assertEquals("Probe", reader.readMap().get("wallet"));
+        }
+    }
+
+    /**
+     * The opposite mutation from the test above, and it catches a different one: this file has no
+     * mark, so leaving the mark in place leaves this test green. It goes red when the first
+     * character is dropped whether or not it is a mark, which would cost every header without one
+     * its first character.
+     */
+    @Test
+    public void aFileWithoutOneKeepsItsFirstCharacter() throws IOException {
+        File file = write("\"wallet\",\"currency\"\n\"Probe\",\"EUR\"\n");
+        try (CSVReaderHeaderAware reader = new CSVReaderHeaderAware(CSVDataImporter.openFile(file))) {
+            assertEquals("Probe", reader.readMap().get("wallet"));
+        }
+    }
+
+    /**
+     * A file that opens with two marks. One tool adding a mark to a file another tool already
+     * marked leaves both, and stopping after the first leaves the second one joined to the wallet
+     * column, so every row is refused for having no wallet column and nothing on screen shows why.
+     */
+    @Test
+    public void everyMarkAtTheFrontComesOff() throws IOException {
+        File file = write("\uFEFF\uFEFF\"wallet\",\"currency\"\n\"Probe\",\"EUR\"\n");
+        try (CSVReaderHeaderAware reader = new CSVReaderHeaderAware(CSVDataImporter.openFile(file))) {
+            assertEquals("Probe", reader.readMap().get("wallet"));
+        }
+    }
+
+    /**
+     * The one test that drives a real import, and the only one that goes red with the checking
+     * pass changed to open the file directly. Every other test here stays green while a marked
+     * file is refused again.
+     *
+     * It reaches the checking pass and no further, so the reader the constructor opens for the
+     * saving pass is not covered by anything. Changing that one line to open the file directly
+     * leaves every test here green, and a marked file then passes the check and fails on the save.
+     * Covering it needs a content resolver, which is what none of this can reach.
+     *
+     * The row leaves its wallet cell empty, so the refusal fires on the empty cell before the
+     * currency is looked up, and nothing an app startup would have set up is ever reached. That
+     * refusal can only fire if the wallet column was found, which is the whole point: with the
+     * mark still on the file the message is about a wallet column that was never found instead.
+     *
+     * The context is null because nothing between here and the refusal reads it. Only saving a
+     * row does, and no row is ever saved: the import reads the file once to refuse a bad one
+     * before saving anything, and this file is refused on that pass.
+     */
+    @Test
+    public void anImportOpensTheFileThroughOpenFile() throws IOException {
+        File file = write("\uFEFF\"wallet\",\"currency\",\"category\",\"datetime\",\"money\"\n"
+                + "\"\",\"EUR\",\"Food\",\"2026-08-12 09:00:00\",\"1.00\"\n");
+        CSVDataImporter importer = new CSVDataImporter(null, file);
+        try {
+            importer.importData();
+            fail("a row with an empty wallet cell has to be refused");
+        } catch (RuntimeException expected) {
+            assertEquals("Line 2: the wallet is empty, and every row needs one",
+                    expected.getMessage());
+        } finally {
+            importer.close();
+        }
+    }
+
+    /**
+     * A file holding a mark and nothing else, and a file holding nothing at all. Neither has
+     * anything the reader can take a header from, and the reader asks the header for its length
+     * without checking that there was one. The empty file has always reached the failure dialog
+     * as a null pointer message. The mark only file reported a successful import of nothing until
+     * the mark started being dropped, which put it in the same case as the empty one.
+     *
+     * Both hold no characters at all once the mark is gone, which is what the refusal checks for.
+     * A file holding a line ending and nothing else is not covered and still reports a successful
+     * import of nothing.
+     */
+    @Test
+    public void aFileWithNoCharactersInItIsRefusedInWordsAPersonCanRead() throws IOException {
+        assertEquals("the file has no header line in it", refusedContents("\uFEFF"));
+        assertEquals("the file has no header line in it", refusedContents(""));
+    }
+
+    private static File write(String contents) throws IOException {
+        File file = File.createTempFile("tallybook-import", ".csv");
+        file.deleteOnExit();
+        try (Writer writer = new OutputStreamWriter(new FileOutputStream(file), "UTF-8")) {
+            writer.write(contents);
+        }
+        return file;
+    }
+
+    private static String refusedContents(String contents) throws IOException {
+        File file = write(contents);
+        try {
+            CSVDataImporter.openFile(file).close();
+            fail("a file with no header line has to be refused");
+            return null;
+        } catch (RuntimeException expected) {
+            return expected.getMessage();
+        }
     }
 
     private static String messageFrom(Map<String, String> row, String column) {


### PR DESCRIPTION
A CSV file that starts with a byte order mark would not import. The mark has no width, so the header looks correct on screen while the app says the file has no wallet column. Those files import now.

An empty file used to fail with an internal error message, and a file holding only the mark reported a successful import of nothing. Both are refused in plain words. A refusal for a missing column now lists the columns that were read out of the header line.
