### PR TITLE
Stop a withdrawal dated before its deposit taking a goal below zero

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -1804,25 +1804,22 @@ public class SQLDatabaseTest {
     }
 
     /**
-     * A saving's progress counts only the rows that have landed, which is what the savings list
-     * adds to its start money to show. Its projected progress counts every withdrawal it has and
-     * only the deposits that are confirmed, whatever their dates. An unconfirmed deposit is in
-     * neither, because landing takes being confirmed and it never does.
+     * A saving's progress counts only the rows that have landed, which is confirmed and dated at
+     * or before this moment, and it is what the savings list adds to its start money to show.
      *
-     * The saving here carries a deposit and a withdrawal of each kind the two rules can tell
-     * apart, which separates the two sums from the rules they are most likely to be rewritten
-     * into: counting the unconfirmed deposit, dropping the unconfirmed withdrawal, putting a date
-     * test on the projected rule, on either half of it or on the whole, narrowing the landed test
-     * to deposits, dropping either half of it, or copying one sum onto the other all give
-     * something else. It is those cases and not every rule that could be written: a rewrite that
-     * lands on the same two figures for this saving goes through.
+     * The saving here carries a row of every kind that rule has to leave out, which separates it
+     * from the rules it is most likely to be rewritten into: dropping the date test, dropping
+     * the confirmed test, narrowing it to deposits, or counting every row the saving has all
+     * give something else. It is those cases and not every rule that could be written, so a
+     * rewrite landing on the same figure for this saving goes through.
      *
-     * This pins the two sums apart. It says nothing about the ceilings the editor works out of
-     * them, and neither sum carries any date order, so it is not a check that the saving stays
-     * above zero at every moment in between.
+     * This pins one sum. It says nothing about the ceiling the transaction editor holds a
+     * withdrawal to, which is worked out there over the rows in date order, and the sum here
+     * carries no date order, so it is not a check that the saving stays above zero at every
+     * moment.
      */
     @Test
-    public void savingProjectedProgressCountsRowsTheProgressLeavesOut() throws Exception {
+    public void savingProgressCountsOnlyTheRowsThatHaveLanded() throws Exception {
         long wallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 0L, false, "tag-wallet-1");
         long saving = insertSaving("desc-1", "encoded-icon", 0L, 10000L, wallet, null, false, "note-1", "tag-1");
         long deposit = getSystemCategory(Contract.CategoryTag.SAVING_DEPOSIT);
@@ -1830,30 +1827,29 @@ public class SQLDatabaseTest {
         Calendar calendar = Calendar.getInstance();
         calendar.add(Calendar.MONTH, 1);
         Date nextMonth = calendar.getTime();
-        // Landed, so both sums count them: a confirmed deposit of 1000 and a confirmed
-        // withdrawal of 100, both dated now. The withdrawal is the only row either sum counts
-        // negatively while it is landed, so without it the progress cannot tell a rule that
-        // counts every landed row from one that counts only landed deposits.
+        // Landed, so the progress counts them: a confirmed deposit of 1000 and a confirmed
+        // withdrawal of 100, both dated now. The withdrawal is the only landed row counted
+        // negatively, so without it the progress cannot tell a rule that counts every landed row
+        // from one that counts only landed deposits.
         insertTransaction(1000, new Date(), null, deposit, Contract.Direction.EXPENSE, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, true, true, null, null, "tag");
         insertTransaction(100, new Date(), null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, true, true, null, null, "tag");
-        // Only the projected sum: a confirmed deposit of 400 dated next month, the row that
-        // stops a date test on the projected rule reading the same as the rule itself.
+        // Left out by the date alone, one on each side: a confirmed deposit of 400 and a
+        // confirmed withdrawal of 300, both dated next month. Without them a rule with no date
+        // test at all reads the same as this one.
         insertTransaction(400, nextMonth, null, deposit, Contract.Direction.EXPENSE, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, true, true, null, null, "tag");
-        // Only the projected sum again: a confirmed withdrawal of 300 dated next month, an
-        // unconfirmed withdrawal of 200 dated now, and an unconfirmed withdrawal of 50 dated next
-        // month. The last one is the drain the projected sum is most pessimistic about, and it is
-        // the only row that separates the rule from one that counts withdrawals only once they
-        // have landed.
         insertTransaction(300, nextMonth, null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, true, true, null, null, "tag");
+        // Left out by the confirmed test alone, one on each side: an unconfirmed withdrawal of
+        // 200 and an unconfirmed deposit of 500, both dated now. Without them a rule that counts
+        // every row dated at or before now reads the same as this one.
         insertTransaction(200, new Date(), null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, false, true, null, null, "tag");
-        insertTransaction(50, nextMonth, null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, false, true, null, null, "tag");
-        // In neither: an unconfirmed deposit of 500, which never lands.
         insertTransaction(500, new Date(), null, deposit, Contract.Direction.EXPENSE, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, false, true, null, null, "tag");
+        // Left out by both, an unconfirmed withdrawal of 50 dated next month, so a rule that
+        // drops one test still has to drop the other to reach it.
+        insertTransaction(50, nextMonth, null, withdraw, Contract.Direction.INCOME, Contract.TransactionType.SAVING, wallet, null, null, null, saving, null, false, true, null, null, "tag");
 
         Cursor cursor = mDatabase.getSavings(null, null, null, null);
         assertEquals(true, cursor.moveToFirst());
         assertEquals(900L, cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS)));
-        assertEquals(750L, cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROJECTED_PROGRESS)));
         cursor.close();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
@@ -334,6 +334,55 @@ public class Contract {
                 ? budgetUUID.substring(0, separator) : budgetUUID;
     }
 
