### PR TITLE
Bump to 1.5.0, versionCode 83

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
         applicationId "io.github.herrerad85.tallybook"
         minSdk 24
         targetSdk 35
-        versionCode 82
-        versionName "1.4.0"
+        versionCode 83
+        versionName "1.5.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         multiDexEnabled true

--- a/fastlane/metadata/android/en-US/changelogs/83.txt
+++ b/fastlane/metadata/android/en-US/changelogs/83.txt
@@ -1,0 +1,3 @@
+New: start a transaction from a person's screen with that person already attached.
+
+Fixes: Android's own backup stored nothing, so a restore brought back an empty app. An income or expense color that would vanish into the page is drawn readable instead. Automatic backup says when a failure turned it off. A debt's master transaction takes the debt's date, not the day it was typed. A saving refuses a withdraw larger than it holds. CSV import reads a file that starts with a byte order mark.


### PR DESCRIPTION
Bumps the version for the next release and adds its changelog entry.

Fourteen commits since the last tag. The changelog names the six things a person using the app would notice, and the one new thing.

The unsigned release build was made twice from clean and came out byte identical both times. It reads back as version 1.5.0 and carries no build stamp that would break a reproducible build.
