### PR TITLE
fix: check a saving withdraw against what the goal will hold, not just today

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -1679,6 +1679,60 @@ public class SQLDatabaseTest {
         checkSavingId(id3, "desc-2-edited", "encoded-icon-edited", 50L, 73000L, id1, null, false, "note-2-edited", "tag-2-edited");
     }
 
+    /**
+     * A saving's progress counts only the rows that have landed, which is what the savings list
+     * adds to its start money to show. Its projected progress counts every withdrawal it has and
+     * only the deposits that are confirmed, whatever their dates. An unconfirmed deposit is in
+     * neither, because landing takes being confirmed and it never does.
+     *
+     * The saving here carries a deposit and a withdrawal of each kind the two rules can tell
+     * apart, which separates the two sums from the rules they are most likely to be rewritten
+     * into: counting the unconfirmed deposit, dropping the unconfirmed withdrawal, putting a date
+     * test on the projected rule, on either half of it or on the whole, narrowing the landed test
+     * to deposits, dropping either half of it, or copying one sum onto the other all give
+     * something else. It is those cases and not every rule that could be written: a rewrite that
+     * lands on the same two figures for this saving goes through.
+     *
+     * This pins the two sums apart. It says nothing about the ceilings the editor works out of
+     * them, and neither sum carries any date order, so it is not a check that the saving stays
+     * above zero at every moment in between.
+     */
+    @Test
+    public void savingProjectedProgressCountsRowsTheProgressLeavesOut() throws Exception {
+        long wallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 0L, false, "tag-wallet-1");
+        long saving = insertSaving("desc-1", "encoded-icon", 0L, 10000L, wallet, null, false, "note-1", "tag-1");
+        long deposit = getSystemCategory(Contract.CategoryTag.SAVING_DEPOSIT);
+        long withdraw = getSystemCategory(Contract.CategoryTag.SAVING_WITHDRAW);
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.MONTH, 1);
+        Date nextMonth = calendar.getTime();
+        // Landed, so both sums count them: a confirmed deposit of 1000 and a confirmed
+        // withdrawal of 100, both dated now. The withdrawal is the only row either sum counts
+        // negatively while it is landed, so without it the progress cannot tell a rule that
+        // counts every landed row from one that counts only landed deposits.
+        insertTransaction(1000, new Date(), null, deposit, Contract.Direction.EXPENSE, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, true, true, null, null, "tag");
+        insertTransaction(100, new Date(), null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, true, true, null, null, "tag");
+        // Only the projected sum: a confirmed deposit of 400 dated next month, the row that
+        // stops a date test on the projected rule reading the same as the rule itself.
+        insertTransaction(400, nextMonth, null, deposit, Contract.Direction.EXPENSE, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, true, true, null, null, "tag");
+        // Only the projected sum again: a confirmed withdrawal of 300 dated next month, an
+        // unconfirmed withdrawal of 200 dated now, and an unconfirmed withdrawal of 50 dated next
+        // month. The last one is the drain the projected sum is most pessimistic about, and it is
+        // the only row that separates the rule from one that counts withdrawals only once they
+        // have landed.
+        insertTransaction(300, nextMonth, null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, true, true, null, null, "tag");
+        insertTransaction(200, new Date(), null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, false, true, null, null, "tag");
+        insertTransaction(50, nextMonth, null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, false, true, null, null, "tag");
+        // In neither: an unconfirmed deposit of 500, which never lands.
+        insertTransaction(500, new Date(), null, deposit, Contract.Direction.EXPENSE, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, false, true, null, null, "tag");
+
+        Cursor cursor = mDatabase.getSavings(null, null, null, null);
+        assertEquals(true, cursor.moveToFirst());
+        assertEquals(900L, cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS)));
+        assertEquals(750L, cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROJECTED_PROGRESS)));
+        cursor.close();
+    }
+
     @Test
     public void deleteSaving() throws Exception {
         long id1 = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
@@ -245,6 +245,7 @@ public class Contract {
         public static final String COMPLETE = Schema.Saving.COMPLETE;
         public static final String NOTE = Schema.Saving.NOTE;
         public static final String PROGRESS = "saving_" + Schema.Alias.PROGRESS;
+        public static final String PROJECTED_PROGRESS = "saving_" + Schema.Alias.PROJECTED_PROGRESS;
         public static final String TAG = Schema.Saving.TAG;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -2975,6 +2975,42 @@ import java.util.UUID;
      * @return a cursor with zero or more rows.
      */
     /*package-local*/ Cursor getSavings(String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        // A saving carries two sums over the same set of rows, its deposits and its withdrawals.
+        // Its progress counts only the confirmed ones dated at or before this moment, so with the
+        // start money added it is what the saving holds now, and it is the sum the savings list
+        // draws its current amount from. A row dated later today is not one of them.
+        //
+        // Its projected progress counts every withdrawal the saving has and every deposit that is
+        // confirmed, whatever their dates. With the start money added it is the lowest the saving
+        // can end up at once everything already on it has happened. Each side of that rule is the
+        // pessimistic one. An unconfirmed deposit is left out because it never lands, since
+        // landing takes being confirmed, so counting it would let money that has not arrived pay
+        // for a withdrawal that does. An unconfirmed withdrawal is counted for the mirror reason,
+        // and not because it is any likelier to happen: leaving it out would hand out a ceiling
+        // it can then take the saving under.
+        //
+        // Both are built from the one signedMoney expression below, so the two can never disagree
+        // about the sign of a row.
+        //
+        // Neither is a balance at a date in between, and the saving is not bounded between the
+        // two either. Both are totals with no date order in them, so a saving carrying rows on
+        // both sides can dip under zero on a date where neither sum says so: a withdrawal dated
+        // tomorrow against a deposit dated next month leaves both sums at zero and the saving
+        // under from tomorrow.
+        //
+        // The confirmed and date test used to sit in the WHERE and now sits in the CASE, so a
+        // saving with rows but none of them in the progress produces a group row where it
+        // produced none, and its progress reads 0 where it read NULL. That is any saving whose
+        // rows are all unconfirmed, all dated later, or a mix of the two. Every reader goes
+        // through getLong, which returns 0 for either, and nothing compares the column in SQL, so
+        // the two are indistinguishable today. Anything added later that can tell them apart has
+        // to account for the change.
+        String signedMoney = "(((" + Schema.Transaction.DIRECTION + " * -2) + 1) * " +
+                Schema.Transaction.MONEY + ")";
+        String landed = Schema.Transaction.CONFIRMED + " = 1 AND DATETIME(" +
+                Schema.Transaction.DATE + ") <= DATETIME('now', 'localtime')";
+        String counted = Schema.Transaction.DIRECTION + " = " + Schema.Direction.INCOME +
+                " OR " + Schema.Transaction.CONFIRMED + " = 1";
         String subQuery = "SELECT " +
                 Schema.Saving.ID + " AS " + Contract.Saving.ID + ", " +
                 Schema.Saving.DESCRIPTION + " AS " + Contract.Saving.DESCRIPTION + ", " +
@@ -2992,16 +3028,18 @@ import java.util.UUID;
                 Schema.Saving.COMPLETE + " AS " + Contract.Saving.COMPLETE + ", " +
                 Schema.Saving.NOTE + " AS " + Contract.Saving.NOTE + ", " +
                 Schema.Saving.TAG + " AS " + Contract.Saving.TAG + ", " +
-                "_progress AS " + Contract.Saving.PROGRESS + " FROM " + Schema.Saving.TABLE +
+                "_progress AS " + Contract.Saving.PROGRESS + ", " +
+                "_projected_progress AS " + Contract.Saving.PROJECTED_PROGRESS +
+                " FROM " + Schema.Saving.TABLE +
                 " AS s LEFT JOIN " + Schema.Wallet.TABLE + " ON " + Schema.Saving.WALLET + " = " +
                 Schema.Wallet.ID + " LEFT JOIN (SELECT " + Schema.Transaction.SAVING + " AS _saving, " +
-                " SUM(((" + Schema.Transaction.DIRECTION + " * -2) + 1) * " + Schema.Transaction.MONEY +
-                ") AS _progress FROM " + Schema.Transaction.TABLE + " AS j LEFT JOIN " + Schema.Category.TABLE +
+                " SUM(CASE WHEN " + landed + " THEN " + signedMoney + " ELSE 0 END) AS _progress, " +
+                " SUM(CASE WHEN " + counted + " THEN " + signedMoney + " ELSE 0 END) AS _projected_progress" +
+                " FROM " + Schema.Transaction.TABLE + " AS j LEFT JOIN " + Schema.Category.TABLE +
                 " ON " + Schema.Transaction.CATEGORY + " = " + Schema.Category.ID + " WHERE j." +
-                Schema.Transaction.DELETED + " = 0 AND " + Schema.Transaction.CONFIRMED +
-                " = 1 AND (" + Schema.Category.TAG + " = '" + Schema.CategoryTag.SAVING_DEPOSIT + "' OR " +
-                Schema.Category.TAG + " = '" + Schema.CategoryTag.SAVING_WITHDRAW + "') AND DATETIME(" +
-                Schema.Transaction.DATE + ") <= DATETIME('now', 'localtime') GROUP BY _saving) ON " +
+                Schema.Transaction.DELETED + " = 0 AND (" + Schema.Category.TAG + " = '" +
+                Schema.CategoryTag.SAVING_DEPOSIT + "' OR " + Schema.Category.TAG + " = '" +
+                Schema.CategoryTag.SAVING_WITHDRAW + "') GROUP BY _saving) ON " +
                 Schema.Saving.ID + " = _saving WHERE s." + Schema.Saving.DELETED + " = 0";
         return queryFrom(subQuery, projection, selection, selectionArgs, sortOrder);
     }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Schema.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Schema.java
@@ -40,6 +40,7 @@ package com.oriondev.moneywallet.storage.database;
     /*package-local*/ static final class Alias {
         /*package-local*/ static final String TOTAL_MONEY = "total_money";
         /*package-local*/ static final String PROGRESS = "progress";
+        /*package-local*/ static final String PROJECTED_PROGRESS = "projected_progress";
         /*package-local*/ static final String CATEGORY_GROUP_ID = "category_group_id";
         /*package-local*/ static final String CATEGORY_GROUP_NAME = "category_group_name";
         /*package-local*/ static final String CATEGORY_GROUP_INDEX = "category_group_index";

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -124,6 +124,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private static final String SS_SAVING_ID = "NewEditTransactionActivity::SavedState::SavingId";
     private static final String SS_SAVING_COMPLETED = "NewEditTransactionActivity::SavedState::SavingCompleted";
     private static final String SS_SAVING_WITHDRAW_LIMIT = "NewEditTransactionActivity::SavedState::SavingWithdrawLimit";
+    private static final String SS_SAVING_WITHDRAW_LANDED_LIMIT = "NewEditTransactionActivity::SavedState::SavingWithdrawLandedLimit";
     private static final String SS_SAVING_WITHDRAW_CURRENCY = "NewEditTransactionActivity::SavedState::SavingWithdrawCurrency";
 
     private TextView mCurrencyTextView;
@@ -155,6 +156,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private Long mSavingId = null;
     private boolean mSavingCompleted = false;
     private Long mSavingWithdrawLimit = null;
+    private Long mSavingWithdrawLandedLimit = null;
     private String mSavingWithdrawCurrency = null;
 
     private MoneyFormatter mMoneyFormatter = MoneyFormatter.getInstance();
@@ -462,19 +464,21 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                         mCountInTotalCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.COUNT_IN_TOTAL)) == 1);
                         // A withdraw already in the database is being opened. Without a limit
                         // here it can simply be edited upwards, which is the same bug by another