+    /**
+     * The lowest a saving's balance reaches from a given moment onwards, over the rows it
+     * already carries. A withdrawal dated at that moment can take at most this, because taking
+     * more puts the saving under zero on some date at or after it.
+     *
+     * A saving's own sum cannot answer that. It is a total over the whole set of rows and holds
+     * no date order, so a withdrawal dated before the deposit that funds it clears it and the
+     * saving sits under zero in between.
+     *
+     * dates and signedMoney describe the same rows in the same positions, ordered by date
+     * ascending. A deposit is positive and a withdrawal negative. A deposit that is not
+     * confirmed belongs in neither array; a withdrawal belongs in them whether it is confirmed
+     * or not. The caller orders on the raw date column and this compares those
+     * same strings, so the two orders are one order, and a date this app writes is a fixed width
+     * yyyy-MM-dd HH:mm:ss whose byte order is its time order.
+     *
+     * The answer can be negative, which says the saving is already under zero on some date from
+     * here on and has nothing at all to give. A caller deciding what a withdrawal may take holds
+     * it at zero itself.
+     *
+     * @param startMoney the saving's start money.
+     * @param dates the date of each row, ascending.
+     * @param signedMoney what each row moves the saving by, in the same positions.
+     * @param from the moment to count from, as a date string of the same kind.
+     * @return the lowest balance the saving reaches at or after from.
+     */
+    public static long lowestSavingBalanceFrom(long startMoney, String[] dates,
+                                               long[] signedMoney, String from) {
+        long balance = startMoney;
+        int row = 0;
+        while (row < dates.length && dates[row].compareTo(from) <= 0) {
+            balance += signedMoney[row];
+            row++;
+        }
+        long lowest = balance;
+        for (; row < dates.length; row++) {
+            balance += signedMoney[row];
+            // Only at the end of a run of rows sharing a date. The balance part way through
+            // such a run is not one the saving ever holds, and the order inside the run is
+            // whatever the query gives back, so comparing there both invents a low point and
+            // makes the answer depend on that order.
+            if ((row + 1 == dates.length || !dates[row + 1].equals(dates[row]))
+                    && balance < lowest) {
+                lowest = balance;
+            }
+        }
+        return lowest;
+    }
+
     public static final class Saving {
         public static final String ID = Schema.Saving.ID;
         public static final String DESCRIPTION = Schema.Saving.DESCRIPTION;
@@ -351,7 +400,6 @@ public class Contract {
         public static final String COMPLETE = Schema.Saving.COMPLETE;
         public static final String NOTE = Schema.Saving.NOTE;
         public static final String PROGRESS = "saving_" + Schema.Alias.PROGRESS;
-        public static final String PROJECTED_PROGRESS = "saving_" + Schema.Alias.PROJECTED_PROGRESS;
         public static final String TAG = Schema.Saving.TAG;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -3283,28 +3283,16 @@ import java.util.UUID;
      * @return a cursor with zero or more rows.
      */
     /*package-local*/ Cursor getSavings(String[] projection, String selection, String[] selectionArgs, String sortOrder) {
-        // A saving carries two sums over the same set of rows, its deposits and its withdrawals.
-        // Its progress counts only the confirmed ones dated at or before this moment, so with the
-        // start money added it is what the saving holds now, and it is the sum the savings list
-        // draws its current amount from. A row dated later today is not one of them.
+        // A saving's progress sums its deposits and its withdrawals, counting only the confirmed
+        // ones dated at or before this moment, so with the start money added it is what the
+        // saving holds now, and it is the sum the savings list draws its current amount from. A
+        // row dated later today is not one of them.
         //
-        // Its projected progress counts every withdrawal the saving has and every deposit that is
-        // confirmed, whatever their dates. With the start money added it is the lowest the saving
-        // can end up at once everything already on it has happened. Each side of that rule is the
-        // pessimistic one. An unconfirmed deposit is left out because it never lands, since
-        // landing takes being confirmed, so counting it would let money that has not arrived pay
-        // for a withdrawal that does. An unconfirmed withdrawal is counted for the mirror reason,
-        // and not because it is any likelier to happen: leaving it out would hand out a ceiling
-        // it can then take the saving under.
-        //
-        // Both are built from the one signedMoney expression below, so the two can never disagree
-        // about the sign of a row.
-        //
-        // Neither is a balance at a date in between, and the saving is not bounded between the
-        // two either. Both are totals with no date order in them, so a saving carrying rows on
-        // both sides can dip under zero on a date where neither sum says so: a withdrawal dated
-        // tomorrow against a deposit dated next month leaves both sums at zero and the saving
-        // under from tomorrow.
+        // It is a total and it holds no date order, so it says nothing about what the saving is
+        // worth on any other date. A withdrawal dated before the deposit that funds it leaves
+        // this sum where it was and takes the saving under zero in between. The transaction
+        // editor works that out for itself, walking the saving's rows in date order, and this
+        // sum is not the figure it holds a withdrawal to.
         //
         // The confirmed and date test used to sit in the WHERE and now sits in the CASE, so a
         // saving with rows but none of them in the progress produces a group row where it
@@ -3317,8 +3305,6 @@ import java.util.UUID;
                 Schema.Transaction.MONEY + ")";
         String landed = Schema.Transaction.CONFIRMED + " = 1 AND DATETIME(" +
                 Schema.Transaction.DATE + ") <= DATETIME('now', 'localtime')";
-        String counted = Schema.Transaction.DIRECTION + " = " + Schema.Direction.INCOME +
-                " OR " + Schema.Transaction.CONFIRMED + " = 1";
         String subQuery = "SELECT " +
                 Schema.Saving.ID + " AS " + Contract.Saving.ID + ", " +
                 Schema.Saving.DESCRIPTION + " AS " + Contract.Saving.DESCRIPTION + ", " +
@@ -3336,13 +3322,11 @@ import java.util.UUID;
                 Schema.Saving.COMPLETE + " AS " + Contract.Saving.COMPLETE + ", " +
                 Schema.Saving.NOTE + " AS " + Contract.Saving.NOTE + ", " +
                 Schema.Saving.TAG + " AS " + Contract.Saving.TAG + ", " +
-                "_progress AS " + Contract.Saving.PROGRESS + ", " +
-                "_projected_progress AS " + Contract.Saving.PROJECTED_PROGRESS +
+                "_progress AS " + Contract.Saving.PROGRESS +
                 " FROM " + Schema.Saving.TABLE +
                 " AS s LEFT JOIN " + Schema.Wallet.TABLE + " ON " + Schema.Saving.WALLET + " = " +
                 Schema.Wallet.ID + " LEFT JOIN (SELECT " + Schema.Transaction.SAVING + " AS _saving, " +
-                " SUM(CASE WHEN " + landed + " THEN " + signedMoney + " ELSE 0 END) AS _progress, " +
-                " SUM(CASE WHEN " + counted + " THEN " + signedMoney + " ELSE 0 END) AS _projected_progress" +
+                " SUM(CASE WHEN " + landed + " THEN " + signedMoney + " ELSE 0 END) AS _progress" +
                 " FROM " + Schema.Transaction.TABLE + " AS j LEFT JOIN " + Schema.Category.TABLE +
                 " ON " + Schema.Transaction.CATEGORY + " = " + Schema.Category.ID + " WHERE j." +
                 Schema.Transaction.DELETED + " = 0 AND (" + Schema.Category.TAG + " = '" +

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Schema.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Schema.java
@@ -40,7 +40,6 @@ package com.oriondev.moneywallet.storage.database;
     /*package-local*/ static final class Alias {
         /*package-local*/ static final String TOTAL_MONEY = "total_money";
         /*package-local*/ static final String PROGRESS = "progress";
-        /*package-local*/ static final String PROJECTED_PROGRESS = "projected_progress";
         /*package-local*/ static final String CATEGORY_GROUP_ID = "category_group_id";
         /*package-local*/ static final String CATEGORY_GROUP_NAME = "category_group_name";
         /*package-local*/ static final String CATEGORY_GROUP_INDEX = "category_group_index";

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -68,6 +68,7 @@ import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.MoneyFormatter;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -123,9 +124,6 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private static final String SS_DEBT_ID = "NewEditTransactionActivity::SavedState::DebtId";
     private static final String SS_SAVING_ID = "NewEditTransactionActivity::SavedState::SavingId";
     private static final String SS_SAVING_COMPLETED = "NewEditTransactionActivity::SavedState::SavingCompleted";
-    private static final String SS_SAVING_WITHDRAW_LIMIT = "NewEditTransactionActivity::SavedState::SavingWithdrawLimit";
-    private static final String SS_SAVING_WITHDRAW_LANDED_LIMIT = "NewEditTransactionActivity::SavedState::SavingWithdrawLandedLimit";
-    private static final String SS_SAVING_WITHDRAW_CURRENCY = "NewEditTransactionActivity::SavedState::SavingWithdrawCurrency";
 
     private TextView mCurrencyTextView;
     private TextView mMoneyTextView;
@@ -155,9 +153,6 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private Long mDebtId = null;
     private Long mSavingId = null;
     private boolean mSavingCompleted = false;
-    private Long mSavingWithdrawLimit = null;
-    private Long mSavingWithdrawLandedLimit = null;
-    private String mSavingWithdrawCurrency = null;
 
     private MoneyFormatter mMoneyFormatter = MoneyFormatter.getInstance();
 
@@ -462,24 +457,6 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                         }
                         mConfirmedCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) == 1);
                         mCountInTotalCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.COUNT_IN_TOTAL)) == 1);
-                        // A withdraw already in the database is being opened. Without a limit
-                        // here it can simply be edited upwards, which is the same bug by another
-                        // route. What it can grow to comes from the same two ceilings a new one
-                        // gets, each with this row's own amount added back to it, and each only
-                        // if that sum already counts this row.
-                        //
-                        // The projected sum counts it whatever its confirmed box and its date
-                        // say. The progress counts it only while it is confirmed and not dated
-                        // ahead, which is the same pair getSavings filters on, so adding it back
-                        // there for a row the progress never counted would hand out a ceiling too
-                        // high by exactly that amount.
-                        if (mSavingId != null && category != null
-                                && Contract.CategoryTag.SAVING_WITHDRAW.equals(category.getTag())) {
-                            boolean storedRowHasLanded = cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) == 1
-                                    && !DateUtils.getDateFromSQLDateTimeString(cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE))).after(new Date());
-                            loadSavingWithdrawLimits(contentResolver, mSavingId, money,
-                                    storedRowHasLanded ? money : 0L);
-                        }
                     }
                     cursor.close();
                 }
@@ -737,8 +714,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     }
                 } else if (mType == TYPE_SAVING) {
                     mSavingId = intent.getLongExtra(SAVING_ID, 0L);
-                    long landedMoney = 0L;
-                    long projectedMoney = 0L;
+                    long startMoney = 0L;
                     // getItemId is the id of the transaction being edited, and this branch only
                     // runs when there is no transaction yet, so it was always the -1 assigned for
                     // a new item. That built the uri savings/-1, which matches no route in the
@@ -747,31 +723,18 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     // against: it read the typed digits as minor units and 2000 became 20.00.
                     // Load the saving the intent names, the way the debt branch above loads its
                     // debt.
-                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
+                    Uri savingUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
                     String[] projection = new String[] {
                             Contract.Saving.START_MONEY,
-                            Contract.Saving.PROGRESS,
-                            Contract.Saving.PROJECTED_PROGRESS,
                             Contract.Saving.WALLET_ID,
                             Contract.Saving.WALLET_NAME,
                             Contract.Saving.WALLET_ICON,
                             Contract.Saving.WALLET_CURRENCY
                     };
-                    Cursor cursor = contentResolver.query(uri, projection, null, null, null);
+                    Cursor cursor = contentResolver.query(savingUri, projection, null, null, null);
                     if (cursor != null) {
                         if (cursor.moveToFirst()) {
-                            // Two figures, because a withdraw can take a saving under zero at
-                            // two different moments. What it holds today is its start money plus
-                            // its progress, the same sum the savings list draws its current
-                            // amount from. The lowest it can end up at is its start money plus
-                            // its projected progress, which counts every withdraw it carries and
-                            // only the deposits that are confirmed. END_MONEY is the
-                            // target, and a saving can be deposited past its target, so the
-                            // target would strand the overshoot in a withdraw everything.
-                            landedMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY))
-                                    + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS));
-                            projectedMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY))
-                                    + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROJECTED_PROGRESS));
+                            startMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY));
                             wallet = new Wallet(
                                     cursor.getLong(cursor.getColumnIndex(Contract.Saving.WALLET_ID)),
                                     cursor.getString(cursor.getColumnIndex(Contract.Saving.WALLET_NAME)),
@@ -782,7 +745,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                         }
                         cursor.close();
                     }
