### PR TITLE
A debt keeps the time of day on its own transaction

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -1281,6 +1281,29 @@ public class SQLDatabaseTest {
     }
 
     @Test
+    public void savingADebtKeepsItsMasterTransactionTime() throws Exception {
+        long walletId = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long categoryId = getSystemCategory(Contract.CategoryTag.DEBT);
+        Date picked = DateUtils.getDateFromSQLDateString("2026-07-01");
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-1", picked, null, walletId, "note-1", null, 2000L, false, null, "tag-1", true);
+        // A master transaction is created at the start of the debt's day, so the time under test
+        // has to be put there the way a user does it, through the transaction editor.
+        Date afternoon = DateUtils.getDateFromSQLDateTimeString("2026-07-01 14:30:45");
+        assertEquals(1, updateTransaction(masterTransactionId(debtId), 2000L, afternoon, "desc-1", categoryId,
+                Contract.Direction.INCOME, Contract.TransactionType.DEBT, walletId, null, "note-1",
+                null, null, debtId, true, true, null, null, "tag-1"));
+        assertEquals("2026-07-01 14:30:45", masterTransactionDate(debtId));
+        // The debt editor sends its date on every save, so this is a save that changed something
+        // else and never opened the date field.
+        assertEquals(1, updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-edited", picked, null, walletId, "note-1", null, 2000L, false, null, "tag-1"));
+        assertEquals("2026-07-01 14:30:45", masterTransactionDate(debtId));
+        // And a date that did move takes the transaction to the new day at the same time.
+        Date moved = DateUtils.getDateFromSQLDateString("2026-06-15");
+        assertEquals(1, updateDebt(debtId, Contract.DebtType.DEBT.getValue(), "encoded-icon-1", "desc-edited", moved, null, walletId, "note-1", null, 2000L, false, null, "tag-1"));
+        assertEquals("2026-06-15 14:30:45", masterTransactionDate(debtId));
+    }
+
+    @Test
     public void editingTheMasterTransactionMovesTheDebt() throws Exception {
         long walletId = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
         long otherWalletId = insertWallet("Test wallet 2", "encoded-icon-2", "EUR", "note-wallet-2", true, 2000L, false, "tag-wallet-2");

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -55,6 +55,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -2268,21 +2269,37 @@ import java.util.UUID;
 
     /**
      * A debt and its master transaction are the same event, so the transaction takes the debt's
-     * own date at the start of that day. The debt editor writes the date with no time of day, so
-     * the value cannot be carried across as it stands. Debt.DATE is NOT NULL in the schema, so
-     * the null branch cannot fire today and is only there to keep a schema change from becoming
-     * a crash here.
+     * day. Only the day, since the debt editor writes that date with no time of day. The time of
+     * day is the transaction's own, entered through the time picker in the transaction editor, and
+     * saving the debt no longer replaces it with the start of the day.
      *
-     * The parse is lenient, like every other getDateFromSQLDateString call in this app: a day
-     * past the end of its month rolls forward and a trailing time is dropped without complaint.
-     * NewEditDebtActivity is the only caller that writes this key and it always writes a plain
-     * valid date, so nothing here has to refuse those the way CSVDataImporter.parseDatetime does.
+     * A null transaction date is the insert path, where there is no transaction yet and no time to
+     * keep, so the new one starts at the beginning of the day. Debt.DATE is NOT NULL in the
+     * schema, so its own null branch cannot fire today and is only there to keep a schema change
+     * from becoming a crash here.
+     *
+     * The parse of the debt's date is lenient, like every other getDateFromSQLDateString call in
+     * this app, so a day past the end of its month rolls forward and a trailing time is dropped
+     * without complaint. NewEditDebtActivity is the only caller that writes this key and it always
+     * writes a plain valid date, so nothing here has to refuse those the way
+     * CSVDataImporter.parseDatetime does.
+     *
+     * The calendar that carries the time over is lenient too, so a time that does not exist on the
+     * debt's new day, the hour a spring forward skips, moves forward by the length of the skip.
+     * Tested on a device, 02:30:45 carried onto 2026-03-08 in America/New_York lands on 03:30:45.
+     * A time that happens twice on a fall back day writes back the string it was given.
      */
-    private static String masterTransactionDateFor(String debtDate) {
+    private static String masterTransactionDateFor(String debtDate, String transactionDate) {
         if (debtDate == null) {
             return DateUtils.getSQLDateTimeString(System.currentTimeMillis());
         }
-        return DateUtils.getSQLDateTimeString(DateUtils.getDateFromSQLDateString(debtDate));
+        Date day = DateUtils.getDateFromSQLDateString(debtDate);
+        if (transactionDate == null) {
+            return DateUtils.getSQLDateTimeString(day);
+        }
+        Calendar time = DateUtils.getCalendar(DateUtils.getDateFromSQLDateTimeString(transactionDate));
+        return DateUtils.getSQLDateTimeString(DateUtils.setTime(day, time.get(Calendar.HOUR_OF_DAY),
+                time.get(Calendar.MINUTE), time.get(Calendar.SECOND), 0));
     }
 
     /**
@@ -2375,14 +2392,11 @@ import java.util.UUID;
      * description this method just moved. renamedDebtIcon below carries them and says what it
      * leaves alone.
      *
-     * The debt row is written here instead of through updateDebt, which would push these same
-     * values straight back onto the transaction. The date is the one that would not survive the
-     * round trip, since a debt carries a day and a transaction a moment, so the way back would
-     * replace the time of day the user had just typed with the start of that day.
+     * The debt row is written here instead of through updateDebt, which would turn around and
+     * write the transaction a second time with the values it was just read from.
      *
-     * That is only this direction. Saving a debt from its own editor still puts its master
-     * transaction at the start of the day through masterTransactionDateFor, whether or not the
-     * date was touched, so a time entered here survives until the next save of the debt.
+     * A time of day entered here survives a later save of the debt, since masterTransactionDateFor
+     * takes only the day from the debt.
      */
     private void syncDebtOfMasterTransaction(long transactionId, ContentValues contentValues) {
         Long debtId = masterTransactionDebtId(transactionId);
@@ -2587,7 +2601,7 @@ import java.util.UUID;
                 cv = new ContentValues();
                 Contract.DebtType type = Contract.DebtType.fromValue(contentValues.getAsInteger(Contract.Debt.TYPE));
                 cv.put(Contract.Transaction.MONEY, contentValues.getAsLong(Contract.Debt.MONEY));
-                cv.put(Contract.Transaction.DATE, masterTransactionDateFor(contentValues.getAsString(Contract.Debt.DATE)));
+                cv.put(Contract.Transaction.DATE, masterTransactionDateFor(contentValues.getAsString(Contract.Debt.DATE), null));
                 cv.put(Contract.Transaction.DESCRIPTION, contentValues.getAsString(Contract.Debt.DESCRIPTION));
                 cv.put(Contract.Transaction.CATEGORY_ID, getSystemCategoryId((type == Contract.DebtType.DEBT) ? Schema.CategoryTag.DEBT : Schema.CategoryTag.CREDIT));
                 cv.put(Contract.Transaction.DIRECTION, (type == Contract.DebtType.CREDIT) ? Contract.Direction.EXPENSE : Contract.Direction.INCOME);
@@ -2666,7 +2680,8 @@ import java.util.UUID;
             Long debtCategoryId = getSystemCategoryId(Schema.CategoryTag.DEBT);
             Long creditCategoryId = getSystemCategoryId(Schema.CategoryTag.CREDIT);
             String[] projection = new String[] {
-                    Contract.Transaction.ID
+                    Contract.Transaction.ID,
+                    Contract.Transaction.DATE
             };
             String selection = Contract.Transaction.TYPE + " = ? AND " +
                     Contract.Transaction.DEBT_ID + " = ? AND (" +
@@ -2682,6 +2697,7 @@ import java.util.UUID;
             if (cursor != null) {
                 if (cursor.moveToFirst()) {
                     long transactionId = cursor.getLong(cursor.getColumnIndex(Contract.Transaction.ID));
+                    String transactionDate = cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE));
                     cv = new ContentValues();
                     if (contentValues.containsKey(Contract.Debt.MONEY)) {
                         cv.put(Contract.Transaction.MONEY, contentValues.getAsLong(Contract.Debt.MONEY));
@@ -2690,7 +2706,8 @@ import java.util.UUID;
                         cv.put(Contract.Transaction.DESCRIPTION, contentValues.getAsString(Contract.Debt.DESCRIPTION));
                     }
                     if (contentValues.containsKey(Contract.Debt.DATE)) {
-                        cv.put(Contract.Transaction.DATE, masterTransactionDateFor(contentValues.getAsString(Contract.Debt.DATE)));
+                        cv.put(Contract.Transaction.DATE, masterTransactionDateFor(
+                                contentValues.getAsString(Contract.Debt.DATE), transactionDate));
                     }
                     if (contentValues.containsKey(Contract.Debt.TYPE)) {
                         Contract.DebtType type = Contract.DebtType.fromValue(contentValues.getAsInteger(Contract.Debt.TYPE));


### PR DESCRIPTION
A debt is filed on a day. The transaction that records its money is filed on a day and a time, and the app shows that time and orders the list by it.

Saving a debt threw the time away. Open a debt, change the note or the amount, save, and the transaction it created falls back to midnight. The date field does not have to be touched or even opened, so nothing warns you it happened, and putting the time back only lasts until the next save of the debt.

The debt still decides the day and the transaction now keeps its own time. Moving a debt to another day takes its transaction to that day at the time it already had, which is what the date pickers elsewhere in the app already do. A debt being created still starts its transaction at the beginning of the day, since there is no time yet to keep.

It is worth more than a tidy reading. The time sets where the transaction sits among the other entries on that day, and it decides when an entry dated today starts counting toward a wallet balance and the totals built on it. Falling back to midnight moved the row and could start money counting earlier than the person who entered it asked for.

What this touches: saving a debt from its own editor. Archiving a debt, restoring a backup, an import and the upgrade from the old edition never wrote this date and still do not.

Checked on an emulator with the same debt and the same data on both builds. Before, a debt whose transaction was timed in the afternoon was opened and saved with nothing changed, and the transaction came back reading midnight. After, it keeps the afternoon time, and moving the debt two weeks on carries that time to the new day, which the transaction screen shows.

Fixes #200