-                        // route. What it can grow to is what the saving holds plus what this row
-                        // is already taking out, because the saving's progress counts this row.
+                        // route. What it can grow to comes from the same two ceilings a new one
+                        // gets, each with this row's own amount added back to it, and each only
+                        // if that sum already counts this row.
                         //
-                        // It only counts it while the row is confirmed and not dated ahead, which
-                        // is the same pair getSavings filters on, so the amount is added back only
-                        // when the stored row is one of those. Adding it back for a row the
-                        // progress never counted would hand out a ceiling too high by exactly that
-                        // amount.
+                        // The projected sum counts it whatever its confirmed box and its date
+                        // say. The progress counts it only while it is confirmed and not dated
+                        // ahead, which is the same pair getSavings filters on, so adding it back
+                        // there for a row the progress never counted would hand out a ceiling too
+                        // high by exactly that amount.
                         if (mSavingId != null && category != null
                                 && Contract.CategoryTag.SAVING_WITHDRAW.equals(category.getTag())) {
-                            boolean storedRowCounts = cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) == 1
+                            boolean storedRowHasLanded = cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) == 1
                                     && !DateUtils.getDateFromSQLDateTimeString(cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE))).after(new Date());
-                            loadSavingWithdrawLimit(contentResolver, mSavingId, storedRowCounts ? money : 0L);
+                            loadSavingWithdrawLimits(contentResolver, mSavingId, money,
+                                    storedRowHasLanded ? money : 0L);
                         }
                     }
                     cursor.close();
