### PR TITLE
Bump to 1.6.0, versionCode 84

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This fork is independent and is not endorsed by or affiliated with the original 
 ![Showcase](pictures/showcase.png)
 
 ## Status
-Tallybook is published on F-Droid and actively maintained. The current version in this repository is **1.5.0**, so F-Droid may show an older one.
+Tallybook is published on F-Droid and actively maintained. The current version in this repository is **1.6.0**, so F-Droid may show an older one.
 
-1.5.0 fixes Android's own backup, which stored nothing, so a restore brought back an empty app. It also lets you start a transaction from a person's screen with that person already attached, and clears a run of money, color and import bugs. Before that: 1.4.0 added duplicating a transaction and hiding a category's child categories, then WebDAV backup (1.1.0), a per app language setting (1.2.0), and a map you can point at any tile server (1.3.0).
+1.6.0 lets a budget repeat, says what came in and what went out on a transactions list, and marks the days that have transactions in the calendar day strip. It also stops a search result opening the editor instead of the transaction, keeps the calendar on the day you picked, and checks a saving withdraw against what the goal will hold. Before that: 1.5.0 fixed Android's own backup, which stored nothing, so a restore brought back an empty app, and 1.4.0 added duplicating a transaction and hiding a category's child categories, after WebDAV backup (1.1.0), a per app language setting (1.2.0), and a map you can point at any tile server (1.3.0).
 
 Earlier work, all shipped: Android 14/15 compatibility on a modernized FOSS/OpenStreetMap build, the Android 12+ manifest and PendingIntent updates, a fix for the startup crash caused by a legacy auto-backup path (reported upstream as [#177](https://github.com/AndreAle94/moneywallet/issues/177) and [#286](https://github.com/AndreAle94/moneywallet/issues/286)), the rebrand to a new name and application id, a verified backup and restore migration path (see [MIGRATION.md](MIGRATION.md)), export and import under scoped storage, a local-folder backup option that works with file sync tools, and Android 15 edge-to-edge UI polish.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -35,8 +35,8 @@ android {
         applicationId "io.github.herrerad85.tallybook"
         minSdk 24
         targetSdk 35
-        versionCode 83
-        versionName "1.5.0"
+        versionCode 84
+        versionName "1.6.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments clearPackageData: 'true'
         multiDexEnabled true

--- a/app/src/main/res/xml/changelog.xml
+++ b/app/src/main/res/xml/changelog.xml
@@ -20,6 +20,22 @@
 
 <changelog>
 
+    <version versionName="1.6.0" versionDate="Aug 26, 2026">
+        <change>[b]New![/b] A budget can repeat, opening its next period on its own when the one before it ends.</change>
+        <change>[b]New![/b] A transactions list says what came in and what went out over the period it is showing.</change>
+        <change>[b]New![/b] The calendar day strip marks the days that have transactions.</change>
+        <change>Opening a search result shows the transaction, where before it opened the editor.</change>
+        <change>The calendar keeps the day you picked, and shows which day that is when it is not today.</change>
+        <change>The calendar no longer lands on 1 January of the year before the one you asked for.</change>
+        <change>A detail panel survives a rotation on a screen wide enough to change how many panels fit.</change>
+        <change>Editing a debt's master transaction moves the debt with it.</change>
+        <change>A saving's deposit or withdraw no longer lets you move it to another wallet.</change>
+        <change>A saving refuses a withdraw larger than what the goal will hold, not just larger than what it holds today.</change>
+        <change>Restoring a backup opens the app on your ledger instead of the welcome screen.</change>
+        <change>Text is mirrored in a right to left layout in the places it was still left aligned.</change>
+        <change>Corrected the French wording shown after an import and in the two backup success messages.</change>
+    </version>
+
     <version versionName="1.5.0" versionDate="Aug 22, 2026">
         <change>[b]New![/b] Start a transaction from a person's screen with that person already attached.</change>
         <change>Android's own backup stored nothing, so a restore brought back an empty app. It now carries the ledger.</change>

--- a/fastlane/metadata/android/en-US/changelogs/84.txt
+++ b/fastlane/metadata/android/en-US/changelogs/84.txt
@@ -1,0 +1,3 @@
+New: a budget can repeat, opening its next period on its own. A transactions list says what came in and what went out. The calendar day strip marks the days that have transactions.
+
+Fixes: opening a search result shows the transaction, not the editor. The calendar keeps the day you picked, and no longer lands on 1 January of the wrong year. A saving refuses a withdraw larger than what the goal will hold. Restoring a backup opens the app on your ledger.


### PR DESCRIPTION
Bumps the version for the next release and adds its changelog entry.

Seventeen commits since the last tag. The changelog names thirteen things a person using the app would notice, three of them new: a budget that repeats on its own, a transactions list that says what came in and what went out, and a calendar day strip that marks the days holding transactions.

Three commits are deliberately not in the changelog. One is documentation. The other two fix a repeating budget that has never shipped, so there is nothing there a user could have noticed go wrong.

The store changelog is 457 bytes against the 500 allowed, and the store description is unchanged, since nothing shipping here changes what it says.

The build is green and reads back as version 1.6.0. The in app changelog was opened on a phone and renders all thirteen entries. Two clean unsigned release builds of this tree came out byte identical, so the toolchain is still deterministic.
