### PR TITLE
Keep the detail panel from coming back blank after a rotation

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
@@ -150,7 +150,12 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
     protected void onConfigureRootLayout(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         ViewGroup primaryContainer = mPrimaryPanelBodyContainer != null ? mPrimaryPanelBodyContainer : mPrimaryPanel;
         onCreatePrimaryPanel(inflater, primaryContainer, savedInstanceState);
-        onCreateSecondaryPanel(inflater, mSecondaryPanel, savedInstanceState);
+        // the secondary panel is not the same id in every width qualifier, and a restored child
+        // fragment keeps the container id it was added under. Nest one container that carries
+        // the same id and the same view type everywhere so that id always resolves
+        inflater.inflate(R.layout.layout_secondary_panel_container, mSecondaryPanel, true);
+        ViewGroup secondaryContainer = mSecondaryPanel.findViewById(R.id.secondary_panel_container);
+        onCreateSecondaryPanel(inflater, secondaryContainer, savedInstanceState);
     }
 
     protected abstract void onCreatePrimaryPanel(LayoutInflater inflater, @NonNull ViewGroup primaryPanel, @Nullable Bundle savedInstanceState);

--- a/app/src/main/res/layout/layout_secondary_panel_container.xml
+++ b/app/src/main/res/layout/layout_secondary_panel_container.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/secondary_panel_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />


### PR DESCRIPTION
On a screen that pairs a list with a detail panel, opening an item and then rotating between a narrow window and a wide one left the detail panel empty, with no item, no toolbar, and not even the message the panel shows when nothing is selected. The list beside it was fine, and tapping the same item again did not bring the detail back, though rotating back the other way did.

The boundary is 840dp of window width, so seeing it needs a device or a window that is under that in one orientation and over it in the other. A large tablet does this, and so does a resizable window on a desktop or a foldable.

The cause is that the app gives the detail panel a different home depending on how wide the window is, and the panel remembers which home it was put in. After a rotation across the boundary that home is not there any more, so the panel gets rebuilt into nothing at all and fails quietly. Two screens in the app already avoided this by giving the detail one permanent home inside whichever panel the window picked, and this does the same for all the others.

What this touches: every screen that pairs a list with a detail panel, which is places, people, the transaction list, the calendar, wallets, budgets, categories, debts, events, savings, the main transactions screen, models, recurrences and search. Settings and backup services already had a permanent home, and they behave exactly as before.

Tested on an emulator sized so that portrait is under the boundary and landscape is over it, against a build without the change and one with it. The detail survives the rotation in both directions on the transaction list and on places, and it still holds the same item it did before. Settings and backup still work across the same rotation, and so does a rotation between two narrow widths, which was never broken.

Fixes #187
