### PR TITLE
Show what came in and what went out on a transactions list header

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/wrapper/TransactionHeaderCursor.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/wrapper/TransactionHeaderCursor.java
@@ -37,6 +37,8 @@ public class TransactionHeaderCursor extends AbstractHeaderCursor<TransactionHea
     public static final String COLUMN_HEADER_START_DATE = "header_start_date";
     public static final String COLUMN_HEADER_END_DATE = "header_end_date";
     public static final String COLUMN_HEADER_MONEY = "header_money";
+    public static final String COLUMN_HEADER_INCOME = "header_income";
+    public static final String COLUMN_HEADER_EXPENSE = "header_expense";
     public static final String COLUMN_HEADER_GROUP_TYPE = "header_group_type";
 
     public final static int TYPE_HEADER = 0;
@@ -46,7 +48,9 @@ public class TransactionHeaderCursor extends AbstractHeaderCursor<TransactionHea
     private static final int INDEX_HEADER_START_DATE = 1;
     private static final int INDEX_HEADER_END_DATE = 2;
     private static final int INDEX_HEADER_MONEY = 3;
-    private static final int INDEX_HEADER_GROUP_TYPE = 4;
+    private static final int INDEX_HEADER_INCOME = 4;
+    private static final int INDEX_HEADER_EXPENSE = 5;
+    private static final int INDEX_HEADER_GROUP_TYPE = 6;
 
     private final Group mGroup;
     private final Date mLowerBound;
@@ -87,10 +91,7 @@ public class TransactionHeaderCursor extends AbstractHeaderCursor<TransactionHea
                     String currency = cursor.getString(indexCurrency);
                     long money = cursor.getLong(indexTransactionMoney);
                     int direction = cursor.getInt(indexTransactionDirection);
-                    if (direction == 0) {
-                        money *= -1;
-                    }
-                    header.addMoney(currency, money);
+                    header.add(currency, money, direction);
                 }
             } while (cursor.moveToNext());
         }
@@ -103,6 +104,8 @@ public class TransactionHeaderCursor extends AbstractHeaderCursor<TransactionHea
                 COLUMN_HEADER_START_DATE,
                 COLUMN_HEADER_END_DATE,
                 COLUMN_HEADER_MONEY,
+                COLUMN_HEADER_INCOME,
+                COLUMN_HEADER_EXPENSE,
                 COLUMN_HEADER_GROUP_TYPE
         };
     }
@@ -117,7 +120,11 @@ public class TransactionHeaderCursor extends AbstractHeaderCursor<TransactionHea
                 case INDEX_HEADER_END_DATE:
                     return DateUtils.getSQLDateTimeString(header.getEndDate());
                 case INDEX_HEADER_MONEY:
-                    return header.mMoney.toString();
+                    return header.getMoney().toString();
+                case INDEX_HEADER_INCOME:
+                    return header.getIncome().toString();
+                case INDEX_HEADER_EXPENSE:
+                    return header.getExpense().toString();
             }
         }
         return null;