@@ -733,7 +737,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     }
                 } else if (mType == TYPE_SAVING) {
                     mSavingId = intent.getLongExtra(SAVING_ID, 0L);
-                    long savingMoney = 0L;
+                    long landedMoney = 0L;
+                    long projectedMoney = 0L;
                     // getItemId is the id of the transaction being edited, and this branch only
                     // runs when there is no transaction yet, so it was always the -1 assigned for
                     // a new item. That built the uri savings/-1, which matches no route in the
@@ -746,6 +751,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     String[] projection = new String[] {
                             Contract.Saving.START_MONEY,
                             Contract.Saving.PROGRESS,
+                            Contract.Saving.PROJECTED_PROGRESS,
                             Contract.Saving.WALLET_ID,
                             Contract.Saving.WALLET_NAME,
                             Contract.Saving.WALLET_ICON,
@@ -754,12 +760,18 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     Cursor cursor = contentResolver.query(uri, projection, null, null, null);
                     if (cursor != null) {
                         if (cursor.moveToFirst()) {
-                            // What a saving holds is its start money plus its progress, the same
-                            // sum the savings list draws its current amount from. END_MONEY is the
-                            // target, and a saving can be deposited past its target, so the target
-                            // would strand the overshoot in a withdraw everything.
-                            savingMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY))
+                            // Two figures, because a withdraw can take a saving under zero at
+                            // two different moments. What it holds today is its start money plus
+                            // its progress, the same sum the savings list draws its current
+                            // amount from. The lowest it can end up at is its start money plus
+                            // its projected progress, which counts every withdraw it carries and
+                            // only the deposits that are confirmed. END_MONEY is the
+                            // target, and a saving can be deposited past its target, so the
+                            // target would strand the overshoot in a withdraw everything.
+                            landedMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY))
                                     + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS));
+                            projectedMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY))
+                                    + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROJECTED_PROGRESS));
                             wallet = new Wallet(
                                     cursor.getLong(cursor.getColumnIndex(Contract.Saving.WALLET_ID)),
                                     cursor.getString(cursor.getColumnIndex(Contract.Saving.WALLET_NAME)),
@@ -786,7 +798,19 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             selectionArgs[0] = Contract.CategoryTag.SAVING_DEPOSIT;
                             break;
                         case SAVING_WITHDRAW_EVERYTHING:
-                            money = savingMoney;
+                            // The row this writes opens dated now and confirmed, so it lands
+                            // today and both ceilings bind it. The smaller of the two is what
+                            // the saving can actually give, and prefilling anything above it
+                            // offers an amount this same screen then refuses. Moving the date
+                            // ahead or unticking Confirmed only drops the landed ceiling, and
+                            // the prefill is at or under the other one too.
+                            //
+                            // Never below zero either. A saving already carrying more
+                            // withdrawals than it holds gives a negative figure here, and the
+                            // check below only refuses an amount above the ceiling, so the field
+                            // would open on a negative amount and saving it untouched would
+                            // write a withdraw of a negative amount.
+                            money = Math.max(Math.min(landedMoney, projectedMoney), 0L);
                             mSavingCompleted = true;
                             // Deliberate fall through: withdraw everything needs the withdraw
                             // category set below. A break here, which is what an IDE inspection
@@ -794,11 +818,11 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             // crashes the editor as it opens: the bind value at index 1 is null.
                         case SAVING_WITHDRAW:
                             selectionArgs[0] = Contract.CategoryTag.SAVING_WITHDRAW;
-                            // The figure is already in hand from the query above, so this sets the
-                            // ceiling from it instead of reading the same row again. Nothing is
-                            // added back: this row does not exist yet, so the saving's progress
-                            // cannot already be counting it.
-                            setSavingWithdrawLimit(savingMoney, 0L,
+                            // Both figures are already in hand from the query above, so this
+                            // sets both ceilings from them instead of reading the same row
+                            // again. Nothing is added back to either: this row does not exist
+                            // yet, so neither sum can already be counting it.
+                            setSavingWithdrawLimits(projectedMoney, landedMoney, 0L, 0L,
                                     wallet != null && wallet.getCurrency() != null ? wallet.getCurrency().getIso() : null);
                             break;
                     }
@@ -897,7 +921,23 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             mDebtId = savedInstanceState.containsKey(SS_DEBT_ID) ? savedInstanceState.getLong(SS_DEBT_ID) : null;
             mSavingId = savedInstanceState.containsKey(SS_SAVING_ID) ? savedInstanceState.getLong(SS_SAVING_ID) : null;
             mSavingCompleted = savedInstanceState.getBoolean(SS_SAVING_COMPLETED, false);
+            // v1.5.0 wrote the first key alone, holding what the saving held today, so a bundle
+            // from it has no second key. Neither ceiling can be worked out again here, because
+            // both calls that build them run only when there is no bundle, so the landed one
+            // falls back to the other. That editor then holds one number, today's, and applies
+            // it to every withdraw. It is neither rule: v1.5.0 waved a row dated ahead through,
+            // and this build would bound it by what the saving ends up at, which can be lower or
+            // higher than today's.
+            //
+            // Written out instead of as a second conditional on purpose. A conditional whose
+            // arms are a long and a Long is a numeric one, so the Long arm is unboxed, and here
+            // that arm is a field that is null on every editor which is not a saving withdraw.
+            // As a conditional this line crashed the editor on rotation.
             mSavingWithdrawLimit = savedInstanceState.containsKey(SS_SAVING_WITHDRAW_LIMIT) ? savedInstanceState.getLong(SS_SAVING_WITHDRAW_LIMIT) : null;
+            mSavingWithdrawLandedLimit = mSavingWithdrawLimit;
+            if (savedInstanceState.containsKey(SS_SAVING_WITHDRAW_LANDED_LIMIT)) {
+                mSavingWithdrawLandedLimit = savedInstanceState.getLong(SS_SAVING_WITHDRAW_LANDED_LIMIT);
+            }
             mSavingWithdrawCurrency = savedInstanceState.getString(SS_SAVING_WITHDRAW_CURRENCY);
         }
         // depending on the type we must hide pickers that are now allowed to be changed
