### PR TITLE
Mark the days that have transactions in the calendar strip

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
@@ -53,7 +53,10 @@ import com.oriondev.moneywallet.ui.view.calendar.TimelineView;
 import com.oriondev.moneywallet.utils.DateUtils;
 
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Created by andrea on 06/04/18.
@@ -71,6 +74,20 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
     private static final String STATE_SELECTED_DAY = "CalendarMultiPanelFragment::State::Day";
 
     private static final int DEFAULT_LOADER_ID = 4834;
+    private static final int MARKED_DAYS_LOADER_ID = 4835;
+
+    private static final String COLUMN_DAY = "day";
+
+    /** No day at all, which no real date can collide with because no year is negative here. */
+    static final int NO_DAY = -1;
+
+    /**
+     * One row per day that has a transaction. DISTINCT rides in the first column because the
+     * provider passes a projection straight into the SELECT clause.
+     */
+    private static final String[] MARKED_DAYS_PROJECTION = new String[] {
+            "DISTINCT DATE(" + Contract.Transaction.DATE + ") AS " + COLUMN_DAY
+    };
 
     private BroadcastReceiver mCurrentWalletObserver;
 
@@ -119,6 +136,7 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
         mTimelineView.setSelectedDate(year, month, day);
         mTimelineView.setOnDateSelectedListener(this);
         onDateSelected(year, month, day, mTimelineView.getSelectedPosition());
+        getLoaderManager().initLoader(MARKED_DAYS_LOADER_ID, null, mMarkedDaysCallbacks);
     }
 
     /**
@@ -193,21 +211,99 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
                     args.getInt(ARG_SELECTED_DAY)
             );
             Uri uri = DataContentProvider.CONTENT_TRANSACTIONS;
-            String selection;
-            String[] arguments;
-            long currentWallet = PreferenceManager.getCurrentWallet();
-            if (currentWallet == PreferenceManager.TOTAL_WALLET_ID) {
-                selection = Contract.Transaction.WALLET_COUNT_IN_TOTAL + " = 1";
-                arguments = null;
-            } else {
-                selection = Contract.Transaction.WALLET_ID + " = ?";
-                arguments = new String[] {String.valueOf(currentWallet)};
-            }
-            selection += " AND DATE(" + Contract.Transaction.DATE + ") == DATE('" + DateUtils.getSQLDateString(date) + "')";
+            String selection = walletSelection()
+                    + " AND DATE(" + Contract.Transaction.DATE + ") == DATE('" + DateUtils.getSQLDateString(date) + "')";
             String sortOrder = Contract.Transaction.DATE + " DESC";
-            return new CursorLoader(activity, uri, null, selection, arguments, sortOrder);
+            return new CursorLoader(activity, uri, null, selection, null, sortOrder);
         }
         return null;
+    }
+
+    /**
+     * The wallet this screen is about. The marks under the strip come from this same rule, so a
+     * day is marked when the list has something to show for it and not when it has not.
+     *
+     * The wallet id is written into the text and not bound, so neither query carries arguments.
+     */
+    private static String walletSelection() {
+        long currentWallet = PreferenceManager.getCurrentWallet();
+        if (currentWallet == PreferenceManager.TOTAL_WALLET_ID) {
+            return Contract.Transaction.WALLET_COUNT_IN_TOTAL + " = 1";
+        }
+        return Contract.Transaction.WALLET_ID + " = " + currentWallet;
+    }
+
+    /**
+     * The days this wallet has transactions on, one row each, which is all the strip needs to
+     * know.
+     *
+     * ponytail: few rows come back and that says nothing about the work. The provider has no
+     * query that answers this on its own, so the dates come from the transaction query, whose
+     * GROUP BY leaves the wallet clause outside a subquery SQLite cannot push it into. EXPLAIN
+     * QUERY PLAN answers SCAN t, every transaction row in every wallet, and it answers the same
+     * for the day list this screen already runs on every day tapped. Tapping a day does not run
+     * this one again, so a tap costs what it always did, and the second scan falls on opening the
+     * screen, changing wallet, pulling to refresh, and any change the cursor is watching for. A
+     * provider uri of its own is the way out.
+     */
+    private final LoaderManager.LoaderCallbacks<Cursor> mMarkedDaysCallbacks = new LoaderManager.LoaderCallbacks<Cursor>() {
+
+        @NonNull
+        @Override
+        public Loader<Cursor> onCreateLoader(int id, @Nullable Bundle args) {
+            return new CursorLoader(requireContext(), DataContentProvider.CONTENT_TRANSACTIONS,
+                    MARKED_DAYS_PROJECTION, walletSelection(), null, null);
+        }
+
+        @Override
+        public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
+            if (mTimelineView != null) {
+                mTimelineView.setMarkedDays(readDays(cursor));
+            }
+        }
+
+        @Override
+        public void onLoaderReset(@NonNull Loader<Cursor> loader) {
+            if (mTimelineView != null) {
+                mTimelineView.setMarkedDays(Collections.emptySet());
+            }
+        }
+
+    };
+
+    /**
+     * The dates of a marked days cursor, as the keys the strip matches its cells against.
+     */
+    private static Set<Integer> readDays(@Nullable Cursor cursor) {
+        if (cursor == null) {
+            return Collections.emptySet();
+        }
+        Set<Integer> days = new HashSet<>(cursor.getCount());
+        int index = cursor.getColumnIndex(COLUMN_DAY);
+        for (cursor.moveToPosition(-1); cursor.moveToNext(); ) {
+            int day = dayKey(cursor.getString(index));
+            if (day != NO_DAY) {
+                days.add(day);
+            }
+        }
+        return days;
+    }
+
+    /**
+     * One yyyy-MM-dd date read as the key the strip matches its cells against, or {@link #NO_DAY}
+     * for anything that is not one. The month is put in the strip's terms here, counted from zero.
+     *
+     * DATE() returns either that spelling or null, so a value SQLite could not read arrives as
+     * null and a value it could is ten characters of digits and dashes.
+     */
+    static int dayKey(@Nullable String date) {
+        if (date == null || date.length() != 10) {
+            return NO_DAY;
+        }
+        return TimelineView.dayKey(
+                Integer.parseInt(date.substring(0, 4)),
+                Integer.parseInt(date.substring(5, 7)) - 1,
+                Integer.parseInt(date.substring(8, 10)));
     }
 
     @Override
