### PR TITLE
Keep the calendar on the day you picked

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
@@ -66,6 +66,10 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
     private static final String ARG_SELECTED_MONTH = "CalendarMultiPanelFragment::Arguments::Month";
     private static final String ARG_SELECTED_DAY = "CalendarMultiPanelFragment::Arguments::Day";
 
+    private static final String STATE_SELECTED_YEAR = "CalendarMultiPanelFragment::State::Year";
+    private static final String STATE_SELECTED_MONTH = "CalendarMultiPanelFragment::State::Month";
+    private static final String STATE_SELECTED_DAY = "CalendarMultiPanelFragment::State::Day";
+
     private static final int DEFAULT_LOADER_ID = 4834;
 
     private BroadcastReceiver mCurrentWalletObserver;
@@ -95,19 +99,42 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
         mAdvancedRecyclerView = view.findViewById(R.id.advanced_recycler_view);
         mTimelineView.setFirstDate(1900, Calendar.JANUARY, 1);
         mTimelineView.setLastDate(2100, Calendar.DECEMBER, 31);
-        mTimelineView.setOnDateSelectedListener(this);
         mAbstractCursorAdapter = new TransactionCursorAdapter(this);
         mAdvancedRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
         mAdvancedRecyclerView.setEmptyText(R.string.message_no_transaction_found);
         mAdvancedRecyclerView.setAdapter(mAbstractCursorAdapter);
         mAdvancedRecyclerView.setOnRefreshListener(this);
-        mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
         Calendar calendar = Calendar.getInstance();
-        mTimelineView.setSelectedDate(
-                calendar.get(Calendar.YEAR),
-                calendar.get(Calendar.MONTH),
-                calendar.get(Calendar.DAY_OF_MONTH)
-        );
+        int year = calendar.get(Calendar.YEAR);
+        int month = calendar.get(Calendar.MONTH);
+        int day = calendar.get(Calendar.DAY_OF_MONTH);
+        if (savedInstanceState != null && savedInstanceState.containsKey(STATE_SELECTED_YEAR)) {
+            year = savedInstanceState.getInt(STATE_SELECTED_YEAR);
+            month = savedInstanceState.getInt(STATE_SELECTED_MONTH);
+            day = savedInstanceState.getInt(STATE_SELECTED_DAY);
+        }
+        // The listener is attached after the first selection, and the first load is made here,
+        // because the strip reports nothing when the day selected is the one it already holds.
+        // After setFirstDate above that day is 1 January 1900, which a restored date can equal.
+        mTimelineView.setSelectedDate(year, month, day);
+        mTimelineView.setOnDateSelectedListener(this);
+        onDateSelected(year, month, day, mTimelineView.getSelectedPosition());
+    }
+
+    /**
+     * The day is saved as a date and not as the strip position that also identifies it. A position
+     * is a running day count the strip adjusts by a difference on every selection, and that count
+     * can drift from the date it is meant to name, so restoring one can load a day the user never
+     * picked. The date cannot drift.
+     */
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        if (mTimelineView != null) {
+            outState.putInt(STATE_SELECTED_YEAR, mTimelineView.getSelectedYear());
+            outState.putInt(STATE_SELECTED_MONTH, mTimelineView.getSelectedMonth());
+            outState.putInt(STATE_SELECTED_DAY, mTimelineView.getSelectedDay());
+        }
     }
 
     @Override
@@ -180,7 +207,6 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
                 arguments = new String[] {String.valueOf(currentWallet)};
             }
             selection += " AND DATE(" + Contract.Transaction.DATE + ") == DATE('" + DateUtils.getSQLDateString(date) + "')";
-            System.out.println(selection);
             String sortOrder = Contract.Transaction.DATE + " DESC";
             return new CursorLoader(activity, uri, null, selection, arguments, sortOrder);
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
@@ -20,6 +20,7 @@
 package com.oriondev.moneywallet.ui.view.calendar;
 
 import android.content.Context;
+import android.graphics.Typeface;
 import android.os.Build;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -405,8 +406,12 @@ public class TimelineView extends RecyclerView {
             this.day = day;
             lblDay.setText(dayLabel(dayOfWeek));
             lblDate.setText(String.valueOf(day));
+            // The line below has never run here and neither drawable it names is in this project,
+            // so the accent color is the only mark on a cell and it marks today and the shown day
+            // alike. Weight is what separates them: the shown day is the bold one.
             // lblDate.setBackgroundResource(selected ? R.drawable.mti_bg_lbl_date_selected : (isToday ? R.drawable.mti_bg_lbl_date_today : 0));
             lblDate.setTextColor(selected || isToday ? lblDateSelectedColor : lblDateColor);
+            lblDate.setTypeface(null, selected ? Typeface.BOLD : Typeface.NORMAL);
         }
     }
 }


### PR DESCRIPTION
The calendar behind the icon on the Transactions tab shows one day at a time, and it forgot which day you were on. Rotating the phone, or changing the font size in the phone's own settings, sent it back to today. If you had walked back to a day in March to check something, the phone turning in your hand lost it and you started again.

It now keeps the day you picked, and a fresh open still starts on today.

Two smaller things on the same screen came out of looking at it.

The day you are viewing and today were painted in the same color. The only thing telling them apart was that picking a day slides it to the middle of the strip, and that clue is gone the moment you drag the strip by hand. The day you are viewing is now bold.

The screen also printed its database query to the log every time you changed day. That is gone.

I tested this on an emulator with transactions on seven dates. Picking a day and rotating twice keeps that day, where the old build fell back to today each time. A first launch still opens on today. I also checked the awkward corner where the day picked is the earliest one the screen allows, since that is the one case where restoring it could have left the screen loading forever, and it loads.

None of this changes which transactions the screen finds for a day. It only changes which day it is looking at after the screen is rebuilt, and how the two marked days are told apart.
