### PR TITLE
fix: a savings goal entry can no longer be filed against another wallet

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -943,8 +943,11 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         // depending on the type we must hide pickers that are now allowed to be changed
         switch (mType) {
             case TYPE_DEBT:
+                mCategoryEditText.setVisibility(View.GONE);
+                break;
             case TYPE_SAVING:
                 mCategoryEditText.setVisibility(View.GONE);
+                mWalletEditText.setVisibility(View.GONE);
                 break;
         }
         // now we can create pickers with default values or existing item parameters
@@ -1174,10 +1177,9 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             limit = Math.min(limit, mSavingWithdrawLandedLimit);
         }
         CurrencyUnit currency = mSavingWithdrawCurrency != null ? CurrencyManager.getCurrency(mSavingWithdrawCurrency) : null;
-        // The limit is in the saving's own currency. If the wallet on screen has been changed to
-        // another one the two are not comparable as they stand, and this screen converts nowhere
-        // else, so the check steps aside instead of comparing amounts that do not mean the same
-        // thing.
+        // The limit is in the saving's own currency. If the row sits in a wallet held in another
+        // one the two are not comparable as they stand, and this screen converts nowhere else, so
+        // the check steps aside instead of comparing amounts that do not mean the same thing.
         CurrencyUnit walletCurrency = mWalletPicker.getCurrentWallet().getCurrency();
         if (currency == null || walletCurrency == null || !currency.getIso().equals(walletCurrency.getIso())) {
             return true;

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
@@ -24,18 +24,19 @@ import static org.junit.Assert.fail;
  * spacing exactly as written, including the lines a region is found by, so a reformat or a line
  * wrap anywhere in that text fails the assertion with no defect present.
  *
- * What these assertions check is which token sequences the source does and does not carry:
- * that getItemId appears nowhere in the intent branch, that the saving uri is built from
- * mSavingId, that the statement assigning landedMoney reads START_MONEY and PROGRESS once each
- * and adds them, that the statement assigning projectedMoney does the same with
- * PROJECTED_PROGRESS, that all three columns are in the projection, that the prefill takes the
- * smaller of the two and sits in the withdraw everything case, that the case falls through, and
- * that the statement assigning wallet builds a Wallet from the saving's wallet columns. That
- * makes them a tripwire against a revert or a careless rewrite. It does not make them a proof of
- * behaviour, and they cannot show the value the keypad ends up with. A rewrite that keeps those
- * tokens and still breaks the editor goes through. One example, not a list: a second assignment
- * written with += or -= is invisible here, because "landedMoney -=" does not contain the
- * "landedMoney =" the statement is found by.
+ * What these assertions check is which token sequences the source does and does not carry: that
+ * getItemId appears nowhere in the intent branch, that the saving uri is built from mSavingId,
+ * that the statement assigning landedMoney reads START_MONEY and PROGRESS once each and adds them,
+ * that the statement assigning projectedMoney does the same with PROJECTED_PROGRESS, that all
+ * three columns are in the projection, that the prefill takes the smaller of the two and sits in
+ * the withdraw everything case, that the case falls through, that the statement assigning wallet
+ * builds a Wallet from the saving's wallet columns, that the saving case of the visibility switch
+ * hides the wallet field, and that between the debt label and the saving label the source names no
+ * wallet field and does carry a break. That makes them a tripwire against a revert or a careless
+ * rewrite. It does not make them a proof of behavior, and they cannot show the value the keypad
+ * ends up with. A rewrite that keeps those tokens and still breaks the editor goes through. One
+ * example, not a list: a second assignment written with += or -= is invisible here, because
+ * "landedMoney -=" does not contain the "landedMoney =" the statement is found by.
  *
  * Invariant one: inside the branch that fills a new transaction from its intent, getItemId is
  * always -1, the value NewEditItemActivity assigns whenever it was not launched to edit an
@@ -78,6 +79,15 @@ import static org.junit.Assert.fail;
  * everything else here it is token matching, and it is loose in both directions. A return written
  * around some other test is invisible to it, and a second reading of this one fails it whether or
  * not a return came with it.
+ *
+ * Invariant five: a saving transaction does not offer its wallet field. A saving's progress is
+ * summed over its transactions with no currency anywhere in that sum, so a row moved onto a wallet
+ * held in another currency is added at face value, and 500 euros count as 500 dollars. The debt
+ * label sits beside the saving one in the same switch and the two shared a body until the hide was
+ * added. A debt payment is deliberately left offering its wallet field, since a debt's progress is
+ * summed the same way and answering that is a separate change. Three things are read: the saving
+ * case must hide the wallet field, and between the two labels the field's name must be absent and
+ * a break must be present.
  */
 public class NewEditTransactionActivitySourceTest {
 
@@ -104,6 +114,10 @@ public class NewEditTransactionActivitySourceTest {
             {"landedMoney =", "Contract.Saving.PROGRESS"},
             {"projectedMoney =", "Contract.Saving.PROJECTED_PROGRESS"}
     };
+
+    private static final String DEBT_CASE = "case TYPE_DEBT:";
+    private static final String SAVING_CASE = "case TYPE_SAVING:";
+    private static final String CASE_BREAK = "break;";
 
     @Test
     public void newItemBranchDoesNotReadTheItemId() throws IOException {
@@ -198,6 +212,28 @@ public class NewEditTransactionActivitySourceTest {
                 + "nothing to scale a typed amount against, but the assignment is: " + built,
                 built.contains("Contract.Saving.WALLET_ID")
                         && built.contains("Contract.Saving.WALLET_CURRENCY"));
+    }
+
+    @Test
+    public void aSavingTransactionDoesNotOfferItsWalletField() throws IOException {
+        assertTrue("a saving's progress is summed with no currency in it, so the wallet a saving "
+                + "transaction sits in must not be changeable from the editor",
+                region(SAVING_CASE, CASE_BREAK)
+                        .contains("mWalletEditText.setVisibility(View.GONE)"));
+    }
+
+    @Test
+    public void theDebtCaseDoesNotNameTheWalletField() throws IOException {
+        assertEquals("a debt payment is deliberately left offering its wallet field, so that field "
+                + "must not be named between the debt label and the saving one", -1,
+                region(DEBT_CASE, SAVING_CASE).indexOf("mWalletEditText"));
+    }
+
+    @Test
+    public void theDebtCaseCarriesABreak() throws IOException {
+        assertTrue("a debt payment is deliberately left offering its wallet field, and the two "
+                + "labels shared a body until the wallet hide was added, so a break has to appear "
+                + "between them", region(DEBT_CASE, SAVING_CASE).contains(CASE_BREAK));
     }
 
     /**


### PR DESCRIPTION
Fixes #176.

A savings goal belongs to a wallet, and its current amount is the total of everything filed against it. That total is added up without looking at what currency each entry is in.

The editor that opens on Deposit or Withdraw already hides the category, because the category is not yours to pick on that kind of entry. It left the wallet alone. Tapping it opened the picker, which will make you one in any currency. Pick one, and what you type is added to the goal as though it were the goal's own money.

The wallet is now hidden too, the same way the category already is. The amount still opens in the same currency and saving still works.

It also closes a way around the withdrawal limit. That limit stands down when the entry is in a different currency to the goal, since the two amounts do not mean the same thing, and the wallet was the only way to make them differ. Before, a 5,000.00 withdrawal from a goal holding 760.00 is refused, then goes through once the wallet is switched to a euro one, leaving the goal at minus 4,240.00. After, the same withdrawal is refused, though moving the goal itself still produces the same mismatch.

Two ways to the same wrong total are left open. A debt adds its payments up the same way and its editor still offers the wallet. And a goal itself can still be moved to a wallet in another currency, which changes the currency it is read in while everything filed against it stays where it is.

Entries already in another wallet keep it, and can no longer be moved back from this screen.

Tested on an Android 16 emulator, the same goal on both builds. Before, a 500 euro deposit picked from a euro wallet took a goal held in dollars from 0.00 to 500.00. After, that wallet cannot be reached, and a 260.00 deposit still saves and takes the same goal from 500.00 to 760.00. An ordinary entry and a debt payment still offer theirs.