@@ -162,15 +169,47 @@ public class TransactionHeaderCursor extends AbstractHeaderCursor<TransactionHea
 
     /*package-local*/ static class Header extends DateRangeHeader {
 
-        private Money mMoney;
+        private final Money mMoney;
+        private final Money mIncome;
+        private final Money mExpense;
 
-        private Header(Group group, Date lowerBound, Date upperBound, Date date) {
+        /*package-local*/ Header(Group group, Date lowerBound, Date upperBound, Date date) {
             super(group, lowerBound, upperBound, date);
             mMoney = new Money();
+            mIncome = new Money();
+            mExpense = new Money();
         }
 
-        private void addMoney(String currency, long money) {
-            mMoney.addMoney(currency, money);
+        /**
+         * Count one row into this header. The total is the difference and can come out either
+         * sign. The other two are the same rows split by their direction and both only ever
+         * grow, so a row adds to one of them and leaves the other alone, while the total takes
+         * that same amount as a plus or a minus.
+         *
+         * Direction is all that is read here, so the two halves of a transfer land in both, and a
+         * debt taken on lands in the incoming one. That is what PeriodDetailSummaryLoader counts
+         * too, which is the report a reader reaches from this header, so the two agree.
+         */
+        /*package-local*/ void add(String currency, long money, int direction) {
+            if (direction == Contract.Direction.INCOME) {
+                mIncome.addMoney(currency, money);
+                mMoney.addMoney(currency, money);
+            } else {
+                mExpense.addMoney(currency, money);
+                mMoney.addMoney(currency, -money);
+            }
+        }
+
+        /*package-local*/ Money getMoney() {
+            return mMoney;
+        }
+
+        /*package-local*/ Money getIncome() {
+            return mIncome;
+        }
+
+        /*package-local*/ Money getExpense() {
+            return mExpense;
         }
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/TransactionCursorAdapter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/TransactionCursorAdapter.java
@@ -48,11 +48,14 @@ import java.util.Date;
 public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView.ViewHolder> {
 
     private final ActionListener mActionListener;
+    private final boolean mHeaderOpensReport;
 
     private int mIndexType;
     private int mIndexHeaderStartDate;
     private int mIndexHeaderEndDate;
     private int mIndexHeaderMoney;
+    private int mIndexHeaderIncome;
+    private int mIndexHeaderExpense;
     private int mIndexHeaderGroupType;
     private int mIndexCategoryName;
     private int mIndexCategoryIcon;
@@ -66,8 +69,18 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
     private MoneyFormatter mMoneyFormatter;
 
     public TransactionCursorAdapter(ActionListener actionListener) {
+        this(actionListener, false);
+    }
+
+    /**
+     * Three of the four screens using this adapter answer a header click with an empty method, so
+     * the arrow and the click both wait to be asked for. A screen that shows the arrow has to
+     * open something from onHeaderClick, and one that does not must not show it.
+     */
+    public TransactionCursorAdapter(ActionListener actionListener, boolean headerOpensReport) {
         super(null, Contract.Transaction.ID);
         mActionListener = actionListener;
+        mHeaderOpensReport = headerOpensReport;
         mMoneyFormatter = MoneyFormatter.getInstance();
     }
 
@@ -77,6 +90,8 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
         mIndexHeaderStartDate = cursor.getColumnIndex(TransactionHeaderCursor.COLUMN_HEADER_START_DATE);
         mIndexHeaderEndDate = cursor.getColumnIndex(TransactionHeaderCursor.COLUMN_HEADER_END_DATE);
         mIndexHeaderMoney = cursor.getColumnIndex(TransactionHeaderCursor.COLUMN_HEADER_MONEY);
+        mIndexHeaderIncome = cursor.getColumnIndex(TransactionHeaderCursor.COLUMN_HEADER_INCOME);
+        mIndexHeaderExpense = cursor.getColumnIndex(TransactionHeaderCursor.COLUMN_HEADER_EXPENSE);
         mIndexHeaderGroupType = cursor.getColumnIndex(TransactionHeaderCursor.COLUMN_HEADER_GROUP_TYPE);
         mIndexCategoryName = cursor.getColumnIndex(Contract.Transaction.CATEGORY_NAME);
         mIndexCategoryIcon = cursor.getColumnIndex(Contract.Transaction.CATEGORY_ICON);
@@ -118,14 +133,44 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
         Date end = DateUtils.getDateFromSQLDateTimeString(cursor.getString(mIndexHeaderEndDate));
         DateFormatter.applyDateRange(holder.mLeftTextView, start, end);
         Money money = Money.parse(cursor.getString(mIndexHeaderMoney));
-        mMoneyFormatter.applyTinted(holder.mRightTextView, money);
+        // untinted, because with the plus and minus setting off, which is the default, this
+        // class shows a sign on an amount it does not color and leaves the sign off one it
+        // does. A tinted difference printed 45.00 for a stretch that spent 45 and earned
+        // nothing, and left the color to say which way it went, on a line whose other two
+        // figures are colored whatever they hold
+        mMoneyFormatter.applyNotTinted(holder.mRightTextView, money);
+        Money income = Money.parse(cursor.getString(mIndexHeaderIncome));
+        Money expense = Money.parse(cursor.getString(mIndexHeaderExpense));
+        mMoneyFormatter.applyTintedIncome(holder.mIncomeTextView, orZero(income, money));
+        mMoneyFormatter.applyTintedExpense(holder.mExpenseTextView, orZero(expense, money));
+    }
+
+    /**
+     * The figure itself, or a zero in the currencies the difference was counted in when the
+     * figure holds none of its own. An amount with no currency in it renders as the placeholder
+     * for a value nobody knows, and a stretch that only spent has a known zero income.
+     *
+     * The zero is put here and not into the running totals because a figure that has rows of
+     * its own must not gain a currency it has none in, which is what putting it in the totals
+     * did. A figure with no rows at all still takes every currency the header counted, so on a
+     * header counting two it reads as two zeros and is cut off the way any long figure is.
+     */
+    /*package-local*/ static Money orZero(Money money, Money counted) {
+        if (money.getNumberOfCurrencies() > 0) {
+            return money;
+        }
+        Money zero = new Money();
+        for (String currency : counted.getCurrencies()) {
+            zero.addMoney(currency, 0);
+        }
+        return zero;
     }
 
     @Override
     public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
         if (viewType == TransactionHeaderCursor.TYPE_HEADER) {
-            View itemView = inflater.inflate(R.layout.adapter_header_item, parent, false);
+            View itemView = inflater.inflate(R.layout.adapter_transaction_header_item, parent, false);
             return new HeaderViewHolder(itemView);
         } else if (viewType == TransactionHeaderCursor.TYPE_ITEM){
             View itemView = inflater.inflate(R.layout.adapter_transaction_item, parent, false);
@@ -148,12 +193,26 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
 
         private TextView mLeftTextView;
         private TextView mRightTextView;
+        private TextView mIncomeTextView;
+        private TextView mExpenseTextView;
 
         /*package-local*/ HeaderViewHolder(View itemView) {
             super(itemView);
             mLeftTextView = itemView.findViewById(R.id.left_text_view);
             mRightTextView = itemView.findViewById(R.id.right_text_view);
-            itemView.setOnClickListener(this);
+            mIncomeTextView = itemView.findViewById(R.id.income_text_view);
+            mExpenseTextView = itemView.findViewById(R.id.expense_text_view);
+            // the arrow is a ThemedImageView, which tints itself from the row it sits on and
+            // repaints when the mode changes. A theme attribute in the vector would resolve
+            // against the xml theme, which is the light one whatever mode the user picked
+            itemView.findViewById(R.id.report_image_view)
+                    .setVisibility(mHeaderOpensReport ? View.VISIBLE : View.GONE);
+            if (mHeaderOpensReport) {
+                itemView.setOnClickListener(this);
+            } else {
+                // no destination, so the row keeps its ripple to itself
+                itemView.setBackground(null);
+            }
         }
 
         @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransactionListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransactionListFragment.java
@@ -67,7 +67,8 @@ public class TransactionListFragment extends CursorListFragment implements Trans
 
     @Override
     protected AbstractCursorAdapter onCreateAdapter() {
-        return new TransactionCursorAdapter(this);
+        // the only one of the four that opens the report from a header click
+        return new TransactionCursorAdapter(this, true);
     }
 
     @Override

--- a/app/src/main/res/drawable/ic_chevron_right_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_chevron_right_black_24dp.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0"
+    android:autoMirrored="true">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,6L8.59,7.41 13.17,12l-4.58,4.59L10,18l6,-6z"/>
+</vector>

--- a/app/src/main/res/layout/adapter_transaction_header_item.xml
+++ b/app/src/main/res/layout/adapter_transaction_header_item.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="@dimen/material_component_lists_header_height"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:background="?attr/selectableItemBackground">
+
+    <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
+        android:id="@+id/left_text_view"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="@dimen/material_component_lists_header_start_margin"
+        android:layout_marginStart="@dimen/material_component_lists_header_start_margin"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textSize="@dimen/material_component_lists_header_text_size"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/right_text_view"
+        app:theme_textColor="textColorPrimary"
+        tools:text="August 1 - 31" />
+
+    <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
+        android:id="@+id/right_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:textSize="@dimen/material_component_lists_header_text_size"
+        app:layout_constraintTop_toTopOf="@+id/left_text_view"
+        app:layout_constraintEnd_toStartOf="@+id/report_image_view"
+        app:layout_goneMarginEnd="@dimen/material_component_lists_header_end_margin"
+        app:layout_goneMarginRight="@dimen/material_component_lists_header_end_margin"
+        app:theme_textColor="textColorPrimary"
+        tools:text="$ 600.00" />
+
+    <!--
+      The summary sits under whichever of the two above is taller. A total in several currencies
+      is one string with the amounts joined together, long enough to wrap, so the amount on the
+      right can run to more than one line and anchoring to the date range alone would let it be
+      drawn over.
+    -->
+    <androidx.constraintlayout.widget.Barrier
+        android:id="@+id/header_line_barrier"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:barrierDirection="bottom"
+        app:constraint_referenced_ids="left_text_view,right_text_view" />
+
+    <LinearLayout
+        android:id="@+id/summary_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:layout_marginLeft="@dimen/material_component_lists_header_start_margin"
+        android:layout_marginStart="@dimen/material_component_lists_header_start_margin"
+        android:layout_marginEnd="8dp"
+        android:layout_marginRight="8dp"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@+id/header_line_barrier"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/report_image_view"
+        app:layout_goneMarginEnd="@dimen/material_component_lists_header_end_margin"
+        app:layout_goneMarginRight="@dimen/material_component_lists_header_end_margin">
+
+        <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
+            android:id="@+id/income_label_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="4dp"
+            android:layout_marginRight="4dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/hint_incomes"
+            android:textSize="@dimen/material_component_lists_header_summary_text_size"
+            app:theme_textColor="textColorSecondary" />
+
+        <!--
+          Both amounts carry a weight so that a row too narrow for all four takes the room off
+          each of them and both ellipsize. Without one the last view in the row gets only what
+          the others left, which is nothing, and the expense went missing with no ellipsis to
+          say so.
+
+          ponytail: the weight is also what splits any room left over, so at an ordinary width
+          each amount sits in half the line with its text at the start. And the two labels are
+          not weighted, so a locale whose words are long enough to fill the line on their own
+          takes the room off the amounts first. Both want a constraint chain instead of a row.
+        -->
+        <TextView
+            android:id="@+id/income_text_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="12dp"
+            android:layout_marginRight="12dp"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textSize="@dimen/material_component_lists_header_summary_text_size"
+            tools:text="$ 120.00" />
+
+        <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
+            android:id="@+id/expense_label_text_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="4dp"
+            android:layout_marginRight="4dp"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/hint_expenses"
+            android:textSize="@dimen/material_component_lists_header_summary_text_size"
+            app:theme_textColor="textColorSecondary" />
+
+        <TextView
+            android:id="@+id/expense_text_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textSize="@dimen/material_component_lists_header_summary_text_size"
+            tools:text="$ 720.00" />
+
+    </LinearLayout>
+
+    <com.oriondev.moneywallet.ui.view.theme.ThemedImageView
+        android:id="@+id/report_image_view"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginRight="@dimen/material_component_lists_header_end_margin"
+        android:layout_marginEnd="@dimen/material_component_lists_header_end_margin"
+        android:contentDescription="@string/description_show_period_report"
+        android:src="@drawable/ic_chevron_right_black_24dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:theme_backgroundColor="colorWindowForeground" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/descriptions.xml
+++ b/app/src/main/res/values/descriptions.xml
@@ -44,4 +44,5 @@
     <string name="description_show_subcategories">"Show subcategories of %1$s"</string>
     <string name="description_hide_subcategories">"Hide subcategories of %1$s"</string>
     <string name="description_day_has_transactions">"Has transactions"</string>
+    <string name="description_show_period_report">"Show the report for this period"</string>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -90,6 +90,7 @@
     <dimen name="material_component_lists_header_start_margin">16dp</dimen>
     <dimen name="material_component_lists_header_end_margin">16dp</dimen>
     <dimen name="material_component_lists_header_text_size">14sp</dimen>
+    <dimen name="material_component_lists_header_summary_text_size">12sp</dimen>
 
     <dimen name="material_component_lists_card_top_layout_height">64dp</dimen>
     <dimen name="material_component_lists_card_start_margin">8dp</dimen>

--- a/app/src/test/java/com/oriondev/moneywallet/storage/wrapper/TransactionHeaderMoneyTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/storage/wrapper/TransactionHeaderMoneyTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.storage.wrapper;
+
+import com.oriondev.moneywallet.model.Group;
+import com.oriondev.moneywallet.storage.database.Contract;
+
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A group header on the transactions list carries three figures now, what came in, what went out
+ * and the difference. The first two are what a reader compares, so neither may cancel against the
+ * other, and the third has to stay the difference of them or the header contradicts itself.
+ *
+ * Group.DAILY is used throughout because the other groupings ask PreferenceManager for the first
+ * day of the week or the month, which needs a running app. The arithmetic under test does not
+ * depend on which grouping built the header.
+ */
+public class TransactionHeaderMoneyTest {
+
+    private static final String USD = "USD";
+
+    private TransactionHeaderCursor.Header header() {
+        Date date = new Date(0);
+        return new TransactionHeaderCursor.Header(Group.DAILY, null, null, date);
+    }
+
+    @Test
+    public void incomeAndExpenseAreBothPositiveAndTheTotalIsTheDifference() {
+        TransactionHeaderCursor.Header header = header();
+        header.add(USD, 120000, Contract.Direction.INCOME);
+        header.add(USD, 45000, Contract.Direction.INCOME);
+        header.add(USD, 60000, Contract.Direction.EXPENSE);
+        header.add(USD, 4000, Contract.Direction.EXPENSE);
+        assertEquals(165000, header.getIncome().getMoney(USD));
+        assertEquals(64000, header.getExpense().getMoney(USD));
+        assertEquals(101000, header.getMoney().getMoney(USD));
+    }
+
+    @Test
+    public void spendingMoreThanCameInLeavesTheTotalNegativeAndTheOtherTwoUntouched() {
+        TransactionHeaderCursor.Header header = header();
+        header.add(USD, 1000, Contract.Direction.INCOME);
+        header.add(USD, 3000, Contract.Direction.EXPENSE);
+        assertEquals(1000, header.getIncome().getMoney(USD));
+        assertEquals(3000, header.getExpense().getMoney(USD));
+        assertEquals(-2000, header.getMoney().getMoney(USD));
+    }
+
+    /**
+     * A figure counts only the rows going its own way, so the other one is left holding no
+     * currency at all. What the screen does with that is TransactionCursorAdapter.orZero, and
+     * this is the half of it the header owes: a currency here would be one nobody spent or
+     * earned, and on a header counting two currencies it would be a second amount to read.
+     */
+    @Test
+    public void aHeaderOfExpensesOnlyLeavesTheIncomeHoldingNothing() {
+        TransactionHeaderCursor.Header header = header();
+        header.add(USD, 4500, Contract.Direction.EXPENSE);
+        assertEquals(0, header.getIncome().getNumberOfCurrencies());
+        assertEquals(4500, header.getExpense().getMoney(USD));
+        assertEquals(-4500, header.getMoney().getMoney(USD));
+    }
+
+    @Test
+    public void aHeaderOfIncomeOnlyLeavesTheExpenseHoldingNothing() {
+        TransactionHeaderCursor.Header header = header();
+        header.add(USD, 4500, Contract.Direction.INCOME);
+        assertEquals(0, header.getExpense().getNumberOfCurrencies());
+        assertEquals(4500, header.getIncome().getMoney(USD));
+        assertEquals(4500, header.getMoney().getMoney(USD));
+    }
+
+    @Test
+    public void currenciesAreKeptApart() {
+        TransactionHeaderCursor.Header header = header();
+        header.add(USD, 1000, Contract.Direction.INCOME);
+        header.add("EUR", 700, Contract.Direction.EXPENSE);
+        assertEquals(1000, header.getIncome().getMoney(USD));
+        assertEquals(0, header.getIncome().getMoney("EUR"));
+        assertEquals(700, header.getExpense().getMoney("EUR"));
+        assertEquals(1000, header.getMoney().getMoney(USD));
+        assertEquals(-700, header.getMoney().getMoney("EUR"));
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/adapter/recycler/HeaderZeroFigureTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/adapter/recycler/HeaderZeroFigureTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.adapter.recycler;
+
+import com.oriondev.moneywallet.model.Money;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A stretch that only spent counts no income at all, and an amount holding no currency renders as
+ * the placeholder for a value nobody knows. On a line labelled "Incomes" that reads as unknown
+ * when the answer is a plain zero, so the screen substitutes one.
+ *
+ * What the substitution must not do is invent a currency. The zero is taken from the currencies
+ * the difference was counted in, and a figure that has rows of its own is handed back untouched,
+ * so a header counting two currencies never grows a zero for the one a figure has no rows in.
+ */
+public class HeaderZeroFigureTest {
+
+    private static final String USD = "USD";
+    private static final String EUR = "EUR";
+
+    /**
+     * The contents are what this asserts on, not the identity. Handing the caller its own object
+     * back would satisfy an identity check while quietly adding the zero to it, and returning a
+     * copy that left the contents alone would fail one while being perfectly correct.
+     */
+    @Test
+    public void aFigureWithRowsOfItsOwnIsHandedBackUnchanged() {
+        Money income = new Money(USD, 4500);
+        Money counted = new Money(USD, 4500);
+        Money result = TransactionCursorAdapter.orZero(income, counted);
+        assertEquals(income.getCurrencyMoneys(), result.getCurrencyMoneys());
+        assertEquals(4500, result.getMoney(USD));
+    }
+
+    /**
+     * The currency has to be asserted by name. Money.getMoney answers zero for a currency it has
+     * never heard of, so asking it what it holds for one cannot tell a zero apart from an absence
+     * and would pass on a figure carrying some other currency entirely.
+     */
+    @Test
+    public void anEmptyFigureBecomesAZeroInTheCurrencyThatWasCounted() {
+        Money counted = new Money(USD, -4500);
+        Money zero = TransactionCursorAdapter.orZero(new Money(), counted);
+        assertEquals(1, zero.getNumberOfCurrencies());
+        assertTrue(zero.getCurrencies().contains(USD));
+        assertEquals(0, zero.getMoney(USD));
+    }
+
+    @Test
+    public void anEmptyFigureTakesEveryCurrencyTheDifferenceWasCountedIn() {
+        Money counted = new Money(USD, -4500);
+        counted.addMoney(EUR, -700);
+        Money zero = TransactionCursorAdapter.orZero(new Money(), counted);
+        assertEquals(2, zero.getNumberOfCurrencies());
+        assertTrue(zero.getCurrencies().contains(USD));
+        assertTrue(zero.getCurrencies().contains(EUR));
+        assertEquals(0, zero.getMoney(USD));
+        assertEquals(0, zero.getMoney(EUR));
+    }
+
+    /**
+     * The case the zero is deliberately not extended to. A figure holding one of the two
+     * currencies keeps only that one, so the line stays as short as the rows make it.
+     */
+    @Test
+    public void aFigureHoldingOneOfTwoCurrenciesDoesNotGainTheOther() {
+        Money income = new Money(EUR, 70000);
+        Money counted = new Money(USD, -4500);
+        counted.addMoney(EUR, 70000);
+        Money result = TransactionCursorAdapter.orZero(income, counted);
+        assertEquals(1, result.getNumberOfCurrencies());
+        assertTrue(result.getCurrencies().contains(EUR));
+    }
+
+    @Test
+    public void nothingCountedAtAllStaysUnknown() {
+        Money zero = TransactionCursorAdapter.orZero(new Money(), new Money());
+        assertEquals(0, zero.getNumberOfCurrencies());
+    }
+}


### PR DESCRIPTION
The transactions list groups its rows under a date range, and that
heading carried one number, the difference between what you earned and
what you spent over those days. Two months with nothing in common can
land on the same difference, so the number you see most often was the one
telling you least, and the two figures you actually want to compare were
only reachable by opening the report for that stretch.

The heading now carries both of them on a second line, each behind a
word, so what tells them apart is not only the color. A stretch that only
spent shows a zero for what came in, not a dash.

The difference itself now shows its own sign. A month that spent 45 and
earned nothing used to read 45.00 and leave the color to tell you it went
out, which is fine on its own and reads as wrong sitting directly above
the 0.00 and the 45.00 it is made from.

Tapping that heading has always opened the report for those days and has
never said so. It now ends in an arrow, on the one screen where the tap
leads somewhere. On the screens where tapping a heading does nothing, and
there is one, the arrow stays away and the heading also stops pretending
to be tappable.

The debts and transfers lists share the old heading and are untouched.

Tested on an emulator against figures added up by hand, and on a wallet
group holding two currencies, where each figure lists only the currencies
it has rows in. Checked in the light theme and in both dark ones,
including switching between them with the list already open, and at the
largest system text size.