-                    uri = DataContentProvider.CONTENT_CATEGORIES;
+                    Uri uri = DataContentProvider.CONTENT_CATEGORIES;
                     projection = new String[] {
                             Contract.Category.ID,
                             Contract.Category.NAME,
@@ -798,19 +761,22 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             selectionArgs[0] = Contract.CategoryTag.SAVING_DEPOSIT;
                             break;
                         case SAVING_WITHDRAW_EVERYTHING:
-                            // The row this writes opens dated now and confirmed, so it lands
-                            // today and both ceilings bind it. The smaller of the two is what
-                            // the saving can actually give, and prefilling anything above it
-                            // offers an amount this same screen then refuses. Moving the date
-                            // ahead or unticking Confirmed only drops the landed ceiling, and
-                            // the prefill is at or under the other one too.
+                            // The row this writes opens dated now, so what it can actually take
+                            // is the lowest the saving reaches from now onwards, which is the
+                            // same figure the check applies when the save is pressed. Prefilling
+                            // anything above it offers an amount this same screen then refuses.
+                            // END_MONEY is the target, and a saving can be deposited past its
+                            // target, so the target would strand the overshoot here.
                             //
                             // Never below zero either. A saving already carrying more
                             // withdrawals than it holds gives a negative figure here, and the
-                            // check below only refuses an amount above the ceiling, so the field
-                            // would open on a negative amount and saving it untouched would
-                            // write a withdraw of a negative amount.
-                            money = Math.max(Math.min(landedMoney, projectedMoney), 0L);
+                            // check on the way out only refuses an amount above the ceiling, so
+                            // the field would open on a negative amount and saving it untouched
+                            // would write a withdrawal of a negative amount. A saving whose rows
+                            // do not come back offers nothing for the same reason.
+                            Long lowest = readLowestSavingBalanceFrom(contentResolver, savingUri,
+                                    startMoney, DateUtils.getSQLDateTimeString(new Date()), -1L);
+                            money = lowest != null ? Math.max(lowest, 0L) : 0L;
                             mSavingCompleted = true;
                             // Deliberate fall through: withdraw everything needs the withdraw
                             // category set below. A break here, which is what an IDE inspection
@@ -818,12 +784,6 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             // crashes the editor as it opens: the bind value at index 1 is null.
                         case SAVING_WITHDRAW:
                             selectionArgs[0] = Contract.CategoryTag.SAVING_WITHDRAW;
-                            // Both figures are already in hand from the query above, so this
-                            // sets both ceilings from them instead of reading the same row
-                            // again. Nothing is added back to either: this row does not exist
-                            // yet, so neither sum can already be counting it.
-                            setSavingWithdrawLimits(projectedMoney, landedMoney, 0L, 0L,
-                                    wallet != null && wallet.getCurrency() != null ? wallet.getCurrency().getIso() : null);
                             break;
                     }
                     cursor = contentResolver.query(uri, projection, selection, selectionArgs, null);
@@ -921,24 +881,6 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             mDebtId = savedInstanceState.containsKey(SS_DEBT_ID) ? savedInstanceState.getLong(SS_DEBT_ID) : null;
             mSavingId = savedInstanceState.containsKey(SS_SAVING_ID) ? savedInstanceState.getLong(SS_SAVING_ID) : null;
             mSavingCompleted = savedInstanceState.getBoolean(SS_SAVING_COMPLETED, false);
-            // v1.5.0 wrote the first key alone, holding what the saving held today, so a bundle
-            // from it has no second key. Neither ceiling can be worked out again here, because
-            // both calls that build them run only when there is no bundle, so the landed one
-            // falls back to the other. That editor then holds one number, today's, and applies
-            // it to every withdraw. It is neither rule: v1.5.0 waved a row dated ahead through,
-            // and this build would bound it by what the saving ends up at, which can be lower or
-            // higher than today's.
-            //
-            // Written out instead of as a second conditional on purpose. A conditional whose
-            // arms are a long and a Long is a numeric one, so the Long arm is unboxed, and here
-            // that arm is a field that is null on every editor which is not a saving withdraw.
-            // As a conditional this line crashed the editor on rotation.
-            mSavingWithdrawLimit = savedInstanceState.containsKey(SS_SAVING_WITHDRAW_LIMIT) ? savedInstanceState.getLong(SS_SAVING_WITHDRAW_LIMIT) : null;
-            mSavingWithdrawLandedLimit = mSavingWithdrawLimit;
-            if (savedInstanceState.containsKey(SS_SAVING_WITHDRAW_LANDED_LIMIT)) {
-                mSavingWithdrawLandedLimit = savedInstanceState.getLong(SS_SAVING_WITHDRAW_LANDED_LIMIT);
-            }
-            mSavingWithdrawCurrency = savedInstanceState.getString(SS_SAVING_WITHDRAW_CURRENCY);
         }
         // depending on the type we must hide pickers that are now allowed to be changed
         switch (mType) {
@@ -1019,15 +961,6 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             outState.putLong(SS_SAVING_ID, mSavingId);
         }
         outState.putBoolean(SS_SAVING_COMPLETED, mSavingCompleted);
-        // Never the landed key without the other one. The restore above reads the landed key
-        // as an override on the projected one and falls back to it when there is none, and
-        // the check bails out entirely on a null projected ceiling, so a bundle carrying
-        // only the landed key would come back with no ceiling at all.
-        if (mSavingWithdrawLimit != null && mSavingWithdrawLandedLimit != null) {
-            outState.putLong(SS_SAVING_WITHDRAW_LIMIT, mSavingWithdrawLimit);
-            outState.putLong(SS_SAVING_WITHDRAW_LANDED_LIMIT, mSavingWithdrawLandedLimit);
-            outState.putString(SS_SAVING_WITHDRAW_CURRENCY, mSavingWithdrawCurrency);
-        }
     }
 
     @Override
@@ -1077,120 +1010,174 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     }
 
     /**
-     * Reads both of a saving's figures, the lowest it can end up at once everything already on
-     * it has happened and what it holds today, and remembers the currency they are in.
+     * The lowest a saving's balance reaches from a moment onwards, over the rows it already
+     * carries, or null when those rows do not come back at all.
      *
-     * alreadyTaken is what the row being edited is itself withdrawing, added back because the
-     * projected sum counts that row. alreadyTakenLanded is the same amount when the progress
-     * counts it too, which is while the stored row is confirmed and not dated ahead, and zero
-     * otherwise. A new withdraw has no stored row to add back and does not come through here; it
-     * sets its ceilings from the figures the saving branch of this screen has already read.
+     * They come back ordered on the raw date column, which is the order
+     * {@link Contract#lowestSavingBalanceFrom(long, String[], long[], String)} needs, and are
+     * held to the two saving categories so this walks the same rows the saving's own sums count.
+     * A deposit that is not confirmed is left out, because landing takes being confirmed and
+     * money that never arrives must not pay for a withdrawal that does. A withdrawal is counted
+     * whether it is confirmed or not, for the mirror reason, that leaving it out hands out a
+     * ceiling it can then take the saving under.
+     *
+     * excludedId names the row being edited, whose own drain has to come out before the walk or
+     * the row would be held against itself. A new row names nothing, since the id of a new item
+     * is minus one and no row carries it.
      */
-    private void loadSavingWithdrawLimits(ContentResolver contentResolver, long savingId,
-                                          long alreadyTaken, long alreadyTakenLanded) {
-        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, savingId);
+    private Long readLowestSavingBalanceFrom(ContentResolver contentResolver, Uri savingUri,
+                                             long startMoney, String from, long excludedId) {
         String[] projection = new String[] {
-                Contract.Saving.START_MONEY,
-                Contract.Saving.PROGRESS,
-                Contract.Saving.PROJECTED_PROGRESS,
-                Contract.Saving.WALLET_CURRENCY
+                Contract.Transaction.ID,
+                Contract.Transaction.DATE,
+                Contract.Transaction.MONEY,
+                Contract.Transaction.DIRECTION,
+                Contract.Transaction.CONFIRMED
+        };
+        String selection = Contract.Transaction.CATEGORY_TAG + " IN (?, ?)";
+        String[] selectionArgs = new String[] {
+                Contract.CategoryTag.SAVING_DEPOSIT,
+                Contract.CategoryTag.SAVING_WITHDRAW
+        };
+        Cursor cursor = contentResolver.query(Uri.withAppendedPath(savingUri, "transactions"),
+                projection, selection, selectionArgs, Contract.Transaction.DATE + " ASC");
+        if (cursor == null) {
+            return null;
+        }
+        String[] dates = new String[cursor.getCount()];
+        long[] signedMoney = new long[cursor.getCount()];
+        int rows = 0;
+        while (cursor.moveToNext()) {
+            if (cursor.getLong(cursor.getColumnIndex(Contract.Transaction.ID)) == excludedId) {
+                continue;
+            }
+            // A withdrawal is the income half of the pair, since it pays money into the wallet,
+            // and it is what takes the saving down.
+            boolean withdrawal = cursor.getInt(cursor.getColumnIndex(Contract.Transaction.DIRECTION))
+                    == Contract.Direction.INCOME;
+            if (!withdrawal && cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) != 1) {
+                continue;
+            }
+            long money = cursor.getLong(cursor.getColumnIndex(Contract.Transaction.MONEY));
+            dates[rows] = cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE));
+            signedMoney[rows] = withdrawal ? -money : money;
+            rows++;
+        }
+        cursor.close();
+        return Contract.lowestSavingBalanceFrom(startMoney, Arrays.copyOf(dates, rows),
+                Arrays.copyOf(signedMoney, rows), from);
+    }
+
+    /**
+     * Whether the row being edited is being kept or lowered on a date it does not move back
+     * from. Such a save takes nothing the saving is not already giving, so it is never refused.
+     *
+     * Without this, two withdrawals that already have a saving under zero would freeze each
+     * other, since neither can be lowered while the other one alone is more than the saving
+     * holds, and deleting one would be the only way out. Moving a stored row earlier is a new
+     * drain on the dates it moves across and is held to the ceiling like any other.
+     *
+     * A new row answers false, since there is no stored row to compare with.
+     */
+    private boolean isStoredWithdrawalKeptOrLowered(ContentResolver contentResolver, long money,
+                                                    String date) {
+        if (getMode() != Mode.EDIT_ITEM) {
+            return false;
+        }
+        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS, getItemId());
+        String[] projection = new String[] {
+                Contract.Transaction.MONEY,
+                Contract.Transaction.DATE
         };
         Cursor cursor = contentResolver.query(uri, projection, null, null, null);
