### PR TITLE
Keep the calendar day strip on the year you picked

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
@@ -122,10 +122,7 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
     }
 
     /**
-     * The day is saved as a date and not as the strip position that also identifies it. A position
-     * is a running day count the strip adjusts by a difference on every selection, and that count
-     * can drift from the date it is meant to name, so restoring one can load a day the user never
-     * picked. The date cannot drift.
+     * The day is saved as a date and not as the strip position that also identifies it.
      */
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
@@ -38,7 +38,8 @@ import com.oriondev.moneywallet.R;
 import android.icu.text.DateFormatSymbols;
 import java.util.Calendar;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
+
+import static com.oriondev.moneywallet.utils.DateUtils.getCalendarDaysBetween;
 
 public class TimelineView extends RecyclerView {
 
@@ -206,28 +207,11 @@ public class TimelineView extends RecyclerView {
         if (year == startYear && month == startMonth && day < startDay) {
             day = startDay;
         }
-
-        // Get new selected dayOfYear
-        calendar.set(year, month, day, 1, 0, 0);
-        final int newDayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
-        final long newTimestamp = calendar.getTimeInMillis();
-
-        // Get current selected dayOfYear
-        calendar.set(selectedYear, selectedMonth, selectedDay, 1, 0, 0);
-        final int oldDayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
-        final long oldTimestamp = calendar.getTimeInMillis();
-
-        int dayDifference;
-        if (year == selectedYear) {
-            dayDifference = newDayOfYear - oldDayOfYear;
-        } else {
-            // Lazy...
-            int dayDifferenceApprox = (int) ((newTimestamp - oldTimestamp) / TimeUnit.DAYS.toMillis(1));
-            calendar.add(Calendar.DAY_OF_YEAR, dayDifferenceApprox);
-            dayDifference = dayDifferenceApprox + (newDayOfYear - calendar.get(Calendar.DAY_OF_YEAR));
-        }
-
-        onDateSelected(selectedPosition + dayDifference, year, month, day);
+        // counted from the first date, which is how TimelineAdapter turns a position back into a
+        // date. What this replaced adjusted the previous position by a difference, so it needed
+        // that position to already be right
+        onDateSelected(getCalendarDaysBetween(startYear, startMonth, startDay, year, month, day),
+                year, month, day);
     }
 
     public int getSelectedYear() {
@@ -317,16 +301,8 @@ public class TimelineView extends RecyclerView {
     }
 
     public void setLastDate(int endYear, int endMonth, int endDay) {
-        Calendar firstDate = Calendar.getInstance();
-        firstDate.set(startYear, startMonth, startDay);
-        Calendar lastDate = Calendar.getInstance();
-        lastDate.set(endYear, endMonth, endDay);
-
-        // TODO: might now work for summer time...
-        int dayDiff = (int) TimeUnit.DAYS.convert(lastDate.getTimeInMillis() - firstDate.getTimeInMillis(),
-                TimeUnit.MILLISECONDS);
-
-        setDayCount(dayDiff + 1);
+        // the last date is a cell of its own, so the count is one more than the span
+        setDayCount(getCalendarDaysBetween(startYear, startMonth, startDay, endYear, endMonth, endDay) + 1);
     }
 
     void setDayCount(int dayCount) {

--- a/app/src/main/java/com/oriondev/moneywallet/utils/DateUtils.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/DateUtils.java
@@ -27,6 +27,8 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Created by andrea on 03/03/18.
@@ -192,6 +194,27 @@ public class DateUtils {
 
     public static int getDaysBetween(Date start, Date end) {
         return (int)( (Math.abs(end.getTime() - start.getTime())) / (1000 * 60 * 60 * 24));
+    }
+
+    /**
+     * The number of calendar days from one date to the other, negative when the second date is
+     * the earlier one. The months are zero based, the way {@link Calendar} numbers them.
+     *
+     * Counted in UTC, where every day is 24 hours long. Subtracting two local timestamps and
+     * dividing by 24 hours does not answer this, because a zone whose offset grew between the two
+     * dates leaves the span short of a whole number of days and the division truncates.
+     */
+    public static int getCalendarDaysBetween(int fromYear, int fromMonth, int fromDay,
+                                             int toYear, int toMonth, int toDay) {
+        long span = utcMidnight(toYear, toMonth, toDay) - utcMidnight(fromYear, fromMonth, fromDay);
+        return (int) (span / TimeUnit.DAYS.toMillis(1));
+    }
+
+    private static long utcMidnight(int year, int month, int day) {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.clear();
+        calendar.set(year, month, day);
+        return calendar.getTimeInMillis();
     }
 
     public static Calendar getCalendar(Date date) {

--- a/app/src/test/java/com/oriondev/moneywallet/utils/DateUtilsTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/DateUtilsTest.java
@@ -1,0 +1,73 @@
+package com.oriondev.moneywallet.utils;
+
+import org.junit.After;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateUtilsTest {
+
+    /**
+     * A spread of zones whose offsets have moved differently since 1900, and UTC, which has never
+     * moved at all. None of the five has ever dropped a whole calendar date the way a zone that
+     * crossed the date line has, so every day counted below is one that existed locally.
+     */
+    private static final String[] ZONES = {
+            "Australia/Sydney", "Europe/Paris", "Europe/Madrid", "America/Chicago", "UTC"
+    };
+
+    /** 1 January 1900 to 31 December 2100, the range the calendar strip is given. */
+    private static final int LAST_POSITION = 73413;
+
+    private final TimeZone systemTimeZone = TimeZone.getDefault();
+
+    @After
+    public void restoreSystemTimeZone() {
+        TimeZone.setDefault(systemTimeZone);
+    }
+
+    /**
+     * The strip turns a position back into a day by adding that many days to its first date, so a
+     * day count is right only if it inverts that walk. Counting from a span of local milliseconds
+     * did not, and 1 January of a later year came back naming 1 January of the year before.
+     */
+    @Test
+    public void countsThePositionThatRendersTheDayAsked() {
+        for (String zone : ZONES) {
+            TimeZone.setDefault(TimeZone.getTimeZone(zone));
+            Calendar day = Calendar.getInstance();
+            for (int position = 0; position <= LAST_POSITION; position++) {
+                day.set(1900, Calendar.JANUARY, 1, 1, 0, 0);
+                day.add(Calendar.DAY_OF_YEAR, position);
+                assertEquals(zone, position, DateUtils.getCalendarDaysBetween(
+                        1900, Calendar.JANUARY, 1, day.get(Calendar.YEAR),
+                        day.get(Calendar.MONTH), day.get(Calendar.DAY_OF_MONTH)));
+            }
+        }
+    }
+
+    @Test
+    public void countsWholeDays() {
+        // 7 days left in August, then 30, 31, 30 and 31, then 1 January itself
+        assertEquals(130, DateUtils.getCalendarDaysBetween(
+                2026, Calendar.AUGUST, 24, 2027, Calendar.JANUARY, 1));
+        assertEquals(0, DateUtils.getCalendarDaysBetween(
+                2027, Calendar.JANUARY, 1, 2027, Calendar.JANUARY, 1));
+        assertEquals(1, DateUtils.getCalendarDaysBetween(
+                2026, Calendar.DECEMBER, 31, 2027, Calendar.JANUARY, 1));
+        assertEquals(-1, DateUtils.getCalendarDaysBetween(
+                2027, Calendar.JANUARY, 1, 2026, Calendar.DECEMBER, 31));
+        // 2026 is a common year and 2024 is a leap year
+        assertEquals(365, DateUtils.getCalendarDaysBetween(
+                2026, Calendar.JANUARY, 1, 2027, Calendar.JANUARY, 1));
+        assertEquals(366, DateUtils.getCalendarDaysBetween(
+                2024, Calendar.JANUARY, 1, 2025, Calendar.JANUARY, 1));
+        // 127 years of 365 days, plus a day for each leap year from 1904 to 2024. 1900 is not
+        // one, being a century that 400 does not divide, and 2000 is one for the same rule
+        assertEquals(127 * 365 + ((2024 - 1904) / 4 + 1), DateUtils.getCalendarDaysBetween(
+                1900, Calendar.JANUARY, 1, 2027, Calendar.JANUARY, 1));
+    }
+}


### PR DESCRIPTION
The day strip in the calendar could show 1 January of the year before the one you asked for. The month row above it still read the right month, so the strip was the only part that was wrong, and the day numbers on their own look like a plausible January. The weekday letters are what give it away.

There are two ways to see it. Tap January of a later year in the month row, or have 1 January selected when the screen is rebuilt, which covers rotating the device and covers opening the calendar on New Year's Day.

Whether it happens at all depends on the time zone, because the count behind it came from a span of local time divided by 24 hours. A zone whose offset grew between the two dates leaves that span a little short of a whole number of days, so the division came up a day short. Being a day short is harmless for almost every date, since a later step puts it right. 1 January is the exception, because a day short of it lands in the year before, and it is also the only date a month tap ever asks for.

The strip already had an exact meaning for a position, whole days counted from the first date it was given. This counts that directly and deletes the estimate. The same faulty count sat a few lines below deciding how many days the strip holds, with a note in the code admitting it was wrong, so that is gone as well. One thing that falls out of it, the last day the strip covers is now reachable in zones where it was not before.

Tested on an emulator against a build without the change and one with it, in Paris with the device set to New Year's Day 2027 and in Sydney by tapping January 2027. Before, both drew the 1 on a Thursday, which is 1 January 2026. After, both draw it on a Friday, and 1 January 2027 is a Friday.

Fixes #191
