### PR TITLE
fix: a savings goal or a debt stays in the currency its money is in

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -46,6 +46,7 @@ import java.util.Locale;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.fail;
 
 /**
  * Created by andrea on 28/08/18.
@@ -1391,9 +1392,203 @@ public class SQLDatabaseTest {
         checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), storedIcon, "rent payment", date, null, walletId, "note-1", null, 5000L, false, null, "tag-1");
     }
 
+    /**
+     * A debt is read in the currency of its wallet and what is left to settle is that amount less
+     * its payments, added up with no currency in the sum. The payments stay in the wallet they
+     * were filed against when the debt moves, so the move is refused.
+     */
+    @Test
+    public void movingADebtAwayFromTheCurrencyItsPaymentsAreInIsRefused() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long paidCategoryId = getSystemCategory(Contract.CategoryTag.PAID_DEBT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1", false);
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, euroWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        try {
+            updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, dollarWallet, "note-1", null, 2000L, false, null, "tag-1");
+            fail("The debt was moved away from the currency its payments are in");
+        } catch (SQLiteDataException e) {
+            assertEquals(Contract.ErrorCode.WALLETS_NOT_CONSISTENT, e.getErrorCode());
+        }
+        checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1");
+    }
+
+    /**
+     * And the move back is allowed. A ledger that was moved across currencies before any of this
+     * existed holds a debt in one currency and its payments in another, and the move that puts it
+     * right is the one a check made against the debt's own wallet would refuse hardest. Deleting
+     * the debt would then be the only way out, and that takes the payments with it.
+     */
+    @Test
+    public void movingADebtBackToTheCurrencyItsPaymentsAreInIsAllowed() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long paidCategoryId = getSystemCategory(Contract.CategoryTag.PAID_DEBT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        // The debt is held in euro and its payment sits in the dollar wallet.
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1", false);
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, dollarWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        assertEquals(1, updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, dollarWallet, "note-1", null, 2000L, false, null, "tag-1"));
+        checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, dollarWallet, "note-1", null, 2000L, false, null, "tag-1");
+    }
+
+    /**
+     * A mismatched debt can still be moved between two wallets of the currency it is read in. That
+     * move puts nothing right and takes nothing further wrong, and refusing it would leave a
+     * legacy ledger with one permitted wallet and deletion as the only other way out.
+     */
+    @Test
+    public void movingAMismatchedDebtWithinItsOwnCurrencyIsAllowed() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long otherEuroWallet = insertWallet("Test wallet 2", "encoded-icon-2", "EUR", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long dollarWallet = insertWallet("Test wallet 3", "encoded-icon-3", "USD", "note-wallet-3", true, 2000L, false, "tag-wallet-3");
+        long paidCategoryId = getSystemCategory(Contract.CategoryTag.PAID_DEBT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1", false);
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, dollarWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        assertEquals(1, updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, otherEuroWallet, "note-1", null, 2000L, false, null, "tag-1"));
+        checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, otherEuroWallet, "note-1", null, 2000L, false, null, "tag-1");
+    }
+
+    /**
+     * And a third currency is still refused, which is what separates the case above from no check
+     * at all on a mismatched debt.
+     */
+    @Test
+    public void movingAMismatchedDebtToAThirdCurrencyIsRefused() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long poundWallet = insertWallet("Test wallet 3", "encoded-icon-3", "GBP", "note-wallet-3", true, 2000L, false, "tag-wallet-3");
+        long paidCategoryId = getSystemCategory(Contract.CategoryTag.PAID_DEBT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1", false);
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, dollarWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        try {
+            updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, poundWallet, "note-1", null, 2000L, false, null, "tag-1");
+            fail("The debt was moved to a currency matching neither what it holds nor its payments");
+        } catch (SQLiteDataException e) {
+            assertEquals(Contract.ErrorCode.WALLETS_NOT_CONSISTENT, e.getErrorCode());
+        }
+        checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1");
+    }
+
+    /**
+     * A debt whose payments are already spread over two currencies is still held to those two. It
+     * cannot be put fully right by any single wallet, which is a reason to leave both of the
+     * currencies it holds open and not a reason to let it go anywhere at all.
+     */
+    @Test
+    public void movingAMixedDebtToACurrencyItHoldsNoneOfIsRefused() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long poundWallet = insertWallet("Test wallet 3", "encoded-icon-3", "GBP", "note-wallet-3", true, 2000L, false, "tag-wallet-3");
+        long paidCategoryId = getSystemCategory(Contract.CategoryTag.PAID_DEBT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1", false);
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, euroWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, dollarWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        try {
+            updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, poundWallet, "note-1", null, 2000L, false, null, "tag-1");
+            fail("The debt was moved to a currency it holds nothing in");
+        } catch (SQLiteDataException e) {
+            assertEquals(Contract.ErrorCode.WALLETS_NOT_CONSISTENT, e.getErrorCode());
+        }
+        checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1");
+    }
+
+    /**
+     * And either of the two currencies it does hold is still open to it.
+     */
+    @Test
+    public void movingAMixedDebtToOneOfItsOwnCurrenciesIsAllowed() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long paidCategoryId = getSystemCategory(Contract.CategoryTag.PAID_DEBT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1", false);
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, euroWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, dollarWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        assertEquals(1, updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, dollarWallet, "note-1", null, 2000L, false, null, "tag-1"));
+        checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, dollarWallet, "note-1", null, 2000L, false, null, "tag-1");
+    }
+
+    /**
+     * A debt with nothing filed against it strands nothing, so it can be moved anywhere. A debt
+     * given its master transaction strands nothing either, since updateDebt carries that
+     * transaction to the new wallet with it.
+     */
+    @Test
+    public void movingADebtThatStrandsNothingGoesThrough() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1", true);
+        assertEquals(1, updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, dollarWallet, "note-1", null, 2000L, false, null, "tag-1"));
+        checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, dollarWallet, "note-1", null, 2000L, false, null, "tag-1");
+        assertEquals(dollarWallet, masterTransactionWallet(debtId));
+    }
+
+    /**
+     * The same move made from the other side. A debt's master transaction still offers its wallet,
+     * and the sync carries that wallet onto the debt, so this reaches the debt without the debt
+     * editor being opened.
+     *
+     * The transaction is asserted back where it started as well as the debt. Nothing here runs
+     * inside a database transaction, so a refusal raised after the row was written would leave the
+     * two in different wallets, which is worse than the move it refused.
+     */
+    @Test
+    public void movingTheMasterTransactionToAnotherCurrencyMovesNothing() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long categoryId = getSystemCategory(Contract.CategoryTag.DEBT);
+        long paidCategoryId = getSystemCategory(Contract.CategoryTag.PAID_DEBT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1", true);
+        // The payment is what the move would strand. Without one the debt has nothing left behind
+        // and the move is allowed, which movingADebtThatStrandsNothingGoesThrough pins.
+        insertTransaction(500L, date, "payment", paidCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.DEBT, euroWallet, null, "payment-note", null, null, debtId, true, true, null, null, "tag-payment");
+        long transactionId = masterTransactionId(debtId);
+        try {
+            updateTransaction(transactionId, 2000L, date, "desc-1", categoryId,
+                    Contract.Direction.INCOME, Contract.TransactionType.DEBT, dollarWallet, null,
+                    "note-1", null, null, debtId, true, true, null, null, "tag-transaction");
+            fail("The master transaction was moved to a wallet in another currency");
+        } catch (SQLiteDataException e) {
+            assertEquals(Contract.ErrorCode.WALLETS_NOT_CONSISTENT, e.getErrorCode());
+        }
+        checkDebtId(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", date, null, euroWallet, "note-1", null, 2000L, false, null, "tag-1");
+        assertEquals(euroWallet, masterTransactionWallet(debtId));
+    }
+
+    private long masterTransactionWallet(long debtId) {
+        Cursor cursor = mDatabase.getTransaction(masterTransactionId(debtId),
+                new String[] {Contract.Transaction.WALLET_ID});
+        assertNotNull(cursor);
+        assertEquals(1, cursor.getCount());
+        cursor.moveToFirst();
+        long walletId = cursor.getLong(cursor.getColumnIndex(Contract.Transaction.WALLET_ID));
+        cursor.close();
+        return walletId;
+    }
+
     private long masterTransactionId(long debtId) {
+        // By category, since a debt that also carries a payment has more than one transaction and
+        // only one of them is the master. Every debt here is a debt and not a credit, so the debt
+        // system category is the only one this has to match.
         Cursor cursor = mDatabase.getTransactions(new String[] {Contract.Transaction.ID},
-                Contract.Transaction.DEBT_ID + " = ?", new String[] {String.valueOf(debtId)}, null);
+                Contract.Transaction.DEBT_ID + " = ? AND " + Contract.Transaction.CATEGORY_ID + " = ?",
+                new String[] {String.valueOf(debtId), String.valueOf(getSystemCategory(Contract.CategoryTag.DEBT))}, null);
         assertNotNull(cursor);
         assertEquals(1, cursor.getCount());
         cursor.moveToFirst();
@@ -1801,6 +1996,78 @@ public class SQLDatabaseTest {
         // now check that both savings have been successfully update
         checkSavingId(id2, "desc-1-edited", "encoded-icon-edited", 3L, 100L, id1, exp, true, "note-1-edited", "tag-1-edited");
         checkSavingId(id3, "desc-2-edited", "encoded-icon-edited", 50L, 73000L, id1, null, false, "note-2-edited", "tag-2-edited");
+    }
+
+    /**
+     * A saving is read in the currency of its wallet and its progress is worked out from its
+     * deposits and withdrawals, added up with no currency in the sum. They stay in the wallet they
+     * were filed against when the saving moves, so the move is refused.
+     */
+    @Test
+    public void movingASavingAwayFromTheCurrencyItsDepositsAreInIsRefused() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long depositCategoryId = getSystemCategory(Contract.CategoryTag.SAVING_DEPOSIT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long savingId = insertSaving("desc-1", "encoded-icon", 0L, 10000L, euroWallet, null, false, "note-1", "tag-1");
+        insertTransaction(500L, date, "deposit", depositCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.SAVING, euroWallet, null, "deposit-note", null, savingId, null, true, true, null, null, "tag-deposit");
+        try {
+            updateSaving(savingId, "desc-1", "encoded-icon", 0L, 10000L, dollarWallet, null, false, "note-1", "tag-1");
+            fail("The saving was moved away from the currency its deposits are in");
+        } catch (SQLiteDataException e) {
+            assertEquals(Contract.ErrorCode.WALLETS_NOT_CONSISTENT, e.getErrorCode());
+        }
+        checkSavingId(savingId, "desc-1", "encoded-icon", 0L, 10000L, euroWallet, null, false, "note-1", "tag-1");
+    }
+
+    /**
+     * And the move back is allowed, for the reason spelled out on the debt half of this,
+     * movingADebtBackToTheCurrencyItsPaymentsAreInIsAllowed.
+     */
+    @Test
+    public void movingASavingBackToTheCurrencyItsDepositsAreInIsAllowed() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long depositCategoryId = getSystemCategory(Contract.CategoryTag.SAVING_DEPOSIT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long savingId = insertSaving("desc-1", "encoded-icon", 0L, 10000L, euroWallet, null, false, "note-1", "tag-1");
+        insertTransaction(500L, date, "deposit", depositCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.SAVING, dollarWallet, null, "deposit-note", null, savingId, null, true, true, null, null, "tag-deposit");
+        assertEquals(1, updateSaving(savingId, "desc-1", "encoded-icon", 0L, 10000L, dollarWallet, null, false, "note-1", "tag-1"));
+        checkSavingId(savingId, "desc-1", "encoded-icon", 0L, 10000L, dollarWallet, null, false, "note-1", "tag-1");
+    }
+
+    /**
+     * And the wallet is still a field you can change. Without this case a guard that refused every
+     * move, or one that refused every save naming a wallet, passes the refusal above just as well.
+     * The debt half of it is editingTheMasterTransactionMovesTheDebt, which moves a debt between
+     * two wallets that agree.
+     */
+    @Test
+    public void movingASavingToAWalletInTheSameCurrencyGoesThrough() throws Exception {
+        long walletId = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long otherWalletId = insertWallet("Test wallet 2", "encoded-icon-2", "EUR", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long depositCategoryId = getSystemCategory(Contract.CategoryTag.SAVING_DEPOSIT);
+        Date date = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long savingId = insertSaving("desc-1", "encoded-icon", 0L, 10000L, walletId, null, false, "note-1", "tag-1");
+        insertTransaction(500L, date, "deposit", depositCategoryId, Contract.Direction.EXPENSE,
+                Contract.TransactionType.SAVING, walletId, null, "deposit-note", null, savingId, null, true, true, null, null, "tag-deposit");
+        assertEquals(1, updateSaving(savingId, "desc-1", "encoded-icon", 0L, 10000L, otherWalletId, null, false, "note-1", "tag-1"));
+        checkSavingId(savingId, "desc-1", "encoded-icon", 0L, 10000L, otherWalletId, null, false, "note-1", "tag-1");
+    }
+
+    /**
+     * A saving with nothing filed against it strands nothing, so it can be moved anywhere. A goal
+     * created against the wrong wallet and corrected straight away is the ordinary case of this.
+     */
+    @Test
+    public void movingASavingThatStrandsNothingGoesThrough() throws Exception {
+        long euroWallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long dollarWallet = insertWallet("Test wallet 2", "encoded-icon-2", "USD", "note-wallet-2", true, 2000L, false, "tag-wallet-2");
+        long savingId = insertSaving("desc-1", "encoded-icon", 0L, 10000L, euroWallet, null, false, "note-1", "tag-1");
+        assertEquals(1, updateSaving(savingId, "desc-1", "encoded-icon", 0L, 10000L, dollarWallet, null, false, "note-1", "tag-1"));
+        checkSavingId(savingId, "desc-1", "encoded-icon", 0L, 10000L, dollarWallet, null, false, "note-1", "tag-1");
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -894,9 +894,11 @@ import java.util.UUID;
      * @param transactionId id of the transaction to update.
      * @param contentValues set of column values to update.
      * @return the number of rows affected by the update.
-     * @throws SQLiteDataException if the transaction is part of a transfer.
+     * @throws SQLiteDataException if the transaction is part of a transfer, or if it is a debt's
+     *                             master transaction and checkStrandedCurrency refuses the wallet.
      */
     /*package-local*/ int updateTransaction(long transactionId, ContentValues contentValues) {
+        checkDebtOfMasterTransactionWallet(transactionId, contentValues);
         int rows = updateTransactionRow(transactionId, contentValues);
         if (rows > 0) {
             syncDebtOfMasterTransaction(transactionId, contentValues);
@@ -2290,8 +2292,12 @@ import java.util.UUID;
      * a payment on the paid debt or paid credit one. Same test updateDebt uses to find the master
      * transaction from the other side.
      *
-     * Asked of the stored row, which by this point carries the update, so an update naming none
-     * of these three columns is still judged on what the row holds.
+     * Asked of the stored row. syncDebtOfMasterTransaction asks after the row is written and
+     * checkDebtOfMasterTransactionWallet asks before it, and the only saves that reach both are
+     * the transaction editor's. That editor has no field for the type or the debt id and hides the
+     * category picker on a debt row, so it sends all three back at what it loaded and the answer
+     * is the same either way. updateDebt writes the master transaction through updateTransactionRow
+     * and reaches neither.
      *
      * Straight off the table, the way the transfer check at the top of updateTransactionRow reads
      * its own. getTransaction would answer this too, and it builds the joined view every reader
@@ -2328,6 +2334,29 @@ import java.util.UUID;
             }
         }
         return debtId;
+    }
+
+    /**
+     * The wallet half of the sync below, asked before anything is written.
+     *
+     * Nothing here runs inside a database transaction, so a refusal raised from the sync would
+     * leave the transaction already moved and the debt sitting in the wallet it started in. The
+     * question is asked of the debt's own wallet, which is the one every figure on the debt is
+     * read in, and not of the transaction's.
+     *
+     * @param transactionId id of the transaction being updated.
+     * @param contentValues set of column values to update.
+     * @throws SQLiteDataException if checkStrandedCurrency refuses the wallet.
+     */
+    private void checkDebtOfMasterTransactionWallet(long transactionId, ContentValues contentValues) {
+        if (!contentValues.containsKey(Contract.Transaction.WALLET_ID)) {
+            return;
+        }
+        Long debtId = masterTransactionDebtId(transactionId);
+        if (debtId == null) {
+            return;
+        }
+        checkDebtWalletCurrency(debtId, contentValues.getAsLong(Contract.Transaction.WALLET_ID));
     }
 
     /**
@@ -2585,8 +2614,12 @@ import java.util.UUID;
      * @param debtId id of the debt to update.
      * @param contentValues bundle that contains the data from the content provider.
      * @return the number of row affected.
+     * @throws SQLiteDataException if checkStrandedCurrency refuses the wallet.
      */
     /*package-local*/ int updateDebt(long debtId, ContentValues contentValues) {
+        if (contentValues.containsKey(Contract.Debt.WALLET_ID)) {
+            checkDebtWalletCurrency(debtId, contentValues.getAsLong(Contract.Debt.WALLET_ID));
+        }
         ContentValues cv = new ContentValues();
         if (contentValues.containsKey(Contract.Debt.TYPE)) {
             cv.put(Schema.Debt.TYPE, contentValues.getAsInteger(Contract.Debt.TYPE));
@@ -3229,6 +3262,182 @@ import java.util.UUID;
     }
 
     /**
+     * A saving and a debt each point at one wallet, and that wallet decides the currency the whole
+     * thing is read in. What is filed against them is added up with no currency in the sum and
+     * stays in the wallet it was filed against, so moving one of them to a wallet in another
+     * currency rereads their figures against money that is still held somewhere else.
+     *
+     * Three wallets go through. One of the currency the row is read in today, one of a currency
+     * something filed against the row already sits in, and any wallet at all when nothing is filed
+     * against the row, since then there is nothing to leave behind. A wallet id that names no row
+     * goes through as well, having no currency to be asked about. On a row whose transactions
+     * are all in a wallet of the currency it points at, the first two are the same currency and
+     * this is the plain refusal to change the currency a saving or a debt is read in.
+     *
+     * They come apart on a row that was moved across currencies, and both are needed to leave one
+     * usable. Without the wallet it has now, the move to another wallet of the currency it is
+     * already read in would be refused, which puts nothing right and takes nothing further wrong.
+     * Without what is filed against it, the move back to the currency the transactions are really
+     * in would be refused, and that is the one move that puts the row right. Either way deleting
+     * the saving or the debt becomes the way out, and that takes every transaction filed against
+     * it.
+     *
+     * On a row whose transactions are already spread over several currencies, every one of those
+     * currencies goes through and only a currency it holds nothing in is refused. This does not
+     * work out which of them leaves the fewest transactions misread; a row like that cannot be put
+     * fully right by any single wallet, and picking between its currencies is a judgement this
+     * does not make.
+     *
+     * @param storedWalletId id of the wallet the row holds now.
+     * @param walletId id of the wallet the update names.
+     * @param selection what counts as filed against the row, over the transaction table as t.
+     * @param selectionArgs arguments of that selection.
+     * @throws SQLiteDataException if the wallet is found, its currency is not the one the row is
+     *                             read in now, and the row has transactions, none of them in it.
+     */
+    private void checkStrandedCurrency(long storedWalletId, long walletId, String selection,
+                                       String[] selectionArgs) {
+        String walletCurrency = walletCurrency(walletId);
+        if (walletCurrency == null || TextUtils.equals(walletCurrency,
+                walletCurrency(storedWalletId))) {
+            return;
+        }
+        if (noneIsHeldIn(walletCurrency, selection, selectionArgs)) {
+            String message = String.format(Locale.ENGLISH,
+                    "Wallet (id: %d) is in %s and nothing filed against this item is",
+                    walletId, walletCurrency);
+            throw new SQLiteDataException(Contract.ErrorCode.WALLETS_NOT_CONSISTENT, message);
+        }
+    }
+
+    /**
+     * Whether the selection matches at least one transaction and none of the ones it matches is
+     * held in this currency. False when it matches none at all, which is a row with nothing filed
+     * against it and nothing to say about where it may go.
+     *
+     * Counted in one statement instead of read back as a list, since the answer is a yes or a no
+     * and a saving or a debt can carry any number of rows.
+     */
+    private boolean noneIsHeldIn(String currency, String selection, String[] selectionArgs) {
+        String query = "SELECT COUNT(*), SUM(CASE WHEN w." + Schema.Wallet.CURRENCY +
+                " = ? THEN 1 ELSE 0 END) FROM " + Schema.Transaction.TABLE + " AS t JOIN " +
+                Schema.Wallet.TABLE + " AS w ON t." + Schema.Transaction.WALLET + " = w." +
+                Schema.Wallet.ID + " WHERE t." + Schema.Transaction.DELETED + " = 0 AND " +
+                selection;
+        String[] args = new String[selectionArgs.length + 1];
+        args[0] = currency;
+        System.arraycopy(selectionArgs, 0, args, 1, selectionArgs.length);
+        Cursor cursor = getReadableDatabase().rawQuery(query, args);
+        boolean noneIsHeldIn = false;
+        if (cursor != null) {
+            try {
+                if (cursor.moveToFirst()) {
+                    noneIsHeldIn = cursor.getLong(0) > 0L && cursor.getLong(1) == 0L;
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        return noneIsHeldIn;
+    }
+
+    /**
+     * The currency of one wallet, or null when there is no such row. Read straight off the table,
+     * so a wallet flagged deleted still answers and a saving or a debt left pointing at one can
+     * still be edited.
+     */
+    private String walletCurrency(long walletId) {
+        String[] projection = new String[] {Schema.Wallet.CURRENCY};
+        String selection = Schema.Wallet.ID + " = ?";
+        String[] selectionArgs = new String[] {String.valueOf(walletId)};
+        Cursor cursor = getReadableDatabase().query(Schema.Wallet.TABLE, projection, selection,
+                selectionArgs, null, null, null);
+        String currency = null;
+        if (cursor != null) {
+            try {
+                if (cursor.moveToFirst()) {
+                    currency = cursor.getString(cursor.getColumnIndex(Schema.Wallet.CURRENCY));
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        return currency;
+    }
+
+    /**
+     * The wallet a saving or a debt holds now, or null when there is no such row.
+     */
+    private Long storedWallet(String table, String idColumn, String walletColumn, long id) {
+        String[] projection = new String[] {walletColumn};
+        String selection = idColumn + " = ?";
+        String[] selectionArgs = new String[] {String.valueOf(id)};
+        Cursor cursor = getReadableDatabase().query(table, projection, selection, selectionArgs,
+                null, null, null);
+        Long walletId = null;
+        if (cursor != null) {
+            try {
+                if (cursor.moveToFirst()) {
+                    walletId = cursor.getLong(cursor.getColumnIndex(walletColumn));
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        return walletId;
+    }
+
+    /**
+     * Everything filed against a saving stays where it is when the saving moves.
+     *
+     * @param savingId id of the saving being updated.
+     * @param walletId id of the wallet the update names.
+     * @throws SQLiteDataException if checkStrandedCurrency refuses the wallet.
+     */
+    private void checkSavingWalletCurrency(long savingId, long walletId) {
+        Long storedWalletId = storedWallet(Schema.Saving.TABLE, Schema.Saving.ID,
+                Schema.Saving.WALLET, savingId);
+        if (storedWalletId == null || storedWalletId == walletId) {
+            return;
+        }
+        checkStrandedCurrency(storedWalletId, walletId, "t." + Schema.Transaction.SAVING + " = ?",
+                new String[] {String.valueOf(savingId)});
+    }
+
+    /**
+     * A debt's payments stay where they are when the debt moves. Its master transaction does not,
+     * it travels with the debt in both directions, so it is not something the move strands and it
+     * is left out of the question. Told apart by category, the way updateDebt and
+     * masterTransactionDebtId both tell them apart.
+     *
+     * @param debtId id of the debt being updated.
+     * @param walletId id of the wallet the update names.
+     * @throws SQLiteDataException if checkStrandedCurrency refuses the wallet.
+     */
+    private void checkDebtWalletCurrency(long debtId, long walletId) {
+        Long storedWalletId = storedWallet(Schema.Debt.TABLE, Schema.Debt.ID, Schema.Debt.WALLET,
+                debtId);
+        Long debtCategoryId = getSystemCategoryId(Schema.CategoryTag.DEBT);
+        Long creditCategoryId = getSystemCategoryId(Schema.CategoryTag.CREDIT);
+        // Without both category ids the master transaction cannot be told from a payment. Counting
+        // it as one refuses the move of a debt that has a master transaction and no payments,
+        // since that transaction sits in the wallet the debt is leaving and would then be the only
+        // thing answering for it. Nothing else here fails closed and neither does this.
+        if (storedWalletId == null || storedWalletId == walletId || debtCategoryId == null
+                || creditCategoryId == null) {
+            return;
+        }
+        String selection = "t." + Schema.Transaction.DEBT + " = ? AND t." +
+                Schema.Transaction.CATEGORY + " NOT IN (?, ?)";
+        String[] selectionArgs = new String[] {
+                String.valueOf(debtId),
+                String.valueOf(debtCategoryId),
+                String.valueOf(creditCategoryId)
+        };
+        checkStrandedCurrency(storedWalletId, walletId, selection, selectionArgs);
+    }
+
+    /**
      * Delete a budget from the database. If the 'mCacheDeletedObjects' flag is enabled the data
      * is not removed but simply flagged as deleted.
      *
@@ -3390,8 +3599,12 @@ import java.util.UUID;
      * @param savingId id of the saving to update.
      * @param contentValues bundle that contains the values to update.
      * @return the number of row affected.
+     * @throws SQLiteDataException if checkStrandedCurrency refuses the wallet.
      */
     /*package-local*/ int updateSaving(long savingId, ContentValues contentValues) {
+        if (contentValues.containsKey(Contract.Saving.WALLET_ID)) {
+            checkSavingWalletCurrency(savingId, contentValues.getAsLong(Contract.Saving.WALLET_ID));
+        }
         ContentValues cv = new ContentValues();
         if (contentValues.containsKey(Contract.Saving.COMPLETE)) {
             cv.put(Schema.Saving.COMPLETE, contentValues.getAsBoolean(Contract.Saving.COMPLETE));

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditDebtActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditDebtActivity.java
@@ -50,6 +50,7 @@ import com.oriondev.moneywallet.picker.PlacePicker;
 import com.oriondev.moneywallet.picker.WalletPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.SQLiteDataException;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.text.MaterialEditText;
 import com.oriondev.moneywallet.ui.view.text.NonEmptyTextValidator;
@@ -462,14 +463,26 @@ public class NewEditDebtActivity extends NewEditItemActivity implements IconPick
         contentValues.put(Contract.Debt.PEOPLE_IDS, Contract.getObjectIds(mPersonPicker.getCurrentPeople()));
         contentValues.put(Contract.Debt.INSERT_MASTER_TRANSACTION, addMasterTransaction);
         ContentResolver contentResolver = getContentResolver();
-        switch (mode) {
-            case NEW_ITEM:
-                contentResolver.insert(DataContentProvider.CONTENT_DEBTS, contentValues);
-                break;
-            case EDIT_ITEM:
-                Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, getItemId());
-                contentResolver.update(uri, contentValues, null, null);
-                break;
+        try {
+            switch (mode) {
+                case NEW_ITEM:
+                    contentResolver.insert(DataContentProvider.CONTENT_DEBTS, contentValues);
+                    break;
+                case EDIT_ITEM:
+                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, getItemId());
+                    contentResolver.update(uri, contentValues, null, null);
+                    break;
+            }
+        } catch (SQLiteDataException e) {
+            if (e.getErrorCode() != Contract.ErrorCode.WALLETS_NOT_CONSISTENT) {
+                throw e;
+            }
+            ThemedDialog.buildMaterialDialog(this)
+                    .title(R.string.title_error)
+                    .content(R.string.error_wallet_currency_not_consistent)
+                    .positiveText(android.R.string.ok)
+                    .show();
+            return;
         }
         setResult(Activity.RESULT_OK);
         finish();

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditSavingActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditSavingActivity.java
@@ -44,10 +44,12 @@ import com.oriondev.moneywallet.picker.MoneyPicker;
 import com.oriondev.moneywallet.picker.WalletPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.SQLiteDataException;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.text.MaterialEditText;
 import com.oriondev.moneywallet.ui.view.text.NonEmptyTextValidator;
 import com.oriondev.moneywallet.ui.view.text.Validator;
+import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.DateFormatter;
 import com.oriondev.moneywallet.utils.DateUtils;
@@ -300,14 +302,26 @@ public class NewEditSavingActivity extends NewEditItemActivity implements IconPi
             contentValues.put(Contract.Saving.COMPLETE, false);
             contentValues.put(Contract.Saving.NOTE, mNoteEditText.getTextAsString());
             ContentResolver contentResolver = getContentResolver();
-            switch (mode) {
-                case NEW_ITEM:
-                    contentResolver.insert(DataContentProvider.CONTENT_SAVINGS, contentValues);
-                    break;
-                case EDIT_ITEM:
-                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, getItemId());
-                    contentResolver.update(uri, contentValues, null, null);
-                    break;
+            try {
+                switch (mode) {
+                    case NEW_ITEM:
+                        contentResolver.insert(DataContentProvider.CONTENT_SAVINGS, contentValues);
+                        break;
+                    case EDIT_ITEM:
+                        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, getItemId());
+                        contentResolver.update(uri, contentValues, null, null);
+                        break;
+                }
+            } catch (SQLiteDataException e) {
+                if (e.getErrorCode() != Contract.ErrorCode.WALLETS_NOT_CONSISTENT) {
+                    throw e;
+                }
+                ThemedDialog.buildMaterialDialog(this)
+                        .title(R.string.title_error)
+                        .content(R.string.error_wallet_currency_not_consistent)
+                        .positiveText(android.R.string.ok)
+                        .show();
+                return;
             }
             setResult(Activity.RESULT_OK);
             finish();

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -55,6 +55,7 @@ import com.oriondev.moneywallet.picker.PlacePicker;
 import com.oriondev.moneywallet.picker.WalletPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.SQLiteDataException;
 import com.oriondev.moneywallet.storage.database.TransactionContentValuesBuilder;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.AttachmentView;
@@ -1230,17 +1231,29 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     .attachmentIds(Contract.getObjectIds(mAttachmentPicker.getCurrentAttachments()))
                     .build();
             ContentResolver contentResolver = getContentResolver();
-            switch (mode) {
-                case NEW_ITEM:
-                    contentResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
-                    if (mSavingId != null && mSavingCompleted) {
-                        setSavingCompleted(contentResolver, mSavingId);
-                    }
-                    break;
-                case EDIT_ITEM:
-                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS, getItemId());
-                    contentResolver.update(uri, contentValues, null, null);
-                    break;
+            try {
+                switch (mode) {
+                    case NEW_ITEM:
+                        contentResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
+                        if (mSavingId != null && mSavingCompleted) {
+                            setSavingCompleted(contentResolver, mSavingId);
+                        }
+                        break;
+                    case EDIT_ITEM:
+                        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS, getItemId());
+                        contentResolver.update(uri, contentValues, null, null);
+                        break;
+                }
+            } catch (SQLiteDataException e) {
+                if (e.getErrorCode() != Contract.ErrorCode.WALLETS_NOT_CONSISTENT) {
+                    throw e;
+                }
+                ThemedDialog.buildMaterialDialog(this)
+                        .title(R.string.title_error)
+                        .content(R.string.error_debt_wallet_currency_not_consistent)
+                        .positiveText(android.R.string.ok)
+                        .show();
+                return;
             }
             mAttachmentPicker.cleanUp(false);
             setResult(RESULT_OK);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,6 +290,8 @@
     <string name="error_input_missing_wallet">"Select a wallet"</string>
     <string name="error_input_missing_multiple_wallets">"Select at least one wallet"</string>
     <string name="error_input_invalid_multiple_wallets">"Wallets must have the same currency"</string>
+    <string name="error_wallet_currency_not_consistent">"You can only move this to a wallet in the currency it uses now, or one its transactions are in."</string>
+    <string name="error_debt_wallet_currency_not_consistent">"This would move the debt to a wallet in a different currency from its payments."</string>
     <string name="error_input_missing_date">"Select a date"</string>
     <string name="error_input_missing_start_date">"Select a start date"</string>
     <string name="error_input_missing_end_date">Select an end date</string>


### PR DESCRIPTION
Fixes #198.

A savings goal and a debt each live in one wallet, and that wallet decides the currency everything about them is read in. Their editors let you move them to a wallet in another currency and nothing converts. The target, the amount left to settle and the progress are all read again in the new currency while every deposit and payment stays in the wallet it was filed against, so the same digits come to mean something else.

A debt has a second way in. The entry that stands for the debt itself still offers a wallet, and changing it carries the debt across, so a debt can end up in another currency without its editor being opened at all. Its payments stay where they were.

The app now refuses a wallet unless it uses the currency the goal or the debt is read in today, or a currency some of its own entries are already in. One with nothing filed against it can still go anywhere, since it leaves nothing behind. The refusal happens in one place that all three ways in run through, so none of them is left open and none of them crashes.

That second half is there for anyone whose ledger has already been moved this way. Checking only against the wallet it sits in now would refuse the move back to the currency the money is really in, which is the one move that puts it right, and deleting would then be the only way out. Deleting a debt takes its payments with it.

One thing this does not cover is that a wallet's own currency can still be changed with nothing converted, which arrives at the same mismatch by another road.

Tested on an emulator holding a dollar wallet and a euro wallet. All three ways in are refused with a message and nothing is written. Moving a mismatched debt back to the currency its payments are in works, and the entry standing for the debt travels with it. Moving between two wallets of the same currency still works.