@@ -232,6 +328,9 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
                 mTimelineView.getSelectedMonth(),
                 mTimelineView.getSelectedDay()
         );
+        // a pull is what somebody does when the screen looks wrong, and the marks are part of
+        // what they are looking at
+        loadMarkedDays();
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.REFRESHING);
     }
 
@@ -258,6 +357,7 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
                 mTimelineView.getSelectedMonth(),
                 mTimelineView.getSelectedDay()
         );
+        loadMarkedDays();
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
     }
 
@@ -267,5 +367,14 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
         arguments.putInt(ARG_SELECTED_MONTH, month);
         arguments.putInt(ARG_SELECTED_DAY, day);
         getLoaderManager().restartLoader(DEFAULT_LOADER_ID, arguments, this);
+    }
+
+    /**
+     * Read again for a wallet the query cannot be told about, since the wallet is read where the
+     * selection is built. A transaction added or removed inside this wallet needs none of this,
+     * because the cursor is watching the transactions it came from.
+     */
+    private void loadMarkedDays() {
+        getLoaderManager().restartLoader(MARKED_DAYS_LOADER_ID, null, mMarkedDaysCallbacks);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
@@ -22,6 +22,7 @@ package com.oriondev.moneywallet.ui.view.calendar;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.os.Build;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -37,7 +38,9 @@ import com.oriondev.moneywallet.R;
 
 import android.icu.text.DateFormatSymbols;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Locale;
+import java.util.Set;
 
 import static com.oriondev.moneywallet.utils.DateUtils.getCalendarDaysBetween;
 
@@ -55,6 +58,8 @@ public class TimelineView extends RecyclerView {
     private LinearLayoutManager layoutManager;
     private OnDateSelectedListener onDateSelectedListener;
     private MonthView.DateLabelAdapter dateLabelAdapter;
+
+    private Set<Integer> markedDays = Collections.emptySet();
 
     private int startYear = 1970, startMonth = 0, startDay = 1;
     private int selectedYear, selectedMonth, selectedDay;
@@ -234,6 +239,26 @@ public class TimelineView extends RecyclerView {
         this.onDateSelectedListener = onDateSelectedListener;
     }
 
+    /**
+     * The days that get a mark under the number, as the keys {@link #dayKey} builds. The strip
+     * runs from 1900 to 2100 and binds a cell as it is scrolled into view, so the marked days are
+     * held here and are not asked for one cell at a time.
+     */
+    public void setMarkedDays(@NonNull Set<Integer> markedDays) {
+        this.markedDays = markedDays;
+        if (adapter != null) {
+            adapter.notifyDataSetChanged();
+        }
+    }
+
+    /**
+     * A year, month and day read as one number. The month is the {@link Calendar} one, counted
+     * from zero, so a caller holding a month counted from one subtracts before it calls this.
+     */
+    public static int dayKey(int year, int month, int day) {
+        return (year * 100 + month) * 100 + day;
+    }
+
     public void setDateLabelAdapter(@Nullable MonthView.DateLabelAdapter dateLabelAdapter) {
         this.dateLabelAdapter = dateLabelAdapter;
     }
@@ -338,7 +363,8 @@ public class TimelineView extends RecyclerView {
             int dayOfWeek = calendar.get(Calendar.DAY_OF_WEEK);
             int day = calendar.get(Calendar.DAY_OF_MONTH);
             boolean isToday = DateUtils.isToday(calendar.getTimeInMillis());
-            holder.bind(position, year, month, day, dayOfWeek,position == selectedPosition, isToday);
+            holder.bind(position, year, month, day, dayOfWeek,position == selectedPosition, isToday,
+                    markedDays.contains(dayKey(year, month, day)));
         }
 
         @Override
@@ -351,6 +377,7 @@ public class TimelineView extends RecyclerView {
 
         private final TextView lblDay;
         private final TextView lblDate;
+        private final DotView dotMarker;
 
         private int position;
         private int year, month, day;
@@ -360,6 +387,7 @@ public class TimelineView extends RecyclerView {
 
             lblDay = root.findViewById(R.id.mti_timeline_lbl_day);
             lblDate = root.findViewById(R.id.mti_timeline_lbl_date);
+            dotMarker = root.findViewById(R.id.mti_timeline_dot_marker);
 
             lblDay.setTextColor(lblDayColor);
             lblDay.setTextSize(TypedValue.COMPLEX_UNIT_PX, dayLabelSize(lblDay, root));
@@ -375,7 +403,7 @@ public class TimelineView extends RecyclerView {
             });
         }
 
-        void bind(int position, int year, int month, int day, int dayOfWeek, boolean selected, boolean isToday) {
+        void bind(int position, int year, int month, int day, int dayOfWeek, boolean selected, boolean isToday, boolean marked) {
             this.position = position;
             this.year = year;
             this.month = month;
@@ -386,8 +414,11 @@ public class TimelineView extends RecyclerView {
             // so the accent color is the only mark on a cell and it marks today and the shown day
             // alike. Weight is what separates them: the shown day is the bold one.
             // lblDate.setBackgroundResource(selected ? R.drawable.mti_bg_lbl_date_selected : (isToday ? R.drawable.mti_bg_lbl_date_today : 0));
-            lblDate.setTextColor(selected || isToday ? lblDateSelectedColor : lblDateColor);
+            int dateColor = selected || isToday ? lblDateSelectedColor : lblDateColor;
+            lblDate.setTextColor(dateColor);
             lblDate.setTypeface(null, selected ? Typeface.BOLD : Typeface.NORMAL);
+            dotMarker.setColor(dateColor);
+            dotMarker.setVisibility(marked ? VISIBLE : INVISIBLE);
         }
     }
 }

--- a/app/src/main/res/layout/view_mti_item_day.xml
+++ b/app/src/main/res/layout/view_mti_item_day.xml
@@ -23,7 +23,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mt_layout_toolbar"
     android:layout_width="@dimen/view_mti_timeline_width"
-    android:layout_height="@dimen/view_mti_timeline_height"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/view_mti_timeline_height"
     android:clickable="true"
     android:focusable="true"
     android:gravity="center_horizontal"
@@ -50,5 +51,14 @@
         android:textColor="#FFFFFF"
         android:textSize="@dimen/view_mti_timeline_lbl_date_text"
         tools:text="25"/>
+
+    <com.oriondev.moneywallet.ui.view.calendar.DotView
+        android:id="@+id/mti_timeline_dot_marker"
+        android:layout_width="@dimen/view_mti_timeline_dot_size"
+        android:layout_height="@dimen/view_mti_timeline_dot_size"
+        android:layout_marginTop="2dp"
+        android:contentDescription="@string/description_day_has_transactions"
+        android:visibility="invisible"
+        tools:visibility="visible"/>
 
 </LinearLayout>

--- a/app/src/main/res/values/descriptions.xml
+++ b/app/src/main/res/values/descriptions.xml
@@ -43,4 +43,5 @@
     <string name="description_setting_category_icon">"Setting category icon"</string>
     <string name="description_show_subcategories">"Show subcategories of %1$s"</string>
     <string name="description_hide_subcategories">"Hide subcategories of %1$s"</string>
+    <string name="description_day_has_transactions">"Has transactions"</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -183,6 +183,7 @@
     <dimen name="view_mti_timeline_lbl_day_text">12sp</dimen>
     <dimen name="view_mti_timeline_lbl_date_text">14sp</dimen>
     <dimen name="view_mti_timeline_lbl_value">12dp</dimen>
+    <dimen name="view_mti_timeline_dot_size">5dp</dimen>
 
     <dimen name="view_pie_chart_height">320dp</dimen>
     <dimen name="view_pie_chart_margin_top">12dp</dimen>

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarDayKeyTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarDayKeyTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.fragment.multipanel;
+
+import com.oriondev.moneywallet.ui.view.calendar.TimelineView;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * The calendar strip marks a day when its own key for that cell equals a key built from a date
+ * SQLite returned. The two are built by different code from different material, the cell from a
+ * {@link Calendar} and the mark from a string, so the month has to be counted the same way on
+ * both sides or every mark lands eleven months from where it belongs.
+ *
+ * A run of this cannot see the strip. What it pins is that the two keys agree.
+ */
+public class CalendarDayKeyTest {
+
+    @Test
+    public void keyMatchesTheCellForTheSameDay() {
+        assertEquals(TimelineView.dayKey(2026, Calendar.AUGUST, 3),
+                CalendarMultiPanelFragment.dayKey("2026-08-03"));
+    }
+
+    @Test
+    public void januaryAndDecemberAreTheMonthsAtTheEnds() {
+        assertEquals(TimelineView.dayKey(2027, Calendar.JANUARY, 1),
+                CalendarMultiPanelFragment.dayKey("2027-01-01"));
+        assertEquals(TimelineView.dayKey(2026, Calendar.DECEMBER, 31),
+                CalendarMultiPanelFragment.dayKey("2026-12-31"));
+    }
+
+    @Test
+    public void twoDaysOfTheSameMonthGetDifferentKeys() {
+        assertEquals(CalendarMultiPanelFragment.dayKey("2026-08-03") + 1,
+                CalendarMultiPanelFragment.dayKey("2026-08-04"));
+    }
+
+    @Test
+    public void aDateSqliteCouldNotReadIsNoDay() {
+        assertEquals(CalendarMultiPanelFragment.NO_DAY, CalendarMultiPanelFragment.dayKey(null));
+        assertEquals(CalendarMultiPanelFragment.NO_DAY, CalendarMultiPanelFragment.dayKey(""));
+        assertEquals(CalendarMultiPanelFragment.NO_DAY,
+                CalendarMultiPanelFragment.dayKey("2026-08-03 09:00:00"));
+    }
+}


### PR DESCRIPTION
Closes #189.

The calendar shows one day at a time, and nothing on the day strip told
you which days had anything on them. The reporter read the one day they
were on as the whole month, and there was no reason to read it any other
way, since every other day looked identical to it.

Each day in the strip now shows a small dot under the number when that
day has transactions in the wallet you are looking at, in the color the
number already uses. A day with nothing on it is unchanged. The dots
follow the wallet you switch to, and they move on their own when you add
or delete a transaction, with no need to leave the screen and come back.

A dot appears on exactly the days the screen has something to show for,
so a marked day always loads rows and an unmarked one never does.

The strip also grows with the system text size now. A day cell used to be
a fixed height, so at the larger text sizes the mark was pushed out of
the bottom of it and never drawn at all, on a strip where the day numbers
were already being cut off before any of this.

A screen reader says "Has transactions" on a marked day and says nothing
extra on the rest.

Tested on an emulator with transactions on five days across two months.
The dots landed on those five and on none of the others, and the day
tapped under a dot loaded its transaction. Checked again at the largest
system text size, where the mark is absent before this change and drawn
after it.