@@ -976,8 +1016,13 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             outState.putLong(SS_SAVING_ID, mSavingId);
         }
         outState.putBoolean(SS_SAVING_COMPLETED, mSavingCompleted);
-        if (mSavingWithdrawLimit != null) {
+        // Never the landed key without the other one. The restore above reads the landed key
+        // as an override on the projected one and falls back to it when there is none, and
+        // the check bails out entirely on a null projected ceiling, so a bundle carrying
+        // only the landed key would come back with no ceiling at all.
+        if (mSavingWithdrawLimit != null && mSavingWithdrawLandedLimit != null) {
             outState.putLong(SS_SAVING_WITHDRAW_LIMIT, mSavingWithdrawLimit);
+            outState.putLong(SS_SAVING_WITHDRAW_LANDED_LIMIT, mSavingWithdrawLandedLimit);
             outState.putString(SS_SAVING_WITHDRAW_CURRENCY, mSavingWithdrawCurrency);
         }
     }
@@ -1029,26 +1074,33 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     }
 
     /**
-     * Reads what a saving holds, its start money plus its progress, which is the same sum the
-     * savings list draws its current amount from, and remembers the currency that figure is in.
+     * Reads both of a saving's figures, the lowest it can end up at once everything already on
+     * it has happened and what it holds today, and remembers the currency they are in.
      *
-     * alreadyTaken is what the row being edited is itself withdrawing. The progress counts that
-     * row, so adding it back gives what the row is allowed to grow to. It is zero for a new row.
+     * alreadyTaken is what the row being edited is itself withdrawing, added back because the
+     * projected sum counts that row. alreadyTakenLanded is the same amount when the progress
+     * counts it too, which is while the stored row is confirmed and not dated ahead, and zero
+     * otherwise. A new withdraw has no stored row to add back and does not come through here; it
+     * sets its ceilings from the figures the saving branch of this screen has already read.
      */
-    private void loadSavingWithdrawLimit(ContentResolver contentResolver, long savingId, long alreadyTaken) {
+    private void loadSavingWithdrawLimits(ContentResolver contentResolver, long savingId,
+                                          long alreadyTaken, long alreadyTakenLanded) {
         Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, savingId);
         String[] projection = new String[] {
                 Contract.Saving.START_MONEY,
                 Contract.Saving.PROGRESS,
+                Contract.Saving.PROJECTED_PROGRESS,
                 Contract.Saving.WALLET_CURRENCY
         };
         Cursor cursor = contentResolver.query(uri, projection, null, null, null);
         if (cursor != null) {
             if (cursor.moveToFirst()) {
-                setSavingWithdrawLimit(
-                        cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY))
-                                + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS)),
+                long startMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY));
+                setSavingWithdrawLimits(
+                        startMoney + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROJECTED_PROGRESS)),
+                        startMoney + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS)),
                         alreadyTaken,
+                        alreadyTakenLanded,
                         cursor.getString(cursor.getColumnIndex(Contract.Saving.WALLET_CURRENCY)));
             }
             cursor.close();
@@ -1056,35 +1108,70 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     }
 
     /**
-     * Never below what the row already takes. A saving that is under zero gives a negative
-     * ceiling, and the amount field cannot go negative, so that would refuse every save of the
-     * row, including lowering the amount or correcting the note. Holding it at what the row
-     * already takes lets the row be kept or reduced and still refuses raising it. For a new row
-     * that term is zero, so the floor is zero and a saving holding nothing allows no withdraw.
+     * Two ceilings, because one number cannot say both things. A withdraw must not take the
+     * saving under zero once everything already on it has happened, which is what the projected
+     * sum bounds, and a withdraw already counted in today's figure must not take it under zero
+     * today, which is what the progress bounds. Bounding only the first lets a deposit dated
+     * ahead pay for a withdraw taken now; bounding only the second lets a withdraw dated ahead
+     * land on a saving that cannot cover it.
+     *
+     * Each ceiling is held at the term added back to it, since a saving that is under zero gives
+     * a negative one and that would refuse every save of the row, including lowering the amount
+     * or correcting the note. A row both sums already count gets its own amount added back to
+     * both, so it can always be kept or reduced. A stored row the progress does not count gets
+     * nothing added back to the landed ceiling, which is a different case on purpose:
+     * confirming it and dating it today adds a drain today's figure has never carried, so it is
+     * held to today's figure like any other new drain and can be refused at its own amount.
+     *
+     * For a new row both terms are zero, so the floor is zero.
      */
