### PR TITLE
Mirror the text fields in a right to left language

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/text/MaterialEditText.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/text/MaterialEditText.java
@@ -283,7 +283,9 @@ public class MaterialEditText extends androidx.appcompat.widget.AppCompatEditTex
         }
         int lineHeight = hasFocus() ? mFocusedBottomLineSize : mDefaultBottomLineSize;
         int top = getMeasuredHeight() - getPaddingBottom() + getPixels(BOTTOM_LINE_PADDING_DP) - lineHeight;
-        int left = getPaddingLeft() + getScrollX() + (mShowCancelButton && isRtl() ? getPixels(CANCEL_BUTTON_PADDING_DP) : 0);
+        // the cancel button reserves CANCEL_BUTTON_PADDING_DP inside the padding on the side it is
+        // drawn, and the line reaches back over that to keep the width it has with no button shown
+        int left = getPaddingLeft() + getScrollX() - (mShowCancelButton && isRtl() ? getPixels(CANCEL_BUTTON_PADDING_DP) : 0);
         int right = getScrollX() + getMeasuredWidth() - getPaddingRight() + (mShowCancelButton  && !isRtl()? getPixels(CANCEL_BUTTON_PADDING_DP) : 0);
         canvas.drawRect(
                 left,

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/text/Utils.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/text/Utils.java
@@ -20,7 +20,6 @@
 package com.oriondev.moneywallet.ui.view.text;
 
 import android.content.Context;
-import android.content.res.Configuration;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
@@ -40,7 +39,7 @@ import android.view.View;
     }
 
     /*package-local*/ static boolean isRtl(Resources resources) {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && resources.getConfiguration().getLayoutDirection() == Configuration.SCREENLAYOUT_LAYOUTDIR_RTL;
+        return resources.getConfiguration().getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
     }
 
     /*package-local*/ static void setBackgroundCompat(@NonNull View view, Drawable drawable) {

--- a/app/src/test/java/com/oriondev/moneywallet/ui/view/text/MaterialEditTextSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/view/text/MaterialEditTextSourceTest.java
@@ -1,0 +1,83 @@
+package com.oriondev.moneywallet.ui.view.text;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * The line this pins is drawn inside onDraw on a real Canvas, so a JVM unit test cannot observe it:
+ * there is no Robolectric on the unit test classpath. The invariant is pinned by reading the source
+ * instead, the same way CategoryChildIndicatorSourceTest does.
+ *
+ * What it asserts is that the two statements setting the underline's edges still read as they read
+ * now. The pair looks like a typo: one adds the slot the cancel button reserves and the other takes
+ * it away. Both are correct, because each reaches outward from its own side, and making them agree
+ * puts the button outside the line it is meant to sit on, whichever way they are made to agree.
+ * Nothing on the JVM catches that, because the value is only ever compared against pixels on a
+ * device.
+ *
+ * Comments are stripped before anything is matched, so neither assertion can be satisfied by the
+ * wording of a comment describing code that is gone. String literals are not stripped; the only ones
+ * in the file under test are empty, and if one is ever added that carries either statement below,
+ * the literal half has to be stripped here at the same time.
+ *
+ * The assertions pin exact spellings, so a rewrite that behaves identically can still fail here, and
+ * a rewrite that keeps both statements and stops drawing with them goes through. A failure means
+ * read the source and decide, not that the view is broken.
+ */
+public class MaterialEditTextSourceTest {
+
+    private static final Pattern COMMENTS = Pattern.compile("//.*?$|/[*].*?[*]/", Pattern.DOTALL | Pattern.MULTILINE);
+
+    private String readSource() {
+        String path = "src/main/java/com/oriondev/moneywallet/ui/view/text/MaterialEditText.java";
+        File file = new File(path);
+        if (!file.exists()) {
+            // a runner rooted at the repo root instead of the module, which the precedent
+            // handles the same way
+            file = new File("app/" + path);
+        }
+        if (!file.exists()) {
+            fail("Cannot find MaterialEditText.java at " + file.getAbsolutePath());
+        }
+        try {
+            String source = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            return COMMENTS.matcher(source).replaceAll(" ");
+        } catch (IOException e) {
+            fail("Cannot read MaterialEditText.java: " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Test
+    public void theBottomLineReachesBackOverTheCancelButtonOnBothSides() {
+        String source = readSource();
+        int onDrawBottomLine = source.indexOf("protected void onDrawBottomLine(");
+        assertTrue("the file no longer carries the literal protected void onDrawBottomLine(. The method "
+                + "is gone, or its header was respelled", onDrawBottomLine >= 0);
+        int end = source.indexOf("protected void onDrawCancelButton(", onDrawBottomLine);
+        assertTrue("the literal protected void onDrawCancelButton( no longer appears after that header, so "
+                + "this reader cannot tell where the method it is reading ends. The method is gone or moved, or "
+                + "its own header was respelled", end > onDrawBottomLine);
+        String body = source.substring(onDrawBottomLine, end);
+        assertTrue("the left edge no longer reads exactly int left = getPaddingLeft() + getScrollX() "
+                        + "- (mShowCancelButton && isRtl() ? getPixels(CANCEL_BUTTON_PADDING_DP) : 0); If it adds "
+                        + "the slot instead of subtracting it, the line starts inside the field in a right to left "
+                        + "layout and the cancel button ends up outside it. Read the source and decide",
+                body.contains("int left = getPaddingLeft() + getScrollX() "
+                        + "- (mShowCancelButton && isRtl() ? getPixels(CANCEL_BUTTON_PADDING_DP) : 0);"));
+        assertTrue("the right edge no longer reads exactly int right = getScrollX() + getMeasuredWidth() "
+                        + "- getPaddingRight() + (mShowCancelButton  && !isRtl()? getPixels(CANCEL_BUTTON_PADDING_DP) "
+                        + ": 0); If it subtracts the slot instead of adding it, the line ends inside the field in a "
+                        + "left to right layout and the cancel button ends up outside it. Read the source and decide",
+                body.contains("int right = getScrollX() + getMeasuredWidth() - getPaddingRight() "
+                        + "+ (mShowCancelButton  && !isRtl()? getPixels(CANCEL_BUTTON_PADDING_DP) : 0);"));
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/view/text/UtilsTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/view/text/UtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.view.text;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.view.View;
+
+import org.junit.Test;
+
+/**
+ * Regression coverage for issue #174. {@link Utils#isRtl} used to compare the value returned by
+ * Configuration.getLayoutDirection, which is 0 or 1, against Configuration.SCREENLAYOUT_LAYOUTDIR_RTL,
+ * which is the value 128 of a mask over the screenLayout field. Those can never be equal, so every
+ * right to left branch in MaterialEditText and MaterialTextView was unreachable and nothing either
+ * view draws itself has ever mirrored. The right to left case below fails on the old comparison.
+ */
+public class UtilsTest {
+
+    private Resources resourcesWithLayoutDirection(int layoutDirection) {
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.getLayoutDirection()).thenReturn(layoutDirection);
+        Resources resources = mock(Resources.class);
+        when(resources.getConfiguration()).thenReturn(configuration);
+        return resources;
+    }
+
+    @Test
+    public void rightToLeftConfigurationIsRightToLeft() {
+        assertTrue(Utils.isRtl(resourcesWithLayoutDirection(View.LAYOUT_DIRECTION_RTL)));
+    }
+
+    @Test
+    public void leftToRightConfigurationIsNotRightToLeft() {
+        assertFalse(Utils.isRtl(resourcesWithLayoutDirection(View.LAYOUT_DIRECTION_LTR)));
+    }
+}


### PR DESCRIPTION
Set the app to a right to left language like Persian and most fields on an editor screen come out half mirrored. The value you typed moves to the right, which is correct, but the icon beside the field, the label floating above it and the red error under it all stay on the left, so a label and the thing it labels end up on opposite sides. On a field with a clear button, the button stays on the right as well.

The app has always carried code to mirror all of that and none of it has ever run. The check that asks whether the layout is right to left compares two numbers that can never be equal, so it always answers no. This is a one line fix to that check, and it turns the mirroring on.

It reaches most of the screens where you enter or read back a saved item: new transaction and transfer, the recurring and model versions of both, categories, wallets, currencies, debts, savings, budgets, events, people, places, the import and export screens, the automatic backup dialog on the backup screen, and the panels that show a saved item. In a left to right language nothing moves.

Turning the mirrored paths on found one that had never been right. On a field with a clear button the underline runs a little wider than the text so it passes under the button, and the right to left version pulled it in instead. That would have started the line well inside the field with the button off the end of it, and it is fixed here too.

Expect this to surface layout problems as well as remove them, since none of these paths has ever been seen.

I tested it on an emulator in Persian against a build of master, comparing where each piece lands, and again in English to confirm nothing moved there. Two test files come with it: one fails on the old check, and one guards the underline against being flipped back.