+        boolean unchangedOrSmaller = false;
         if (cursor != null) {
             if (cursor.moveToFirst()) {
-                long startMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY));
-                setSavingWithdrawLimits(
-                        startMoney + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROJECTED_PROGRESS)),
-                        startMoney + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS)),
-                        alreadyTaken,
-                        alreadyTakenLanded,
-                        cursor.getString(cursor.getColumnIndex(Contract.Saving.WALLET_CURRENCY)));
+                unchangedOrSmaller = money <= cursor.getLong(cursor.getColumnIndex(Contract.Transaction.MONEY))
+                        && date.compareTo(cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE))) >= 0;
             }
             cursor.close();
         }
+        return unchangedOrSmaller;
     }
 
     /**
-     * Two ceilings, because one number cannot say both things. A withdraw must not take the
-     * saving under zero once everything already on it has happened, which is what the projected
-     * sum bounds, and a withdraw already counted in today's figure must not take it under zero
-     * today, which is what the progress bounds. Bounding only the first lets a deposit dated
-     * ahead pay for a withdraw taken now; bounding only the second lets a withdraw dated ahead
-     * land on a saving that cannot cover it.
+     * A withdrawal must not take the saving under zero on its own date, nor on any date after
+     * it. What it may take is therefore the lowest the balance reaches from its date onwards,
+     * counted over the saving's rows in date order.
      *
-     * Each ceiling is held at the term added back to it, since a saving that is under zero gives
-     * a negative one and that would refuse every save of the row, including lowering the amount
-     * or correcting the note. A row both sums already count gets its own amount added back to
-     * both, so it can always be kept or reduced. A stored row the progress does not count gets
-     * nothing added back to the landed ceiling, which is a different case on purpose:
-     * confirming it and dating it today adds a drain today's figure has never carried, so it is
-     * held to today's figure like any other new drain and can be refused at its own amount.
+     * That replaces the two totals this used to hold, what the saving holds today and the lowest
+     * it can end up at once everything already on it has happened. A total carries no date order
+     * and neither of them said anything about the dates in between, so a withdrawal dated before
+     * the deposit that funds it cleared both and left the saving under zero for the days between
+     * the two.
      *
-     * For a new row both terms are zero, so the floor is zero.
-     */
-    private void setSavingWithdrawLimits(long projectedHeld, long landedHeld, long alreadyTaken,
-                                         long alreadyTakenLanded, String currencyIso) {
-        mSavingWithdrawLimit = Math.max(projectedHeld + alreadyTaken, alreadyTaken);
-        mSavingWithdrawLandedLimit = Math.max(landedHeld + alreadyTakenLanded, alreadyTakenLanded);
-        mSavingWithdrawCurrency = currencyIso;
-    }
-
-    /**
-     * A withdraw cannot take the saving under zero today, nor once everything already on it has
-     * happened, which counts every withdraw it carries and only the deposits that are confirmed.
-     * Those are two moments and not every moment between them: the sums behind them are totals
-     * and carry no date order, so a withdraw dated before a deposit that funds it still passes
-     * and the saving dips under zero in between.
+     * The figures are read here and not when the editor opened, because the answer depends on
+     * the date on screen and that date is still being chosen while the editor is up. It is still
+     * only a check on the way in. Whatever pays for a withdrawal can be lowered, deleted,
+     * unconfirmed or dated later afterwards, or from another screen while this one waits, with
+     * nothing refused, and the saving's own start money is editable on its own screen.
      *
-     * This is a check on the way in and only on a withdraw, against figures read once when the
-     * editor opened. They are not read again, not even across a rotation, where the pair comes
-     * back out of the bundle. So a withdraw is measured against the saving as it stood when the
-     * screen opened, and anything that pays for it can be taken away either before the save,
-     * from another screen while this one waits, or afterwards, with nothing refused: the deposit
-     * it was allowed against can be lowered, deleted, unconfirmed or dated ahead, and the
-     * saving's own start money is editable on its own screen.
+     * The check runs on a withdrawal alone, so a deposit and an ordinary transaction are
+     * unaffected. It steps aside for a wallet on screen whose currency the saving's figures
+     * cannot be compared with, for a saving whose own currency the app cannot resolve, which a
+     * restored backup can produce, and for a saving whose rows do not come back.
      *
-     * The ceilings are loaded whenever the editor opens on a withdraw, whether that is a new one
-     * from the savings list or one already in the database, and stay null everywhere else, so a
-     * deposit and an ordinary transaction are unaffected. Loaded is not the same as enforced: the
-     * currency test below steps aside both for a wallet on screen whose currency the ceilings
-     * cannot be compared with and for a saving whose own currency the app cannot resolve, which
-     * a restored backup can produce.
-     *
-     * The check applies to every withdraw, including one saved unconfirmed or dated ahead. Such a
-     * row moves the saving by nothing on the day it is written and by its full amount on the day
-     * it lands, and nothing looks at the saving again in between.
-     *
-     * A row already counted in today's figure is held to both ceilings and takes the smaller.
-     * The test is the one getSavings uses, confirmed and dated at or before this moment, so a
-     * row dated later today is not one of them and only the projected ceiling binds it. That is
-     * read from the fields as they stand now and not from the stored row, because it is the row
-     * about to be written that matters.
+     * The Confirmed box does not enter into it. A withdrawal is counted against the saving
+     * whether it is ticked or not, because leaving an unconfirmed one out would hand out a
+     * ceiling it can then take the saving under.
      */
     private boolean validateSavingWithdraw() {
-        if (mSavingWithdrawLimit == null) {
+        if (mSavingId == null) {
             return true;
         }
-        long limit = mSavingWithdrawLimit;
-        if (mSavingWithdrawLandedLimit != null && mConfirmedCheckBox.isChecked()
-                && !mDateTimePicker.getCurrentDateTime().after(new Date())) {
-            limit = Math.min(limit, mSavingWithdrawLandedLimit);
+        Category category = mCategoryPicker.getCurrentCategory();
+        if (category == null || !Contract.CategoryTag.SAVING_WITHDRAW.equals(category.getTag())) {
+            return true;
         }
-        CurrencyUnit currency = mSavingWithdrawCurrency != null ? CurrencyManager.getCurrency(mSavingWithdrawCurrency) : null;
-        // The limit is in the saving's own currency. If the row sits in a wallet held in another
+        ContentResolver contentResolver = getContentResolver();
+        Uri savingUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
+        String[] projection = new String[] {
+                Contract.Saving.START_MONEY,
+                Contract.Saving.WALLET_CURRENCY
+        };
+        long startMoney = 0L;
+        String currencyIso = null;
+        Cursor cursor = contentResolver.query(savingUri, projection, null, null, null);
+        if (cursor != null) {
+            if (cursor.moveToFirst()) {
+                startMoney = cursor.getLong(cursor.getColumnIndex(Contract.Saving.START_MONEY));
+                currencyIso = cursor.getString(cursor.getColumnIndex(Contract.Saving.WALLET_CURRENCY));
+            }
+            cursor.close();
+        }
+        CurrencyUnit currency = currencyIso != null ? CurrencyManager.getCurrency(currencyIso) : null;
+        // The ceiling is in the saving's own currency. If the row sits in a wallet held in another
         // one the two are not comparable as they stand, and this screen converts nowhere else, so
-        // the check steps aside instead of comparing amounts that do not mean the same thing.
+        // the check steps aside instead of comparing amounts that do not mean the same thing. A
+        // saving that gives back no row at all leaves the currency null and stops here too.
         CurrencyUnit walletCurrency = mWalletPicker.getCurrentWallet().getCurrency();
         if (currency == null || walletCurrency == null || !currency.getIso().equals(walletCurrency.getIso())) {
             return true;
         }
-        // An amount of nothing is not refused. Refusing it would refuse every save of a stored
-        // withdraw of nothing, whatever its ceiling, so its own note and date could never be
-        // corrected and only deletion would be open. The old withdraw everything path could
-        // write such a row. What it costs is an empty row: on a saving with nothing left to give
-        // the withdraw everything prefill is zero, and saving that writes the row and, on that
-        // path only, marks the goal complete.
-        if (mMoneyPicker.getCurrentMoney() <= limit) {
+        long money = mMoneyPicker.getCurrentMoney();
+        String date = DateUtils.getSQLDateTimeString(mDateTimePicker.getCurrentDateTime());
+        if (isStoredWithdrawalKeptOrLowered(contentResolver, money, date)) {
+            return true;
+        }
+        Long lowest = readLowestSavingBalanceFrom(contentResolver, savingUri, startMoney, date,
+                getItemId());
+        if (lowest == null) {
+            return true;
+        }
+        // Held at nothing, since a saving already under zero on some date from here on gives a
+        // negative figure and no amount at all would clear it. An amount of nothing is therefore
+        // never refused, and that matters. Refusing it would refuse every save of a stored
+        // withdrawal of nothing, whatever the saving holds, so its own note and date could never
+        // be corrected and only deletion would be open. The old withdraw everything path could
+        // write such a row.
+        long limit = Math.max(lowest, 0L);
+        if (money <= limit) {
             return true;
         }
         // The figure every time, with no separate wording for a ceiling of nothing. What a

--- a/app/src/test/java/com/oriondev/moneywallet/storage/database/LowestSavingBalanceFromTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/storage/database/LowestSavingBalanceFromTest.java
@@ -1,0 +1,124 @@
+package com.oriondev.moneywallet.storage.database;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * What a saving withdrawal dated D may take is the lowest the saving's balance reaches from D
+ * onwards, and {@link Contract#lowestSavingBalanceFrom(long, String[], long[], String)} is the one
+ * place that works that out. The transaction editor holds every withdrawal to it.
+ *
+ * The two sums a saving carries cannot answer it. Both are totals over the whole set of rows and
+ * neither holds any date order, so a withdrawal dated before the deposit that funds it cleared
+ * both of them and left the saving under zero for the days between the two. That is the reported
+ * bug, and the first two cases here are the numbers it was reported with.
+ *
+ * A row dated at or before the moment asked about is part of the balance at that moment, however
+ * far under zero the saving went on the way there, because a withdrawal written today cannot take
+ * back a day that has already passed.
+ */
+public class LowestSavingBalanceFromTest {
+
+    private static final String[] NO_DATES = new String[0];
+    private static final long[] NO_MONEY = new long[0];
+
+    private static final String SEPTEMBER_10 = "2026-09-10 12:00:00";
+    private static final String SEPTEMBER_30 = "2026-09-30 12:00:00";
+    private static final String OCTOBER_01 = "2026-10-01 12:00:00";
+
+    @Test
+    public void aSavingWithNoRowsIsWorthItsStartMoney() {
+        assertEquals(150000L, Contract.lowestSavingBalanceFrom(150000L, NO_DATES, NO_MONEY,
+                SEPTEMBER_10));
+    }
+
+    @Test
+    public void aDepositDatedAheadDoesNotPayForAWithdrawalDatedBeforeIt() {
+        assertEquals(0L, Contract.lowestSavingBalanceFrom(0L,
+                new String[] {SEPTEMBER_30}, new long[] {300000L}, SEPTEMBER_10));
+    }
+
+    @Test
+    public void theSameDepositPaysForAWithdrawalDatedAfterIt() {
+        assertEquals(300000L, Contract.lowestSavingBalanceFrom(0L,
+                new String[] {SEPTEMBER_30}, new long[] {300000L}, OCTOBER_01));
+    }
+
+    @Test
+    public void aSavingWithMoneyInItOffersOnlyWhatItHoldsOnTheDayAsked() {
+        assertEquals(150000L, Contract.lowestSavingBalanceFrom(150000L,
+                new String[] {SEPTEMBER_30}, new long[] {300000L}, SEPTEMBER_10));
+    }
+
+    @Test
+    public void aRowDatedExactlyTheMomentAskedAboutIsAlreadyCounted() {
+        assertEquals(300000L, Contract.lowestSavingBalanceFrom(0L,
+                new String[] {SEPTEMBER_30}, new long[] {300000L}, SEPTEMBER_30));
+    }
+
+    @Test
+    public void aDipAfterTheMomentAskedAboutIsTheAnswer() {
+        // 3,000.00 in on 10 September and 2,500.00 out on 30 September, asked from 10 September:
+        // the saving is worth 3,000.00 on the day and 500.00 twenty days later, and a withdrawal
+        // written now takes from both.
+        assertEquals(50000L, Contract.lowestSavingBalanceFrom(0L,
+                new String[] {SEPTEMBER_10, SEPTEMBER_30},
+                new long[] {300000L, -250000L}, SEPTEMBER_10));
+    }
+
+    @Test
+    public void aDipBeforeTheMomentAskedAboutIsNotTheAnswer() {
+        // 2,500.00 out on 10 September against a start money of 3,000.00, then 1,000.00 back in
+        // on 30 September. Asked from 1 October the saving is worth 1,500.00, and the 500.00 it
+        // was worth in between is a day nothing written now can reach.
+        assertEquals(150000L, Contract.lowestSavingBalanceFrom(300000L,
+                new String[] {SEPTEMBER_10, SEPTEMBER_30},
+                new long[] {-250000L, 100000L}, OCTOBER_01));
+    }
+
+    @Test
+    public void aDipBetweenTwoLaterRowsIsTheAnswer() {
+        // 2,000.00 out on 30 September and 5,000.00 back in on 1 October, against a start money
+        // of 3,000.00, asked from 10 September. The saving is worth 3,000.00 on the day, 1,000.00
+        // for one day, and 6,000.00 after that, so a withdrawal written now may take 1,000.00.
+        // Every other case here has at most one row after the moment asked about, so a walk that
+        // compares only the first and the last balance passes all of them and answers 3,000.00
+        // here, which is three times what the saving can give.
+        assertEquals(100000L, Contract.lowestSavingBalanceFrom(300000L,
+                new String[] {SEPTEMBER_30, OCTOBER_01},
+                new long[] {-200000L, 500000L}, SEPTEMBER_10));
+    }
+
+    @Test
+    public void rowsSharingADateAreCountedTogether() {
+        // A 1,500.00 withdrawal and a 2,000.00 deposit both dated 30 September, against a start
+        // money of 1,000.00, asked from 10 September. Two rows can carry the same date string,
+        // and a database imported from the old app carries 00:00:00 on every row, so a whole
+        // day of them ties. The saving is worth 1,000.00 until 30 September and 1,500.00 after,
+        // and it is never worth the 500.00 negative the withdrawal on its own would make it.
+        // Which of the two comes back first is not something the query decides, so both orders
+        // have to give the same answer.
+        assertEquals(100000L, Contract.lowestSavingBalanceFrom(100000L,
+                new String[] {SEPTEMBER_30, SEPTEMBER_30},
+                new long[] {-150000L, 200000L}, SEPTEMBER_10));
+        assertEquals(100000L, Contract.lowestSavingBalanceFrom(100000L,
+                new String[] {SEPTEMBER_30, SEPTEMBER_30},
+                new long[] {200000L, -150000L}, SEPTEMBER_10));
+        // And where the pair nets downward, the end of the run is the answer, so it has to be
+        // read. The two above are both cleared by a walk that skips a run of more than one row
+        // and never looks at where it ends, because the saving is worth more after that run
+        // than the 1,000.00 it started from. This one is not: 1,500.00 and 1,000.00 both out on
+        // 30 September leave the saving 1,500.00 in the red from that date, and a walk that
+        // skips the run answers 1,000.00 and offers a withdrawal the saving cannot cover.
+        assertEquals(-150000L, Contract.lowestSavingBalanceFrom(100000L,
+                new String[] {SEPTEMBER_30, SEPTEMBER_30},
+                new long[] {-150000L, -100000L}, SEPTEMBER_10));
+    }
+
+    @Test
+    public void aSavingAlreadyUnderZeroAnswersBelowZero() {
+        assertEquals(-100000L, Contract.lowestSavingBalanceFrom(0L,
+                new String[] {SEPTEMBER_10}, new long[] {-100000L}, SEPTEMBER_10));
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
@@ -26,17 +26,19 @@ import static org.junit.Assert.fail;
  *
  * What these assertions check is which token sequences the source does and does not carry: that
  * getItemId appears nowhere in the intent branch, that the saving uri is built from mSavingId,
- * that the statement assigning landedMoney reads START_MONEY and PROGRESS once each and adds them,
- * that the statement assigning projectedMoney does the same with PROJECTED_PROGRESS, that all
- * three columns are in the projection, that the prefill takes the smaller of the two and sits in
- * the withdraw everything case, that the case falls through, that the statement assigning wallet
- * builds a Wallet from the saving's wallet columns, that the saving case of the visibility switch
- * hides the wallet field, and that between the debt label and the saving label the source names no
- * wallet field and does carry a break. That makes them a tripwire against a revert or a careless
- * rewrite. It does not make them a proof of behavior, and they cannot show the value the keypad
- * ends up with. A rewrite that keeps those tokens and still breaks the editor goes through. One
- * example, not a list: a second assignment written with += or -= is invisible here, because
- * "landedMoney -=" does not contain the "landedMoney =" the statement is found by.
+ * that the saving's projection carries every column the block reads out of it, that the withdraw
+ * everything prefill is the lowest the saving reaches from now onwards and sits in its own case,
+ * that the case falls through, that the statement assigning wallet builds a Wallet from the
+ * saving's wallet columns, that the walk over a saving's rows signs and skips them the way the
+ * saving's own sums do, that every column the check's three queries read is in the projection
+ * beside it, that the check counts from the date on screen over rows ordered by date,
+ * that the saving case of the visibility switch hides the wallet field, and that between the debt
+ * label and the saving label the source names no wallet field and does carry a break. That makes
+ * them a tripwire against a revert or a careless rewrite. It does not make them a proof of
+ * behavior, and they cannot show the value the keypad ends up with. A rewrite that keeps those
+ * tokens and still breaks the editor goes through. One example, not a list: a second assignment
+ * written with += or -= is invisible here, because "money -=" does not contain the "money =" a
+ * statement is found by.
  *
  * Invariant one: inside the branch that fills a new transaction from its intent, getItemId is
  * always -1, the value NewEditItemActivity assigns whenever it was not launched to edit an
@@ -45,42 +47,37 @@ import static org.junit.Assert.fail;
  * returned null without reaching the database. The editor opened with no wallet, the amount keypad
  * had no currency to scale against, and a typed 2000 was stored as 20.00.
  *
- * Invariant two: the prefill that WITHDRAW EVERYTHING opens on is the smaller of the saving's two
- * figures. START_MONEY plus PROGRESS is what it holds today, the sum SavingCursorAdapter draws
- * its current amount from. START_MONEY plus PROJECTED_PROGRESS is the lowest it can end up at
- * once everything already on it has happened, counting every withdrawal it has and only the
- * deposits that are confirmed. An unconfirmed deposit is in neither, so this is not what the
- * saving would hold if every row landed; it is never more than that, and it is less by exactly
- * the unconfirmed deposits, which on most savings is nothing at all. The row this prefill is
- * written into is dated now and confirmed, so both bound it, and offering more than the smaller
- * one offers an amount the same screen then refuses. END_MONEY is the target. Reading END_MONEY
- * there returns too little for any saving deposited past its target and leaves the overshoot
- * behind with the saving already marked complete. The prefill is held at zero when the smaller
- * figure is negative, since the amount written out would otherwise be a withdraw of a negative
- * amount.
+ * Invariant two: the prefill that WITHDRAW EVERYTHING opens on is the lowest the saving reaches
+ * from now onwards, which is the same figure the check applies when the save is pressed, since
+ * the row it writes is dated now. Offering more than that offers an amount the same screen then
+ * refuses. END_MONEY is the target. Reading END_MONEY there returns too little for any saving
+ * deposited past its target and leaves the overshoot behind with the saving already marked
+ * complete. The prefill is held at zero when the figure is negative, since the amount written out
+ * would otherwise be a withdrawal of a negative amount, and a saving whose rows do not come back
+ * offers nothing for the same reason.
  *
  * Invariant three: the same row builds the wallet the editor opens on, currency included. Without
  * that construction the wallet field is empty, the keypad has no currency to scale against, and a
  * typed 2000 is stored as 20.00.
  *
- * Invariant four: a withdraw carries two ceilings, one from each of the saving's two figures, and
- * every place that builds or uses them agrees on which is which. Both are plain longs of the same
- * kind, so swapping them compiles, inverts both ceilings and changes nothing the other assertions
- * here look at. Every place they can be swapped is pinned: the two call sites, the parameter list
- * they are received into, the two statements that assign them to their fields, the one that picks
- * which of the two the check starts from, and the bundle they are written to and read back from.
- * The same goes for which term is added back to which ceiling and for how the term that only one
- * of them gets is worked out, for taking the smaller of the two and then comparing against it,
- * for naming what it worked out in the dialog, and for the column the loader reads each figure
- * from.
+ * Invariant four: the walk that feeds the ceiling treats each row the way the saving's own sums
+ * do. A withdrawal is the income half of the pair, since it pays money into the wallet, and it is
+ * the one that takes the saving down, so it is signed negative. Both of those are a single token
+ * that compiles either way and inverts every row when it is wrong, so both are pinned. Only a
+ * deposit is dropped for being unconfirmed. An unconfirmed deposit never lands, since landing
+ * takes being confirmed, and an unconfirmed withdrawal left out would hand out a ceiling it can
+ * then take the saving under.
  *
- * The early return this change deleted is asserted absent, by counting the date test it was
- * written around: that test belongs to the narrowing now and appears once inside the check. Like
- * everything else here it is token matching, and it is loose in both directions. A return written
- * around some other test is invisible to it, and a second reading of this one fails it whether or
- * not a return came with it.
+ * Invariant five: the ceiling is the lowest balance from the date on screen onwards, over the
+ * saving's rows in date order. Four things are pinned, because each is invisible to the unit test
+ * that covers the walk itself. The rows are ordered by date, which is the order the walk needs
+ * and cannot tell is missing. The row being edited is left out of the walk by id, or it is held
+ * against its own drain. The moment counted from is the date on screen and not today, which is
+ * the whole defect this replaced. And a stored row kept or lowered on a date it does not move
+ * back from is never refused, or two withdrawals that already have a saving under zero freeze
+ * each other and deleting one is the only way out.
  *
- * Invariant five: a saving transaction does not offer its wallet field. A saving's progress is
+ * Invariant six: a saving transaction does not offer its wallet field. A saving's progress is
  * summed over its transactions with no currency anywhere in that sum, so a row moved onto a wallet
  * held in another currency is added at face value, and 500 euros count as 500 dollars. The debt
  * label sits beside the saving one in the same switch and the two shared a body until the hide was
@@ -104,16 +101,14 @@ public class NewEditTransactionActivitySourceTest {
     private static final String WITHDRAW_CASE = "case SAVING_WITHDRAW:";
     private static final String CATEGORY_QUERY_START = "uri = DataContentProvider.CONTENT_CATEGORIES;";
 
-    private static final String PREFILL = "money = Math.max(Math.min(landedMoney, projectedMoney), 0L);";
+    /** Squashed, since it is two statements over three lines in the source. */
+    private static final String PREFILL =
+            "Long lowest = readLowestSavingBalanceFrom(contentResolver, savingUri, startMoney, "
+                    + "DateUtils.getSQLDateTimeString(new Date()), -1L); "
+                    + "money = lowest != null ? Math.max(lowest, 0L) : 0L;";
 
     private static final String CHECK_START = "private boolean validateSavingWithdraw() {";
     private static final String CHECK_END = "ThemedDialog.buildMaterialDialog(this)";
-
-    /** Each figure the prefill is built from, paired with the column it has to read. */
-    private static final String[][] FIGURES = {
-            {"landedMoney =", "Contract.Saving.PROGRESS"},
-            {"projectedMoney =", "Contract.Saving.PROJECTED_PROGRESS"}
-    };
 
     private static final String DEBT_CASE = "case TYPE_DEBT:";
     private static final String SAVING_CASE = "case TYPE_SAVING:";
@@ -134,30 +129,19 @@ public class NewEditTransactionActivitySourceTest {
     }
 
     @Test
-    public void withdrawEverythingPrefillsTheSmallerOfTheTwoFigures() throws IOException {
-        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
-        assertTrue("the withdraw everything prefill must be the smaller of the two figures this "
-                + "block computes, held at zero so a saving already over withdrawn cannot prefill "
-                + "a negative amount", saving.contains(PREFILL));
-        for (String[] figure : FIGURES) {
-            String computed = statementAssigning(saving, figure[0]);
-            assertTrue("the figure is START_MONEY plus " + figure[1] + ", so both have to be "
-                    + "read, but the assignment is: " + computed,
-                    computed.contains("Contract.Saving.START_MONEY")
-                            && computed.contains(figure[1]));
-            assertTrue("END_MONEY is the target, not what the saving holds, so it must not be "
-                    + "part of the prefill, but the assignment is: " + computed,
-                    !computed.contains("END_MONEY"));
-            assertTrue("the two columns have to be added to each other and nothing subtracted "
-                    + "from them, since each figure is the start money plus its own sum and the "
-                    + "signs are already in the sum, but the assignment is: " + computed,
-                    computed.contains("+") && !computed.contains("-"));
-        }
+    public void withdrawEverythingPrefillsWhatTheSavingCanGiveFromNow() throws IOException {
+        String saving = squash(region(SAVING_BRANCH_START, SAVING_BRANCH_END));
+        assertTrue("the withdraw everything prefill must be the lowest the saving reaches from "
+                + "now onwards, which is the figure the check applies when the save is pressed, "
+                + "held at zero so a saving already over withdrawn cannot prefill a negative "
+                + "amount: " + saving, saving.contains(PREFILL));
+        assertTrue("END_MONEY is the target, not what the saving holds, so it must not be read "
+                + "in this block at all: " + saving, !saving.contains("Contract.Saving.END_MONEY"));
     }
 
     @Test
     public void withdrawEverythingPrefillsOnlyItsOwnCase() throws IOException {
-        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
+        String saving = squash(region(SAVING_BRANCH_START, SAVING_BRANCH_END));
         String everything = saving.substring(saving.indexOf(WITHDRAW_EVERYTHING_CASE));
         int ownCaseEnd = everything.indexOf(WITHDRAW_CASE);
         assertTrue("the prefill has to sit in the withdraw everything case: moved into the deposit "
@@ -178,29 +162,55 @@ public class NewEditTransactionActivitySourceTest {
     }
 
     @Test
-    public void everyColumnTheFiguresReadIsInTheProjection() throws IOException {
+    public void everyColumnTheSavingRowReadsIsInTheProjection() throws IOException {
         // The saving branch builds two projections, one for the saving and one for its category,
         // so this looks only at the part before the category query starts.
         String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
         String projection = statementAssigning(
                 saving.substring(0, saving.indexOf(CATEGORY_QUERY_START)), "projection =");
         assertTrue("a column read through getColumnIndex but left out of the projection returns "
-                + "index -1 and throws when it is read, so all three have to be listed: "
-                + projection, projection.contains("Contract.Saving.START_MONEY")
-                        && projection.contains("Contract.Saving.PROGRESS")
-                        && projection.contains("Contract.Saving.PROJECTED_PROGRESS"));
+                + "index -1 and throws when it is read: " + projection,
+                projection.contains("Contract.Saving.START_MONEY")
+                        && projection.contains("Contract.Saving.WALLET_ID")
+                        && projection.contains("Contract.Saving.WALLET_CURRENCY"));
     }
 
     @Test
-    public void theSumsReadEachColumnOnce() throws IOException {
-        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
-        for (String[] figure : FIGURES) {
-            String computed = statementAssigning(saving, figure[0]);
-            assertEquals("START_MONEY has to be read once, or the figure counts it twice: "
-                    + computed, 1, occurrences(computed, "Contract.Saving.START_MONEY"));
-            assertEquals(figure[1] + " has to be read once: " + computed,
-                    1, occurrences(computed, figure[1]));
-        }
+    public void theWalkSignsAndSkipsRowsTheWayTheSavingsSumsDo() throws IOException {
+        String source = squash(stripCommentsAndStrings(readSource()));
+        assertTrue("a withdrawal is the income half of the pair, since it pays money into the "
+                + "wallet. Reading the other constant here compiles and turns every row into its "
+                + "opposite", source.contains("boolean withdrawal = cursor.getInt(cursor"
+                        + ".getColumnIndex(Contract.Transaction.DIRECTION)) == Contract.Direction"
+                        + ".INCOME;"));
+        assertTrue("and a withdrawal takes the saving down while a deposit puts money in, so the "
+                + "withdrawal is the negative one. Swapping the two arms compiles as well",
+                source.contains("signedMoney[rows] = withdrawal ? -money : money;"));
+        assertTrue("only a deposit is dropped for being unconfirmed, because landing takes being "
+                + "confirmed and money that never arrives must not pay for a withdrawal that "
+                + "does. Dropping an unconfirmed withdrawal too hands out a ceiling it can then "
+                + "take the saving under", source.contains("if (!withdrawal && cursor.getInt("
+                        + "cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) != 1) {"));
+    }
+
+    @Test
+    public void everyColumnTheCheckReadsIsInItsOwnProjection() throws IOException {
+        // A column read through getColumnIndex but left out of the projection beside it returns
+        // index -1 and throws when it is read. These three are the queries the check runs on the
+        // way out, so a column dropped from any of them is a crash on saving a withdrawal.
+        String source = squash(stripCommentsAndStrings(readSource()));
+        assertTrue("the walk reads five columns off every row of the saving: " + source,
+                source.contains("String[] projection = new String[] { Contract.Transaction.ID, "
+                        + "Contract.Transaction.DATE, Contract.Transaction.MONEY, "
+                        + "Contract.Transaction.DIRECTION, Contract.Transaction.CONFIRMED };"));
+        assertTrue("the stored row is read for both the amount and the date, since it is kept or "
+                + "lowered only when neither has moved the wrong way: " + source,
+                source.contains("String[] projection = new String[] { Contract.Transaction.MONEY,"
+                        + " Contract.Transaction.DATE };"));
+        assertTrue("and the saving itself is read for what the walk starts from and the currency "
+                + "the ceiling is in: " + source, source.contains("String[] projection = new "
+                        + "String[] { Contract.Saving.START_MONEY, "
+                        + "Contract.Saving.WALLET_CURRENCY };"));
     }
 
     @Test
@@ -240,101 +250,53 @@ public class NewEditTransactionActivitySourceTest {
      * Runs of whitespace are collapsed to one space before these are matched, so the amount of
      * space between two tokens does not matter. A break inserted where the pattern has no space
      * at all still fails them, which is a false alarm and not a defect in the code. Everything
-     * else about them is literal: they are token matching, not behaviour, and a rewrite that
-     * keeps these sequences and still gets the ceilings wrong goes through.
+     * else about them is literal. They are token matching, not behavior, and a rewrite that keeps
+     * these sequences and still gets the ceiling wrong goes through.
      */
     @Test
-    public void theTwoCeilingsAreBuiltAndUsedInTheRightOrder() throws IOException {
+    public void theCheckCountsFromTheDateOnScreenOverRowsInDateOrder() throws IOException {
         String source = squash(stripCommentsAndStrings(readSource()));
-        assertTrue("the new withdraw path passes the projected figure first and the landed one "
-                + "second, and swapping them inverts both ceilings",
-                source.contains("setSavingWithdrawLimits(projectedMoney, landedMoney, 0L, 0L,"));
-        // As far as the break that closes the case, not to the end of the saving branch: past
-        // that break the same call runs for a deposit too, and the check would start refusing
-        // deposits. This cannot see a condition wrapped around the call inside the case.
-        String saving = squash(region(SAVING_BRANCH_START, SAVING_BRANCH_END));
-        String fromWithdrawCase = saving.substring(saving.indexOf(WITHDRAW_CASE));
-        String withdrawCase = fromWithdrawCase.substring(0, fromWithdrawCase.indexOf("break;"));
-        assertTrue("and it sits in the withdraw case itself. Above the case label it lands in "
-                + "withdraw everything, which falls through, so a plain withdraw from the savings "
-                + "list loses its ceilings and the check returns on its first line; below the "
-                + "break it runs for a deposit as well: " + withdrawCase,
-                withdrawCase.contains("setSavingWithdrawLimits(projectedMoney, landedMoney, 0L, 0L,"));
-        assertTrue("the loader reads PROJECTED_PROGRESS into the first slot and PROGRESS into the "
-                + "second, and swapping them inverts both ceilings", source.contains(
-                "startMoney + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROJECTED_PROGRESS)), "
-                        + "startMoney + cursor.getLong(cursor.getColumnIndex(Contract.Saving.PROGRESS)), "
-                        + "alreadyTaken, alreadyTakenLanded,"));
-        assertTrue("the edit path adds the stored amount back to the projected ceiling always and "
-                + "to the landed one only while the progress already counts that row",
-                source.contains("loadSavingWithdrawLimits(contentResolver, mSavingId, money, "
-                        + "storedRowHasLanded ? money : 0L);"));
-        assertTrue("and the parameter list it arrives in takes them in that order. These two are "
-                + "longs of the same kind as well, so swapping them here hands the landed ceiling "
-                + "an amount its own sum never counted", source.contains(
-                "private void loadSavingWithdrawLimits(ContentResolver contentResolver, "
-                        + "long savingId, long alreadyTaken, long alreadyTakenLanded) {"));
+        // The order clause is a string literal, so this one assertion reads a source with its
+        // comments taken out and its literals left in. A comment carrying the same text would
+        // satisfy it, which nothing else here can be.
+        assertTrue("the rows come back ordered by date, which is the order the walk needs and "
+                + "cannot tell is missing. In any other order the number it returns is not the "
+                + "lowest balance at all", squash(stripComments(readSource())).contains(
+                        "projection, selection, selectionArgs, Contract.Transaction.DATE + \" ASC\");"));
+        assertTrue("the row being edited is left out of the walk, or its own drain is counted "
+                + "against it and it can never be raised. A new item names -1, which no row "
+                + "carries", source.contains("if (cursor.getLong(cursor.getColumnIndex("
+                        + "Contract.Transaction.ID)) == excludedId) { continue; }"));
+        assertTrue("and the id left out is the one being edited", source.contains(
+                "readLowestSavingBalanceFrom(contentResolver, savingUri, startMoney, date, "
+                        + "getItemId());"));
+        assertTrue("the moment counted from is the date on screen. Counting from today is the "
+                + "defect this replaced, since a row dated earlier drains every day from its own "
+                + "date onwards", source.contains("String date = DateUtils.getSQLDateTimeString("
+                        + "mDateTimePicker.getCurrentDateTime());"));
+        assertTrue("a stored row kept or lowered on a date it does not move back from is never "
+                + "refused. Without that, two withdrawals that already have a saving under zero "
+                + "freeze each other and deleting one is the only way out", source.contains(
+                "unchangedOrSmaller = money <= cursor.getLong(cursor.getColumnIndex("
+                        + "Contract.Transaction.MONEY)) && date.compareTo(cursor.getString("
+                        + "cursor.getColumnIndex(Contract.Transaction.DATE))) >= 0;"));
         // Inside the check itself and in this order, because each of these read on its own is
-        // satisfied by a body that computes the narrowing and then never uses it.
+        // satisfied by a body that works the ceiling out and then never uses it.
         String check = squash(region(CHECK_START, CHECK_END));
-        int starts = check.indexOf("long limit = mSavingWithdrawLimit;");
-        int narrows = check.indexOf("limit = Math.min(limit, mSavingWithdrawLandedLimit);");
-        int compares = check.indexOf("if (mMoneyPicker.getCurrentMoney() <= limit) {");
-        assertTrue("the check starts from the projected ceiling: " + check, starts >= 0);
-        assertTrue("it narrows to the smaller for a row already counted in today's figure, which "
-                + "is one confirmed and not dated later, read from the fields as they stand now: "
-                + check, narrows > starts && check.indexOf("mConfirmedCheckBox.isChecked() && "
-                + "!mDateTimePicker.getCurrentDateTime().after(new Date())") > starts);
-        assertTrue("and it compares against what it worked out, after working it out. Comparing "
-                + "first and narrowing afterwards leaves every literal here in place and the "
-                + "landed ceiling binding nothing: " + check, compares > narrows);
-        assertTrue("the dialog names what the check worked out. Naming a field instead tells the "
-                + "user a figure this same screen has just refused",
+        int keeps = check.indexOf("if (isStoredWithdrawalKeptOrLowered(contentResolver, money, date)) {");
+        int works = check.indexOf("long limit = Math.max(lowest, 0L);");
+        int compares = check.indexOf("if (money <= limit) {");
+        assertTrue("the stored row is let through before anything is worked out: " + check,
+                keeps >= 0);
+        assertTrue("the ceiling is held at nothing, or a saving already under zero on some date "
+                + "from here on refuses every save of every row it carries, an amount of nothing "
+                + "included: " + check, works > keeps);
+        assertTrue("and the amount is compared against what was worked out, after working it out. "
+                + "Comparing first leaves every literal here in place and the ceiling binding "
+                + "nothing: " + check, compares > works);
+        assertTrue("the dialog names what the check worked out. Naming the raw figure instead "
+                + "tells the user a negative number on a saving that is already under zero",
                 source.contains("mMoneyFormatter.getNotTintedString(currency, limit)"));
-        assertEquals("inside this check the date test belongs to the narrowing and is read once. "
-                + "Reading it twice is how the deleted early return comes back, and that return "
-                + "lets a row saved unconfirmed or dated ahead skip the check, which is route one "
-                + "of the reported bug. A second reading is not proof of one: splitting the "
-                + "narrowing, or guarding something else on the same test, fails this too", 1,
-                occurrences(check, "mDateTimePicker.getCurrentDateTime().after(new Date())"));
-        assertTrue("the parameter list receives the projected figure first and the landed one "
-                + "second, which is the third place the same swap inverts both ceilings",
-                source.contains("private void setSavingWithdrawLimits(long projectedHeld, "
-                        + "long landedHeld, long alreadyTaken, long alreadyTakenLanded, "
-                        + "String currencyIso) {"));
-        assertTrue("each field takes its own figure and its own added back term, and each is held "
-                + "at the term it was given, so a row both sums already count can be kept or "
-                + "reduced while a row only the projected sum counts can be refused at its own "
-                + "amount once it is confirmed and dated today",
-                source.contains("mSavingWithdrawLimit = Math.max(projectedHeld + alreadyTaken, "
-                        + "alreadyTaken); mSavingWithdrawLandedLimit = Math.max(landedHeld + "
-                        + "alreadyTakenLanded, alreadyTakenLanded);"));
-        assertTrue("the stored row counts towards the landed ceiling only while the progress "
-                + "counts it, which is while it is confirmed and not dated ahead", source.contains(
-                "boolean storedRowHasLanded = cursor.getInt(cursor.getColumnIndex("
-                        + "Contract.Transaction.CONFIRMED)) == 1 && !DateUtils."
-                        + "getDateFromSQLDateTimeString(cursor.getString(cursor.getColumnIndex("
-                        + "Contract.Transaction.DATE))).after(new Date());"));
-        assertTrue("the loader reads each figure from its own column, and a column left out of "
-                + "its projection returns index -1 and throws when it is read", source.contains(
-                "String[] projection = new String[] { Contract.Saving.START_MONEY, "
-                        + "Contract.Saving.PROGRESS, Contract.Saving.PROJECTED_PROGRESS, "
-                        + "Contract.Saving.WALLET_CURRENCY };"));
-        assertTrue("both ceilings are written to the bundle together. Nothing rebuilds either "
-                + "one on the way back, and the check bails out entirely on a null projected "
-                + "ceiling, so dropping the write is the check gone for that editor",
-                source.contains("outState.putLong(SS_SAVING_WITHDRAW_LIMIT, "
-                        + "mSavingWithdrawLimit); outState.putLong("
-                        + "SS_SAVING_WITHDRAW_LANDED_LIMIT, mSavingWithdrawLandedLimit);"));
-        assertTrue("and the landed one is read back with a plain assignment and an if, never a "
-                + "second conditional. A conditional with a long on one arm and this Long field "
-                + "on the other is a numeric one, so the field is unboxed, and it is null on "
-                + "every editor that is not a saving withdraw: written that way this line crashed "
-                + "the editor on rotation", source.contains(
-                "mSavingWithdrawLandedLimit = mSavingWithdrawLimit; if (savedInstanceState"
-                        + ".containsKey(SS_SAVING_WITHDRAW_LANDED_LIMIT)) { "
-                        + "mSavingWithdrawLandedLimit = savedInstanceState.getLong("
-                        + "SS_SAVING_WITHDRAW_LANDED_LIMIT); }"));
     }
 
     /**
@@ -394,6 +356,18 @@ public class NewEditTransactionActivitySourceTest {
      * could be satisfied, or broken, by prose that no compiler ever sees.
      */
     private static String stripCommentsAndStrings(String text) {
+        return strip(text, true);
+    }
+
+    /**
+     * The same with the string literals left in, for the one assertion whose invariant is written
+     * as a literal. Comments still go, so the text it looks for cannot come from prose.
+     */
+    private static String stripComments(String text) {
+        return strip(text, false);
+    }
+
+    private static String strip(String text, boolean strings) {
         StringBuilder out = new StringBuilder(text.length());
         int i = 0;
         while (i < text.length()) {
@@ -404,7 +378,7 @@ public class NewEditTransactionActivitySourceTest {
             } else if (c == '/' && i + 1 < text.length() && text.charAt(i + 1) == '*') {
                 i = skipTo(text, i + 2, "*/") + 2;
                 out.append(' ');
-            } else if (c == '"' || c == '\'') {
+            } else if (strings && (c == '"' || c == '\'')) {
                 i++;
                 while (i < text.length() && text.charAt(i) != c) {
                     i += text.charAt(i) == '\\' ? 2 : 1;
@@ -422,14 +396,6 @@ public class NewEditTransactionActivitySourceTest {
     /** Collapses every run of whitespace to one space. */
     private static String squash(String text) {
         return text.replaceAll("\\s+", " ");
-    }
-
-    private static int occurrences(String text, String token) {
-        int count = 0;
-        for (int at = text.indexOf(token); at >= 0; at = text.indexOf(token, at + 1)) {
-            count++;
-        }
-        return count;
     }
 
     private static int skipTo(String text, int from, String token) {


### PR DESCRIPTION
A withdrawal from a savings goal was checked against two running totals, what the goal holds today and what it will hold once everything already on it has happened. Neither of those says anything about the order the entries fall in, so a withdrawal dated before the deposit that pays for it passed both checks and left the goal below zero for the days between the two.

On a goal holding nothing, a 3,000.00 deposit dated 30 September let a 3,000.00 withdrawal dated 10 September through with no warning. The savings list read 0.00, which is right for today, and the goal sat 3,000.00 below zero until the deposit landed.

Both totals are replaced by one. The app now walks the goal's entries in date order and works out the lowest the balance gets from the withdrawal's own date onwards, and that is what the withdrawal may take. Anything that would put the goal below zero on that date or later is refused, and the message names what the goal can give.

The confirmed tick no longer changes the ceiling, because a withdrawal counts against the goal whether it is ticked or not, and a deposit that is not ticked has not arrived and pays for nothing. And the figure is worked out when you press save instead of when the screen opens, since the answer depends on a date you are still choosing.

Withdraw everything now offers what the goal can give from today onwards. It used to offer more than the same screen would then accept.

An entry kept the same or lowered, on a date it does not move back from, is never refused, so two withdrawals that already have a goal below zero cannot trap each other. Moving one earlier is a new drain and is checked like anything else.

Checked on an emulator against the steps in the issue. The reported withdrawal is refused where it used to save, and the same amount dated after the deposit still saves, so the check tells the two apart by date instead of refusing everything.

Fixes #195