-    private void setSavingWithdrawLimit(long held, long alreadyTaken, String currencyIso) {
-        mSavingWithdrawLimit = Math.max(held + alreadyTaken, alreadyTaken);
+    private void setSavingWithdrawLimits(long projectedHeld, long landedHeld, long alreadyTaken,
+                                         long alreadyTakenLanded, String currencyIso) {
+        mSavingWithdrawLimit = Math.max(projectedHeld + alreadyTaken, alreadyTaken);
+        mSavingWithdrawLandedLimit = Math.max(landedHeld + alreadyTakenLanded, alreadyTakenLanded);
         mSavingWithdrawCurrency = currencyIso;
     }
 
     /**
-     * A withdraw cannot take out more than the saving holds. The ceiling is loaded whenever the
-     * editor opens on a withdraw, whether that is a new one from the savings list or one already
-     * in the database, and stays null everywhere else, so a deposit and an ordinary transaction
-     * are unaffected.
+     * A withdraw cannot take the saving under zero today, nor once everything already on it has
+     * happened, which counts every withdraw it carries and only the deposits that are confirmed.
+     * Those are two moments and not every moment between them: the sums behind them are totals
+     * and carry no date order, so a withdraw dated before a deposit that funds it still passes
+     * and the saving dips under zero in between.
      *
-     * The check applies only to a row that will count once saved. getSavings sums confirmed rows
-     * that are not dated ahead, so a row saved unconfirmed or into the future moves nothing and
-     * has nothing to be refused for. That is read from the fields as they stand now and not from
-     * the stored row, because it is the row about to be written that matters. What such a row does
-     * when it is later confirmed is the gap issue 175 covers.
+     * This is a check on the way in and only on a withdraw, against figures read once when the
+     * editor opened. They are not read again, not even across a rotation, where the pair comes
+     * back out of the bundle. So a withdraw is measured against the saving as it stood when the
+     * screen opened, and anything that pays for it can be taken away either before the save,
+     * from another screen while this one waits, or afterwards, with nothing refused: the deposit
+     * it was allowed against can be lowered, deleted, unconfirmed or dated ahead, and the
+     * saving's own start money is editable on its own screen.
+     *
+     * The ceilings are loaded whenever the editor opens on a withdraw, whether that is a new one
+     * from the savings list or one already in the database, and stay null everywhere else, so a
+     * deposit and an ordinary transaction are unaffected. Loaded is not the same as enforced: the
+     * currency test below steps aside both for a wallet on screen whose currency the ceilings
+     * cannot be compared with and for a saving whose own currency the app cannot resolve, which
+     * a restored backup can produce.
+     *
+     * The check applies to every withdraw, including one saved unconfirmed or dated ahead. Such a
+     * row moves the saving by nothing on the day it is written and by its full amount on the day
+     * it lands, and nothing looks at the saving again in between.
+     *
+     * A row already counted in today's figure is held to both ceilings and takes the smaller.
+     * The test is the one getSavings uses, confirmed and dated at or before this moment, so a
+     * row dated later today is not one of them and only the projected ceiling binds it. That is
+     * read from the fields as they stand now and not from the stored row, because it is the row
+     * about to be written that matters.
      */
     private boolean validateSavingWithdraw() {
         if (mSavingWithdrawLimit == null) {
             return true;
         }
-        if (!mConfirmedCheckBox.isChecked() || mDateTimePicker.getCurrentDateTime().after(new Date())) {
-            return true;
+        long limit = mSavingWithdrawLimit;
+        if (mSavingWithdrawLandedLimit != null && mConfirmedCheckBox.isChecked()
+                && !mDateTimePicker.getCurrentDateTime().after(new Date())) {
+            limit = Math.min(limit, mSavingWithdrawLandedLimit);
         }
         CurrencyUnit currency = mSavingWithdrawCurrency != null ? CurrencyManager.getCurrency(mSavingWithdrawCurrency) : null;
         // The limit is in the saving's own currency. If the wallet on screen has been changed to
@@ -1095,13 +1182,23 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         if (currency == null || walletCurrency == null || !currency.getIso().equals(walletCurrency.getIso())) {
             return true;
         }
-        if (mMoneyPicker.getCurrentMoney() <= mSavingWithdrawLimit) {
+        // An amount of nothing is not refused. Refusing it would refuse every save of a stored
+        // withdraw of nothing, whatever its ceiling, so its own note and date could never be
+        // corrected and only deletion would be open. The old withdraw everything path could
+        // write such a row. What it costs is an empty row: on a saving with nothing left to give
+        // the withdraw everything prefill is zero, and saving that writes the row and, on that
+        // path only, marks the goal complete.
+        if (mMoneyPicker.getCurrentMoney() <= limit) {
             return true;
         }
-        String message = mSavingWithdrawLimit <= 0
-                ? getString(R.string.error_saving_withdraw_nothing_to_take)
-                : getString(R.string.error_saving_withdraw_over_balance,
-                        mMoneyFormatter.getNotTintedString(currency, mSavingWithdrawLimit));
+        // The figure every time, with no separate wording for a ceiling of nothing. What a
+        // saving holds today and what it has left to give are not the same number once a
+        // withdraw is sitting on it unconfirmed or dated ahead, and the wording this replaced
+        // said the saving was empty, which is false while the savings list still shows a
+        // balance. A ceiling of 0.00 read beside that balance is still a surprise; it is at
+        // least true, and it names the number the save is being held to.
+        String message = getString(R.string.error_saving_withdraw_over_balance,
+                mMoneyFormatter.getNotTintedString(currency, limit));
         ThemedDialog.buildMaterialDialog(this)
                 .title(R.string.title_error)
                 .content(message)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -386,7 +386,6 @@
     <string name="title_failed">"Failed"</string>
     <string name="title_error">"Error"</string>
     <string name="error_saving_withdraw_over_balance">"You cannot withdraw more than %1$s from this saving."</string>
-    <string name="error_saving_withdraw_nothing_to_take">"There is nothing in this saving to withdraw."</string>
     <string name="title_atm_search">"Search ATM"</string>
     <string name="title_bank_search">"Search bank"</string>
     <string name="title_changelog">"Changelog"</string>

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
@@ -19,18 +19,23 @@ import static org.junit.Assert.fail;
  * source instead.
  *
  * Comments and string literals are stripped before anything is matched, so no assertion here can
- * be satisfied or broken by the wording of a comment.
+ * be satisfied or broken by the wording of a comment. Text that goes through squash first also
+ * tolerates any amount of whitespace between two tokens. Everything else is matched with its
+ * spacing exactly as written, including the lines a region is found by, so a reformat or a line
+ * wrap anywhere in that text fails the assertion with no defect present.
  *
  * What these assertions check is which token sequences the source does and does not carry:
  * that getItemId appears nowhere in the intent branch, that the saving uri is built from
- * mSavingId, that the statement assigning savingMoney reads START_MONEY and PROGRESS once each
- * and adds them, that both columns are in the projection, that the prefill sits in the withdraw
- * everything case and that the case falls through, and that the statement assigning wallet builds
- * a Wallet from the saving's wallet columns. That makes them a tripwire against a revert or a
- * careless rewrite. It does not make them a proof of behaviour, and they cannot show the value the
- * keypad ends up with. A rewrite that keeps those tokens and still breaks the editor goes through.
- * One example, not a list: a second assignment written with += or -= is invisible here, because
- * "savingMoney -=" does not contain the "savingMoney =" the statement is found by.
+ * mSavingId, that the statement assigning landedMoney reads START_MONEY and PROGRESS once each
+ * and adds them, that the statement assigning projectedMoney does the same with
+ * PROJECTED_PROGRESS, that all three columns are in the projection, that the prefill takes the
+ * smaller of the two and sits in the withdraw everything case, that the case falls through, and
+ * that the statement assigning wallet builds a Wallet from the saving's wallet columns. That
+ * makes them a tripwire against a revert or a careless rewrite. It does not make them a proof of
+ * behaviour, and they cannot show the value the keypad ends up with. A rewrite that keeps those
+ * tokens and still breaks the editor goes through. One example, not a list: a second assignment
+ * written with += or -= is invisible here, because "landedMoney -=" does not contain the
+ * "landedMoney =" the statement is found by.
  *
  * Invariant one: inside the branch that fills a new transaction from its intent, getItemId is
  * always -1, the value NewEditItemActivity assigns whenever it was not launched to edit an
@@ -39,14 +44,40 @@ import static org.junit.Assert.fail;
  * returned null without reaching the database. The editor opened with no wallet, the amount keypad
  * had no currency to scale against, and a typed 2000 was stored as 20.00.
  *
- * Invariant two: the prefill that WITHDRAW EVERYTHING opens on is what the saving holds, which is
- * START_MONEY plus PROGRESS, the same sum SavingCursorAdapter draws its current amount from.
- * END_MONEY is the target. Reading END_MONEY there returns too little for any saving deposited
- * past its target and leaves the overshoot behind with the saving already marked complete.
+ * Invariant two: the prefill that WITHDRAW EVERYTHING opens on is the smaller of the saving's two
+ * figures. START_MONEY plus PROGRESS is what it holds today, the sum SavingCursorAdapter draws
+ * its current amount from. START_MONEY plus PROJECTED_PROGRESS is the lowest it can end up at
+ * once everything already on it has happened, counting every withdrawal it has and only the
+ * deposits that are confirmed. An unconfirmed deposit is in neither, so this is not what the
+ * saving would hold if every row landed; it is never more than that, and it is less by exactly
+ * the unconfirmed deposits, which on most savings is nothing at all. The row this prefill is
+ * written into is dated now and confirmed, so both bound it, and offering more than the smaller
+ * one offers an amount the same screen then refuses. END_MONEY is the target. Reading END_MONEY
+ * there returns too little for any saving deposited past its target and leaves the overshoot
+ * behind with the saving already marked complete. The prefill is held at zero when the smaller
+ * figure is negative, since the amount written out would otherwise be a withdraw of a negative
+ * amount.
  *
  * Invariant three: the same row builds the wallet the editor opens on, currency included. Without
  * that construction the wallet field is empty, the keypad has no currency to scale against, and a
  * typed 2000 is stored as 20.00.
+ *
+ * Invariant four: a withdraw carries two ceilings, one from each of the saving's two figures, and
+ * every place that builds or uses them agrees on which is which. Both are plain longs of the same
+ * kind, so swapping them compiles, inverts both ceilings and changes nothing the other assertions
+ * here look at. Every place they can be swapped is pinned: the two call sites, the parameter list
+ * they are received into, the two statements that assign them to their fields, the one that picks
+ * which of the two the check starts from, and the bundle they are written to and read back from.
+ * The same goes for which term is added back to which ceiling and for how the term that only one
+ * of them gets is worked out, for taking the smaller of the two and then comparing against it,
+ * for naming what it worked out in the dialog, and for the column the loader reads each figure
+ * from.
+ *
+ * The early return this change deleted is asserted absent, by counting the date test it was
+ * written around: that test belongs to the narrowing now and appears once inside the check. Like
+ * everything else here it is token matching, and it is loose in both directions. A return written
+ * around some other test is invisible to it, and a second reading of this one fails it whether or
+ * not a return came with it.
  */
 public class NewEditTransactionActivitySourceTest {
 
@@ -63,6 +94,17 @@ public class NewEditTransactionActivitySourceTest {
     private static final String WITHDRAW_CASE = "case SAVING_WITHDRAW:";
     private static final String CATEGORY_QUERY_START = "uri = DataContentProvider.CONTENT_CATEGORIES;";
 
+    private static final String PREFILL = "money = Math.max(Math.min(landedMoney, projectedMoney), 0L);";
+
+    private static final String CHECK_START = "private boolean validateSavingWithdraw() {";
+    private static final String CHECK_END = "ThemedDialog.buildMaterialDialog(this)";
+
+    /** Each figure the prefill is built from, paired with the column it has to read. */
+    private static final String[][] FIGURES = {
+            {"landedMoney =", "Contract.Saving.PROGRESS"},
+            {"projectedMoney =", "Contract.Saving.PROJECTED_PROGRESS"}
+    };
+
     @Test
     public void newItemBranchDoesNotReadTheItemId() throws IOException {
         assertEquals("getItemId is read inside the branch that fills a new transaction from its "
@@ -78,21 +120,25 @@ public class NewEditTransactionActivitySourceTest {
     }
 
     @Test
-    public void withdrawEverythingPrefillsWhatTheSavingHolds() throws IOException {
+    public void withdrawEverythingPrefillsTheSmallerOfTheTwoFigures() throws IOException {
         String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
-        assertTrue("the withdraw everything prefill must be the savingMoney this block computes",
-                saving.contains("money = savingMoney;"));
-        String computed = statementAssigning(saving, "savingMoney =");
-        assertTrue("what a saving holds is START_MONEY plus PROGRESS, so both have to be read to "
-                + "compute the prefill, but the assignment is: " + computed,
-                computed.contains("Contract.Saving.START_MONEY")
-                        && computed.contains("Contract.Saving.PROGRESS"));
-        assertTrue("END_MONEY is the target, not what the saving holds, so it must not be part of "
-                + "the prefill, but the assignment is: " + computed,
-                !computed.contains("END_MONEY"));
-        assertTrue("the two columns have to be added, since a saving holds its start money plus "
-                + "everything deposited into it, but the assignment is: " + computed,
-                computed.contains("+") && !computed.contains("-"));
+        assertTrue("the withdraw everything prefill must be the smaller of the two figures this "
+                + "block computes, held at zero so a saving already over withdrawn cannot prefill "
+                + "a negative amount", saving.contains(PREFILL));
+        for (String[] figure : FIGURES) {
+            String computed = statementAssigning(saving, figure[0]);
+            assertTrue("the figure is START_MONEY plus " + figure[1] + ", so both have to be "
+                    + "read, but the assignment is: " + computed,
+                    computed.contains("Contract.Saving.START_MONEY")
+                            && computed.contains(figure[1]));
+            assertTrue("END_MONEY is the target, not what the saving holds, so it must not be "
+                    + "part of the prefill, but the assignment is: " + computed,
+                    !computed.contains("END_MONEY"));
+            assertTrue("the two columns have to be added to each other and nothing subtracted "
+                    + "from them, since each figure is the start money plus its own sum and the "
+                    + "signs are already in the sum, but the assignment is: " + computed,
+                    computed.contains("+") && !computed.contains("-"));
+        }
     }
 
     @Test
@@ -101,8 +147,8 @@ public class NewEditTransactionActivitySourceTest {
         String everything = saving.substring(saving.indexOf(WITHDRAW_EVERYTHING_CASE));
         int ownCaseEnd = everything.indexOf(WITHDRAW_CASE);
         assertTrue("the prefill has to sit in the withdraw everything case: moved into the deposit "
-                + "case it offers the saving's whole balance every time a deposit is opened",
-                everything.substring(0, ownCaseEnd).contains("money = savingMoney;"));
+                + "case it fills in what the saving can give every time a deposit is opened",
+                everything.substring(0, ownCaseEnd).contains(PREFILL));
     }
 
     @Test
@@ -118,26 +164,29 @@ public class NewEditTransactionActivitySourceTest {
     }
 
     @Test
-    public void bothColumnsTheSumReadsAreInTheProjection() throws IOException {
+    public void everyColumnTheFiguresReadIsInTheProjection() throws IOException {
         // The saving branch builds two projections, one for the saving and one for its category,
         // so this looks only at the part before the category query starts.
         String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
         String projection = statementAssigning(
                 saving.substring(0, saving.indexOf(CATEGORY_QUERY_START)), "projection =");
         assertTrue("a column read through getColumnIndex but left out of the projection returns "
-                + "index -1 and throws when it is read, so both have to be listed: " + projection,
-                projection.contains("Contract.Saving.START_MONEY")
-                        && projection.contains("Contract.Saving.PROGRESS"));
+                + "index -1 and throws when it is read, so all three have to be listed: "
+                + projection, projection.contains("Contract.Saving.START_MONEY")
+                        && projection.contains("Contract.Saving.PROGRESS")
+                        && projection.contains("Contract.Saving.PROJECTED_PROGRESS"));
     }
 
     @Test
-    public void theSumReadsEachColumnOnce() throws IOException {
-        String computed = statementAssigning(
-                region(SAVING_BRANCH_START, SAVING_BRANCH_END), "savingMoney =");
-        assertEquals("START_MONEY has to be read once, or the prefill counts it twice: " + computed,
-                1, occurrences(computed, "Contract.Saving.START_MONEY"));
-        assertEquals("PROGRESS has to be read once: " + computed,
-                1, occurrences(computed, "Contract.Saving.PROGRESS"));
+    public void theSumsReadEachColumnOnce() throws IOException {
+        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
+        for (String[] figure : FIGURES) {
+            String computed = statementAssigning(saving, figure[0]);
+            assertEquals("START_MONEY has to be read once, or the figure counts it twice: "
+                    + computed, 1, occurrences(computed, "Contract.Saving.START_MONEY"));
+            assertEquals(figure[1] + " has to be read once: " + computed,
+                    1, occurrences(computed, figure[1]));
+        }
     }
 
     @Test
@@ -152,11 +201,112 @@ public class NewEditTransactionActivitySourceTest {
     }
 
     /**
+     * Runs of whitespace are collapsed to one space before these are matched, so the amount of
+     * space between two tokens does not matter. A break inserted where the pattern has no space
+     * at all still fails them, which is a false alarm and not a defect in the code. Everything
+     * else about them is literal: they are token matching, not behaviour, and a rewrite that
+     * keeps these sequences and still gets the ceilings wrong goes through.
+     */
+    @Test
+    public void theTwoCeilingsAreBuiltAndUsedInTheRightOrder() throws IOException {
+        String source = squash(stripCommentsAndStrings(readSource()));
+        assertTrue("the new withdraw path passes the projected figure first and the landed one "
+                + "second, and swapping them inverts both ceilings",
+                source.contains("setSavingWithdrawLimits(projectedMoney, landedMoney, 0L, 0L,"));
+        // As far as the break that closes the case, not to the end of the saving branch: past
+        // that break the same call runs for a deposit too, and the check would start refusing
+        // deposits. This cannot see a condition wrapped around the call inside the case.
+        String saving = squash(region(SAVING_BRANCH_START, SAVING_BRANCH_END));
+        String fromWithdrawCase = saving.substring(saving.indexOf(WITHDRAW_CASE));
+        String withdrawCase = fromWithdrawCase.substring(0, fromWithdrawCase.indexOf("break;"));
+        assertTrue("and it sits in the withdraw case itself. Above the case label it lands in "
+                + "withdraw everything, which falls through, so a plain withdraw from the savings "
+                + "list loses its ceilings and the check returns on its first line; below the "
+                + "break it runs for a deposit as well: " + withdrawCase,
+                withdrawCase.contains("setSavingWithdrawLimits(projectedMoney, landedMoney, 0L, 0L,"));
+        assertTrue("the loader reads PROJECTED_PROGRESS into the first slot and PROGRESS into the "
+                + "second, and swapping them inverts both ceilings", source.contains(
+                "startMoney + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROJECTED_PROGRESS)), "
+                        + "startMoney + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS)), "
+                        + "alreadyTaken, alreadyTakenLanded,"));
+        assertTrue("the edit path adds the stored amount back to the projected ceiling always and "
+                + "to the landed one only while the progress already counts that row",
+                source.contains("loadSavingWithdrawLimits(contentResolver, mSavingId, money, "
+                        + "storedRowHasLanded ? money : 0L);"));
+        assertTrue("and the parameter list it arrives in takes them in that order. These two are "
+                + "longs of the same kind as well, so swapping them here hands the landed ceiling "
+                + "an amount its own sum never counted", source.contains(
+                "private void loadSavingWithdrawLimits(ContentResolver contentResolver, "
+                        + "long savingId, long alreadyTaken, long alreadyTakenLanded) {"));
+        // Inside the check itself and in this order, because each of these read on its own is
+        // satisfied by a body that computes the narrowing and then never uses it.
+        String check = squash(region(CHECK_START, CHECK_END));
+        int starts = check.indexOf("long limit = mSavingWithdrawLimit;");
+        int narrows = check.indexOf("limit = Math.min(limit, mSavingWithdrawLandedLimit);");
+        int compares = check.indexOf("if (mMoneyPicker.getCurrentMoney() <= limit) {");
+        assertTrue("the check starts from the projected ceiling: " + check, starts >= 0);
+        assertTrue("it narrows to the smaller for a row already counted in today's figure, which "
+                + "is one confirmed and not dated later, read from the fields as they stand now: "
+                + check, narrows > starts && check.indexOf("mConfirmedCheckBox.isChecked() && "
+                + "!mDateTimePicker.getCurrentDateTime().after(new Date())") > starts);
+        assertTrue("and it compares against what it worked out, after working it out. Comparing "
+                + "first and narrowing afterwards leaves every literal here in place and the "
+                + "landed ceiling binding nothing: " + check, compares > narrows);
+        assertTrue("the dialog names what the check worked out. Naming a field instead tells the "
+                + "user a figure this same screen has just refused",
+                source.contains("mMoneyFormatter.getNotTintedString(currency, limit)"));
+        assertEquals("inside this check the date test belongs to the narrowing and is read once. "
+                + "Reading it twice is how the deleted early return comes back, and that return "
+                + "lets a row saved unconfirmed or dated ahead skip the check, which is route one "
+                + "of the reported bug. A second reading is not proof of one: splitting the "
+                + "narrowing, or guarding something else on the same test, fails this too", 1,
+                occurrences(check, "mDateTimePicker.getCurrentDateTime().after(new Date())"));
+        assertTrue("the parameter list receives the projected figure first and the landed one "
+                + "second, which is the third place the same swap inverts both ceilings",
+                source.contains("private void setSavingWithdrawLimits(long projectedHeld, "
+                        + "long landedHeld, long alreadyTaken, long alreadyTakenLanded, "
+                        + "String currencyIso) {"));
+        assertTrue("each field takes its own figure and its own added back term, and each is held "
+                + "at the term it was given, so a row both sums already count can be kept or "
+                + "reduced while a row only the projected sum counts can be refused at its own "
+                + "amount once it is confirmed and dated today",
+                source.contains("mSavingWithdrawLimit = Math.max(projectedHeld + alreadyTaken, "
+                        + "alreadyTaken); mSavingWithdrawLandedLimit = Math.max(landedHeld + "
+                        + "alreadyTakenLanded, alreadyTakenLanded);"));
+        assertTrue("the stored row counts towards the landed ceiling only while the progress "
+                + "counts it, which is while it is confirmed and not dated ahead", source.contains(
+                "boolean storedRowHasLanded = cursor.getInt(cursor.getColumnIndex("
+                        + "Contract.Transaction.CONFIRMED)) == 1 && !DateUtils."
+                        + "getDateFromSQLDateTimeString(cursor.getString(cursor.getColumnIndex("
+                        + "Contract.Transaction.DATE))).after(new Date());"));
+        assertTrue("the loader reads each figure from its own column, and a column left out of "
+                + "its projection returns index -1 and throws when it is read", source.contains(
+                "String[] projection = new String[] { Contract.Saving.START_MONEY, "
+                        + "Contract.Saving.PROGRESS, Contract.Saving.PROJECTED_PROGRESS, "
+                        + "Contract.Saving.WALLET_CURRENCY };"));
+        assertTrue("both ceilings are written to the bundle together. Nothing rebuilds either "
+                + "one on the way back, and the check bails out entirely on a null projected "
+                + "ceiling, so dropping the write is the check gone for that editor",
+                source.contains("outState.putLong(SS_SAVING_WITHDRAW_LIMIT, "
+                        + "mSavingWithdrawLimit); outState.putLong("
+                        + "SS_SAVING_WITHDRAW_LANDED_LIMIT, mSavingWithdrawLandedLimit);"));
+        assertTrue("and the landed one is read back with a plain assignment and an if, never a "
+                + "second conditional. A conditional with a long on one arm and this Long field "
+                + "on the other is a numeric one, so the field is unboxed, and it is null on "
+                + "every editor that is not a saving withdraw: written that way this line crashed "
+                + "the editor on rotation", source.contains(
+                "mSavingWithdrawLandedLimit = mSavingWithdrawLimit; if (savedInstanceState"
+                        + ".containsKey(SS_SAVING_WITHDRAW_LANDED_LIMIT)) { "
+                        + "mSavingWithdrawLandedLimit = savedInstanceState.getLong("
+                        + "SS_SAVING_WITHDRAW_LANDED_LIMIT); }"));
+    }
+
+    /**
      * Returns the statement that assigns to the given left hand side, skipping any long
-     * declaration of the same name, which is how the running total is declared before the block
-     * fills it. Fails when the literal text passed in matches more than once, so a second plain
+     * declaration of the same name, which is how each figure is declared before the block fills
+     * it. Fails when the literal text passed in matches more than once, so a second plain
      * assignment cannot slip past unread. Compound assignments do not contain that text:
-     * "savingMoney -=" does not contain "savingMoney =", so a later += or -= is not seen.
+     * "landedMoney -=" does not contain "landedMoney =", so a later += or -= is not seen.
      */
     private static String statementAssigning(String block, String assignment) {
         String found = null;
@@ -231,6 +381,11 @@ public class NewEditTransactionActivitySourceTest {
             }
         }
         return out.toString();
+    }
+
+    /** Collapses every run of whitespace to one space. */
+    private static String squash(String text) {
+        return text.replaceAll("\\s+", " ");
     }
 
     private static int occurrences(String text, String token) {


### PR DESCRIPTION
A savings goal already refuses a withdrawal bigger than it holds. This closes the way around that a person can walk into, and says below what it leaves open.

A withdrawal dated in the future, or saved without ticking Confirmed, moves the goal by nothing on the day you write it. The app read that as nothing to refuse and let it through at any amount. On the day the date arrives it counts in full and the goal drops below zero, with nothing checking on the way.

A goal now carries two amounts instead of one. The first is what it holds today, which is what the savings list has always shown and still shows. The second is the lowest it can end up at once everything already on it has happened: every withdrawal it carries, and only the deposits that are confirmed. An unconfirmed deposit never arrives on its own, so it must not pay for a withdrawal that does.

A withdrawal has to clear both. One that counts today is held to the smaller of the two. One dated later, or left unticked, leaves today's figure alone, so only the second binds it.

Withdraw everything offers what will be left once the pending entries arrive, not what is showing today. Otherwise it would offer an amount the same screen then refuses.

Three things this does not do. Both figures are totals with no date order in them, so a withdrawal dated before the deposit that funds it still passes and the goal dips below zero in between. Nothing is checked on the way out, so whatever pays for a withdrawal can still be lowered, deleted, unticked or moved later. And restoring a backup is untouched on purpose: a restore has to reproduce the ledger it came from, so refusing an entry there would quietly drop somebody's own records.

Tested on an Android 16 emulator, same input on both builds. Before, a 3,000.00 withdrawal dated next month on a goal holding 1,500.00 saved with no warning. After, it is refused and nothing is written.
