### PR TITLE
A home screen widget showing one wallet's balance

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/ui/widget/WalletWidgetPreferencesTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/ui/widget/WalletWidgetPreferencesTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.widget;
+
+import android.content.Context;
+import android.test.suitebuilder.annotation.LargeTest;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+@LargeTest
+public class WalletWidgetPreferencesTest {
+
+    private static final int WIDGET_A = 900001;
+    private static final int WIDGET_B = 900002;
+
+    private Context mContext;
+
+    @Before
+    public void setUp() {
+        mContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        clear();
+    }
+
+    @After
+    public void tearDown() {
+        clear();
+    }
+
+    private void clear() {
+        WalletWidgetPreferences.delete(mContext, new int[] {WIDGET_A, WIDGET_B});
+    }
+
+    @Test
+    public void anUnknownWidgetHasNoWallet() throws Exception {
+        assertEquals(WalletWidgetPreferences.NO_WALLET, WalletWidgetPreferences.getWallet(mContext, WIDGET_A));
+        // Off is the answer that keeps a balance off a locked phone, so it has to be what an
+        // unconfigured widget reads as and not merely what the checkbox happens to start at.
+        assertFalse(WalletWidgetPreferences.isShowWhenLocked(mContext, WIDGET_A));
+    }
+
+    @Test
+    public void twoWidgetsKeepSeparateWallets() throws Exception {
+        WalletWidgetPreferences.save(mContext, WIDGET_A, 11L, false);
+        WalletWidgetPreferences.save(mContext, WIDGET_B, 22L, true);
+        // The whole point of placing this widget more than once. Writing one placement must not
+        // reach another, which a single stored wallet id would not survive.
+        assertEquals(11L, WalletWidgetPreferences.getWallet(mContext, WIDGET_A));
+        assertEquals(22L, WalletWidgetPreferences.getWallet(mContext, WIDGET_B));
+        assertFalse(WalletWidgetPreferences.isShowWhenLocked(mContext, WIDGET_A));
+        assertTrue(WalletWidgetPreferences.isShowWhenLocked(mContext, WIDGET_B));
+    }
+
+    @Test
+    public void savingAgainReplacesBothValues() throws Exception {
+        WalletWidgetPreferences.save(mContext, WIDGET_A, 11L, true);
+        WalletWidgetPreferences.save(mContext, WIDGET_A, 33L, false);
+        assertEquals(33L, WalletWidgetPreferences.getWallet(mContext, WIDGET_A));
+        assertFalse(WalletWidgetPreferences.isShowWhenLocked(mContext, WIDGET_A));
+    }
+
+    @Test
+    public void deletingOneWidgetLeavesTheOther() throws Exception {
+        WalletWidgetPreferences.save(mContext, WIDGET_A, 11L, true);
+        WalletWidgetPreferences.save(mContext, WIDGET_B, 22L, true);
+        WalletWidgetPreferences.delete(mContext, new int[] {WIDGET_A});
+        // A launcher hands the same id out again after a widget is removed, so a deleted entry
+        // that lingered would point the next widget at a wallet nobody chose for it.
+        assertEquals(WalletWidgetPreferences.NO_WALLET, WalletWidgetPreferences.getWallet(mContext, WIDGET_A));
+        assertFalse(WalletWidgetPreferences.isShowWhenLocked(mContext, WIDGET_A));
+        assertEquals(22L, WalletWidgetPreferences.getWallet(mContext, WIDGET_B));
+        assertTrue(WalletWidgetPreferences.isShowWhenLocked(mContext, WIDGET_B));
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -97,6 +97,44 @@
         <activity android:name=".ui.activity.LockActivity" />
         <activity android:name=".ui.activity.BackendExplorerActivity" />
         <activity android:name=".ui.activity.ImportExportActivity" />
+        <!--
+          ~ Exported because the launcher is a different app and starts this itself on every
+          ~ version this app runs on. Only Android 12 and later can start a configuration screen
+          ~ that is not exported, through the host, and this app runs from API 24.
+          ~
+          ~ It hands out nothing. It is handed a widget id by whoever starts it, shows the wallet
+          ~ picker, and writes the choice against that id.
+          -->
+        <activity
+            android:name="com.oriondev.moneywallet.ui.widget.WalletWidgetConfigureActivity"
+            android:exported="true" >
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
+            </intent-filter>
+        </activity>
+
+        <!--
+          ~ Written out in full instead of as .ui.widget.WalletWidgetProvider on purpose. A
+          ~ relative name is expanded against the namespace in app/build.gradle, so renaming that
+          ~ namespace would change the component name the launcher is holding on the user's
+          ~ behalf, and every placed widget would disappear on the next update with no warning.
+          ~ The namespace here is still com.oriondev.moneywallet while the app ships as
+          ~ io.github.herrerad85.tallybook, so that rename is a thing someone may reasonably do.
+          ~
+          ~ The configuration activity above is written out for the same reason, since
+          ~ widget_wallet_info names it as a literal string that no rename would follow.
+          -->
+        <receiver
+            android:name="com.oriondev.moneywallet.ui.widget.WalletWidgetProvider"
+            android:exported="false"
+            android:label="@string/widget_label" >
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_wallet_info" />
+        </receiver>
 
         <provider
             android:name=".storage.database.DataContentProvider"

--- a/app/src/main/java/com/oriondev/moneywallet/App.java
+++ b/app/src/main/java/com/oriondev/moneywallet/App.java
@@ -35,6 +35,7 @@ import com.oriondev.moneywallet.storage.preference.BackendManager;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.notification.NotificationContract;
 import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
+import com.oriondev.moneywallet.ui.widget.WalletWidgetObserver;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 
 import me.weishu.reflection.Reflection;
@@ -59,6 +60,10 @@ public class App extends Application {
         // this existed needs one repair whether or not its language ever changes again, and a
         // system language changed while the process was dead delivers no configuration callback
         SystemCategoryLocalizer.relocalize(this);
+        // Registered here because a balance is moved by writes from all over the app, and this
+        // is the one place every one of them has already started. It gets its own thread and
+        // folds a burst of writes into one redraw, so an import does not pay for this per row.
+        WalletWidgetObserver.register(this);
         initializeScheduledTimers();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -34,6 +34,7 @@ import androidx.annotation.Nullable;
 
 import com.oriondev.moneywallet.BuildConfig;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.ui.widget.WalletWidgetProvider;
 
 import java.util.List;
 
@@ -839,6 +840,12 @@ public class DataContentProvider extends ContentProvider {
             if (contentProvider instanceof DataContentProvider) {
                 ((DataContentProvider) contentProvider).initializeDatabase(context);
                 PreferenceManager.setCurrentWallet(context, PreferenceManager.NO_CURRENT_WALLET);
+                // Same reason the current wallet is cleared just above. Every wallet is inserted
+                // fresh by a restore, so the ids come back naming other wallets, and a widget is
+                // pointed at one by its id. Left alone it would show a wallet nobody chose and
+                // file new transactions into it. Nothing on this path calls notifyChange either,
+                // which is why the redraw is asked for here.
+                WalletWidgetProvider.forgetConfiguredWallets(context);
             }
             client.close();
         }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
@@ -33,6 +33,7 @@ import com.oriondev.moneywallet.broadcast.DailyBroadcastReceiver;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.Group;
 import com.oriondev.moneywallet.model.LockMode;
+import com.oriondev.moneywallet.ui.widget.WalletWidgetObserver;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -163,6 +164,11 @@ public class PreferenceManager {
 
     public static void setCurrentLockMode(LockMode lockMode) {
         mPreferences.edit().putInt(CURRENT_LOCK_MODE, lockMode.getValue()).apply();
+        // A wallet balance sitting on the home screen is hidden while the app is locked, and
+        // turning the lock on writes no transaction, so nothing else would tell the widgets to
+        // stop showing it. Here and not at the ten call sites in LockActivity, which is also
+        // what setCurrentDailyReminder below does with its alarm.
+        WalletWidgetObserver.requestUpdate();
     }
 
     public static void setCurrentLockCode(String code) {
@@ -173,20 +179,28 @@ public class PreferenceManager {
         mPreferences.edit().putLong(LAST_LOCK_TIMESTAMP, time).apply();
     }
 
+    // These four decide how MoneyFormatter writes an amount, so each of them changes the figure a
+    // wallet widget is showing without anything being written to the ledger. Same reason as the
+    // lock above, and the same answer.
+
     public static void setCurrencyEnabled(boolean enabled) {
         mPreferences.edit().putBoolean(SHOW_CURRENCY, enabled).apply();
+        WalletWidgetObserver.requestUpdate();
     }
 
     public static void setGroupDigitsEnabled(boolean enabled) {
         mPreferences.edit().putBoolean(GROUP_DIGITS, enabled).apply();
+        WalletWidgetObserver.requestUpdate();
     }
 
     public static void setRoundDecimalsEnabled(boolean enabled) {
         mPreferences.edit().putBoolean(ROUND_DECIMALS, enabled).apply();
+        WalletWidgetObserver.requestUpdate();
     }
 
     public static void setShowPlusMinusSymbolEnabled(boolean enabled) {
         mPreferences.edit().putBoolean(SHOW_PLUS_MINUS_SYMBOL, enabled).apply();
+        WalletWidgetObserver.requestUpdate();
     }
 
     public static void setCurrentDateFormatIndex(int index) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -99,6 +99,14 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
      */
     public static final String DUPLICATE_ID = "NewEditTransactionActivity::DuplicateId";
 
+    /**
+     * The wallet a new transaction should open on, when the caller knows one. Without it the
+     * editor opens on whichever wallet the app is currently showing, which is the right answer
+     * from inside the app and the wrong one from a home screen widget, where the wallet the user
+     * tapped is the one they meant.
+     */
+    public static final String WALLET_ID = "NewEditTransactionActivity::WalletId";
+
     public static final int TYPE_STANDARD = 0;
     public static final int TYPE_TRANSFER = 1;
     public static final int TYPE_DEBT = 2;
@@ -552,7 +560,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             Contract.Wallet.START_MONEY,
                             Contract.Wallet.TOTAL_MONEY
                     };
-                    long currentWallet = PreferenceManager.getCurrentWallet();
+                    long currentWallet = intent.getLongExtra(WALLET_ID, PreferenceManager.getCurrentWallet());
                     Cursor cursor;
                     if (currentWallet == PreferenceManager.TOTAL_WALLET_ID) {
                         Uri uri = DataContentProvider.CONTENT_WALLETS;

--- a/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetConfigureActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetConfigureActivity.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.widget;
+
+import android.app.Activity;
+import android.appwidget.AppWidgetManager;
+import android.content.ContentUris;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentManager;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.model.Wallet;
+import com.oriondev.moneywallet.picker.WalletPicker;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
+import com.oriondev.moneywallet.ui.view.text.MaterialEditText;
+import com.oriondev.moneywallet.ui.view.text.Validator;
+import com.oriondev.moneywallet.ui.view.theme.ThemedCheckBox;
+import com.oriondev.moneywallet.utils.CurrencyManager;
+import com.oriondev.moneywallet.utils.IconLoader;
+
+/**
+ * Asks which wallet a widget being placed should show.
+ *
+ * The launcher starts this before the widget exists and takes RESULT_CANCELED as a refusal, so
+ * the placement is undone if the user backs out. That is why the cancelled result is set first
+ * and only replaced once a wallet has actually been chosen.
+ */
+public class WalletWidgetConfigureActivity extends NewEditItemActivity implements WalletPicker.SingleWalletController {
+
+    private static final String TAG_WALLET_PICKER = "WalletWidgetConfigureActivity::Tag::WalletPicker";
+
+    private int mAppWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID;
+
+    private MaterialEditText mWalletEditText;
+    private ThemedCheckBox mShowWhenLockedCheckBox;
+
+    private WalletPicker mWalletPicker;
+
+    @Override
+    protected void onCreateHeaderView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
+        // The wallet and the one checkbox both sit in the body, so there is nothing to put here.
+    }
+
+    @Override
+    protected void onCreatePanelView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.layout_panel_widget_configure, parent, true);
+        mWalletEditText = view.findViewById(R.id.wallet_edit_text);
+        mShowWhenLockedCheckBox = view.findViewById(R.id.show_when_locked_checkbox);
+        mWalletEditText.setTextViewMode(true);
+        mWalletEditText.addValidator(new Validator() {
+
+            @NonNull
+            @Override
+            public String getErrorMessage() {
+                return getString(R.string.error_input_missing_wallet);
+            }
+
+            @Override
+            public boolean isValid(@NonNull CharSequence charSequence) {
+                // Null until onViewCreated has a widget id to work with, and this activity is
+                // exported, so it can be started without one and torn down with the toolbar's
+                // save item already live.
+                return mWalletPicker != null && mWalletPicker.isSelected();
+            }
+
+            @Override
+            public boolean autoValidate() {
+                return false;
+            }
+
+        });
+        mWalletEditText.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                mWalletPicker.showSingleWalletPicker();
+            }
+
+        });
+    }
+
+    @Override
+    protected void onViewCreated(Bundle savedInstanceState) {
+        // Never the inherited edit mode. This activity is exported, because a launcher below
+        // Android 12 starts it itself, so any app on the device can send it an intent. The base
+        // class throws on an edit mode carrying no id, and there is nothing here to edit anyway,
+        // so the mode is fixed before it is read.
+        Intent launched = getIntent();
+        if (launched != null) {
+            launched.putExtra(MODE, Mode.NEW_ITEM);
+        }
+        super.onViewCreated(savedInstanceState);
+        Intent intent = getIntent();
+        if (intent != null && intent.getExtras() != null) {
+            mAppWidgetId = intent.getExtras().getInt(AppWidgetManager.EXTRA_APPWIDGET_ID,
+                    AppWidgetManager.INVALID_APPWIDGET_ID);
+        }
+        // Set before anything can finish this activity. Backing out has to leave the launcher
+        // holding nothing, and the launcher reads that from the result and not from us.
+        setResult(Activity.RESULT_CANCELED, resultIntent());
+        if (mAppWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish();
+            return;
+        }
+        // Seeded with whatever this placement already holds, which is nothing the first time and
+        // the chosen wallet when the user comes back through the launcher to change it. An empty
+        // field there would read as though the setting had been lost.
+        mShowWhenLockedCheckBox.setChecked(WalletWidgetPreferences.isShowWhenLocked(this, mAppWidgetId));
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        mWalletPicker = WalletPicker.createPicker(fragmentManager, TAG_WALLET_PICKER, configuredWallet());
+    }
+
+    /**
+     * The wallet this placement is set to, or null when it has none or the one it named is gone.
+     * A wallet that has been deleted leaves the field empty and the save refused, which is the
+     * same place a first time setup starts from.
+     */
+    private Wallet configuredWallet() {
+        long walletId = WalletWidgetPreferences.getWallet(this, mAppWidgetId);
+        if (walletId == WalletWidgetPreferences.NO_WALLET) {
+            return null;
+        }
+        String[] projection = new String[] {
+                Contract.Wallet.ID,
+                Contract.Wallet.NAME,
+                Contract.Wallet.ICON,
+                Contract.Wallet.CURRENCY,
+                Contract.Wallet.START_MONEY,
+                Contract.Wallet.TOTAL_MONEY
+        };
+        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, walletId);
+        Cursor cursor = getContentResolver().query(uri, projection, null, null, null);
+        if (cursor == null) {
+            return null;
+        }
+        try {
+            if (!cursor.moveToFirst()) {
+                return null;
+            }
+            return new Wallet(
+                    cursor.getLong(cursor.getColumnIndex(Contract.Wallet.ID)),
+                    cursor.getString(cursor.getColumnIndex(Contract.Wallet.NAME)),
+                    IconLoader.parse(cursor.getString(cursor.getColumnIndex(Contract.Wallet.ICON))),
+                    CurrencyManager.getCurrency(cursor.getString(cursor.getColumnIndex(Contract.Wallet.CURRENCY))),
+                    cursor.getLong(cursor.getColumnIndex(Contract.Wallet.START_MONEY)),
+                    cursor.getLong(cursor.getColumnIndex(Contract.Wallet.TOTAL_MONEY))
+            );
+        } finally {
+            cursor.close();
+        }
+    }
+
+    @Override
+    protected int getActivityTileRes(Mode mode) {
+        return R.string.title_activity_widget_configure;
+    }
+
+    @Override
+    protected void onSaveChanges(Mode mode) {
+        if (!mWalletEditText.validate()) {
+            return;
+        }
+        WalletWidgetPreferences.save(this, mAppWidgetId, mWalletPicker.getCurrentWallet().getId(),
+                mShowWhenLockedCheckBox.isChecked());
+        // The launcher does not draw a widget it has just been given, so the first picture of it
+        // has to be pushed from here. Without this the widget sits blank until something else
+        // writes a transaction.
+        AppWidgetManager.getInstance(this).updateAppWidget(mAppWidgetId,
+                WalletWidgetProvider.buildViews(this, mAppWidgetId));
+        setResult(Activity.RESULT_OK, resultIntent());
+        finish();
+    }
+
+    private Intent resultIntent() {
+        Intent intent = new Intent();
+        intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, mAppWidgetId);
+        return intent;
+    }
+
+    @Override
+    public void onWalletChanged(String tag, Wallet wallet) {
+        mWalletEditText.setText(wallet != null ? wallet.getName() : null);
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserver.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.widget;
+
+import android.content.Context;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.HandlerThread;
+
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+
+/**
+ * Pushes a redraw to the placed widgets whenever anything that can move a wallet balance is
+ * written.
+ *
+ * A balance does not only move when a transaction row is written, and the provider notifies the
+ * URI a write came through. A transfer notifies transfers, a debt with a master transaction
+ * notifies debts, and deleting a savings goal takes its transactions with it while notifying
+ * savings, so all of them put rows in or out of the transaction table the wallet total is summed
+ * from. Listening to transactions alone would leave a widget showing the figure from before a
+ * transfer until something unrelated was saved.
+ *
+ * The first four are what the wallet list cursor is registered on in DataContentProvider. Savings
+ * is the one this needs and that cursor does not, since a goal is deleted from a screen that
+ * rebuilds the wallet list on its way back anyway.
+ *
+ * This is what keeps the widget level with the app. The slow period in widget_wallet_info covers
+ * the other half, a transaction dated ahead coming due, which no write announces.
+ */
+public class WalletWidgetObserver extends ContentObserver {
+
+    /**
+     * Long enough to fold an import into one redraw and short enough that a save the user just
+     * made looks immediate. A CSV import writes one row at a time and the provider notifies on
+     * each, so without this a file of five thousand rows would ask for five thousand redraws.
+     */
+    private static final long COALESCE_DELAY_MILLIS = 250L;
+
+    private static final Uri[] OBSERVED_URIS = new Uri[] {
+            DataContentProvider.CONTENT_WALLETS,
+            DataContentProvider.CONTENT_TRANSACTIONS,
+            DataContentProvider.CONTENT_TRANSFERS,
+            DataContentProvider.CONTENT_DEBTS,
+            DataContentProvider.CONTENT_SAVINGS
+    };
+
+    private static volatile Handler sHandler;
+    private static volatile Runnable sUpdate;
+
+    private WalletWidgetObserver(Handler handler) {
+        super(handler);
+    }
+
+    /**
+     * Its own thread, and not the main one. Asking the system for the placed widget ids is a call
+     * into another process, and drawing one reads the wallet total, which is an aggregate over the
+     * transaction table. Neither belongs on the thread that has to draw the screen the user is
+     * looking at while the write that triggered this is still in progress.
+     *
+     * The thread lives as long as the process, like the observer it serves.
+     */
+    public static void register(Context context) {
+        final Context applicationContext = context.getApplicationContext();
+        // Published before the thread that reads them exists, so the thread cannot see half of
+        // this set up.
+        sUpdate = new Runnable() {
+
+            @Override
+            public void run() {
+                WalletWidgetProvider.updateAll(applicationContext);
+            }
+
+        };
+        HandlerThread thread = new HandlerThread("WalletWidgetObserver");
+        thread.start();
+        sHandler = new Handler(thread.getLooper());
+        WalletWidgetObserver observer = new WalletWidgetObserver(sHandler);
+        for (Uri uri : OBSERVED_URIS) {
+            // Descendants too, because the provider notifies the row it wrote and not the list.
+            applicationContext.getContentResolver().registerContentObserver(uri, true, observer);
+        }
+    }
+
+    /**
+     * For the things that change the figure without writing anything, the app lock and the four
+     * settings that decide how an amount is written. They are all set from a settings screen, so
+     * they get the same thread and the same folding as a write does.
+     */
+    public static void requestUpdate() {
+        Handler handler = sHandler;
+        Runnable update = sUpdate;
+        if (handler == null || update == null) {
+            return;
+        }
+        handler.removeCallbacks(update);
+        handler.postDelayed(update, COALESCE_DELAY_MILLIS);
+    }
+
+    @Override
+    public void onChange(boolean selfChange) {
+        requestUpdate();
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetPreferences.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetPreferences.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.widget;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+/**
+ * What one placed widget was configured with. The same widget can be placed once per wallet, so
+ * every value here is keyed by the id the launcher handed out for that placement.
+ *
+ * Its own preference file instead of the app's, because these entries are owned by the launcher's
+ * copy of the widget and are deleted with it. Mixing them into the settings the user edits would
+ * leave the ids of removed widgets sitting in a file nothing else ever cleans.
+ */
+class WalletWidgetPreferences {
+
+    static final long NO_WALLET = -1L;
+
+    private static final String FILE = "wallet_widget";
+    private static final String KEY_WALLET = "wallet::";
+    private static final String KEY_SHOW_WHEN_LOCKED = "show_when_locked::";
+
+    private static SharedPreferences preferences(Context context) {
+        return context.getSharedPreferences(FILE, Context.MODE_PRIVATE);
+    }
+
+    static void save(Context context, int appWidgetId, long walletId, boolean showWhenLocked) {
+        preferences(context).edit()
+                .putLong(KEY_WALLET + appWidgetId, walletId)
+                .putBoolean(KEY_SHOW_WHEN_LOCKED + appWidgetId, showWhenLocked)
+                .apply();
+    }
+
+    static long getWallet(Context context, int appWidgetId) {
+        return preferences(context).getLong(KEY_WALLET + appWidgetId, NO_WALLET);
+    }
+
+    static boolean isShowWhenLocked(Context context, int appWidgetId) {
+        return preferences(context).getBoolean(KEY_SHOW_WHEN_LOCKED + appWidgetId, false);
+    }
+
+    /**
+     * Called from onDeleted and from onRestored. Without it the file grows by two entries for
+     * every widget the user ever places and removes, and nothing else would ever know those ids
+     * are dead.
+     */
+    static void delete(Context context, int[] appWidgetIds) {
+        SharedPreferences.Editor editor = preferences(context).edit();
+        for (int appWidgetId : appWidgetIds) {
+            editor.remove(KEY_WALLET + appWidgetId);
+            editor.remove(KEY_SHOW_WHEN_LOCKED + appWidgetId);
+        }
+        editor.apply();
+    }
+
+    /**
+     * Forget which wallet every placement was pointed at, keeping the rest of what they hold.
+     *
+     * For a restored backup. A wallet is stored here by its row id, and a restore inserts every
+     * wallet fresh, so the ids come back meaning other wallets. A widget left holding the old
+     * number would show a wallet the user never chose and, worse, its button would file new
+     * transactions into it. DataContentProvider already clears the current wallet for the same
+     * reason on the same path.
+     */
+    static void clearWallets(Context context) {
+        SharedPreferences preferences = preferences(context);
+        SharedPreferences.Editor editor = preferences.edit();
+        for (String key : preferences.getAll().keySet()) {
+            if (key.startsWith(KEY_WALLET)) {
+                editor.remove(key);
+            }
+        }
+        editor.apply();
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetProvider.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.widget;
+
+import android.app.PendingIntent;
+import android.appwidget.AppWidgetManager;
+import android.appwidget.AppWidgetProvider;
+import android.content.ComponentName;
+import android.content.ContentUris;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.net.Uri;
+import android.view.View;
+import android.widget.RemoteViews;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.model.CurrencyUnit;
+import com.oriondev.moneywallet.model.LockMode;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.ui.activity.LauncherActivity;
+import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
+import com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity;
+import com.oriondev.moneywallet.utils.CurrencyManager;
+import com.oriondev.moneywallet.utils.MoneyFormatter;
+
+/**
+ * One wallet's balance on the home screen, with a button that opens the transaction editor on
+ * that same wallet.
+ *
+ * A placement holds one wallet, chosen in WalletWidgetConfigureActivity, so three wallets on the
+ * home screen means placing this three times. That is what the launcher's own model is built for
+ * and it costs nothing beyond the id keyed settings next door, where a list inside one widget
+ * would need a RemoteViewsService and a factory to feed it.
+ */
+public class WalletWidgetProvider extends AppWidgetProvider {
+
+    /**
+     * Redraw every placed widget. Called from WalletWidgetObserver when something that can move a
+     * balance is written, and from PreferenceManager when a setting the figure depends on changes.
+     *
+     * Not from the main thread. Asking for the ids is a call into another process and drawing one
+     * reads an aggregate over the transaction table.
+     */
+    public static void updateAll(Context context) {
+        AppWidgetManager manager = AppWidgetManager.getInstance(context);
+        if (manager == null) {
+            return;
+        }
+        int[] appWidgetIds = manager.getAppWidgetIds(new ComponentName(context, WalletWidgetProvider.class));
+        if (appWidgetIds != null) {
+            for (int appWidgetId : appWidgetIds) {
+                manager.updateAppWidget(appWidgetId, buildViews(context, appWidgetId));
+            }
+        }
+    }
+
+    /**
+     * Asked for by the system at a boot, at an install, after a restore and when the slow period
+     * comes round. Handed to the same thread the observer uses, because this arrives in a
+     * broadcast, and a broadcast runs on the main thread with seconds to return, which is no place
+     * to run one whole table aggregate per placed widget against a database a boot has just opened
+     * cold.
+     */
+    @Override
+    public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
+        WalletWidgetObserver.requestUpdate();
+    }
+
+    @Override
+    public void onDeleted(Context context, int[] appWidgetIds) {
+        WalletWidgetPreferences.delete(context, appWidgetIds);
+    }
+
+    /**
+     * A widget carried onto another device by a restore. The settings here do not travel with it,
+     * since backup_rules and data_extraction_rules both carry the database and not the shared
+     * preferences, so there is nothing to move across and the widget comes back asking to be set
+     * up again.
+     *
+     * What this has to do is clear the new ids. The launcher hands out ids that a widget on this
+     * device may have used before, and a leftover entry under one of them would point the restored
+     * widget at a wallet nobody chose for it, in a ledger whose row ids the restore has reassigned
+     * anyway.
+     */
+    @Override
+    public void onRestored(Context context, int[] oldWidgetIds, int[] newWidgetIds) {
+        WalletWidgetPreferences.delete(context, newWidgetIds);
+    }
+
+    /**
+     * Every placement forgets which wallet it was pointed at, and they all redraw.
+     *
+     * For a restored backup, which inserts every wallet fresh, so the row ids a placement is
+     * holding come back naming other wallets. Called from DataContentProvider, which is where the
+     * app already clears the current wallet for that reason. The one way into this package from
+     * outside it, so the id keyed settings stay private to the widget.
+     */
+    public static void forgetConfiguredWallets(Context context) {
+        WalletWidgetPreferences.clearWallets(context);
+        WalletWidgetObserver.requestUpdate();
+    }
+
+    /*package-local*/ static RemoteViews buildViews(Context context, int appWidgetId) {
+        RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.widget_wallet);
+        // The app can be held behind a pin, a sequence or a fingerprint, and a balance drawn on
+        // the home screen is readable by anyone holding the phone, which walks straight past that
+        // lock. So a locked app hides the figure unless this placement was told not to.
+        if (PreferenceManager.getCurrentLockMode() != LockMode.NONE
+                && !WalletWidgetPreferences.isShowWhenLocked(context, appWidgetId)) {
+            return message(context, views, R.string.widget_message_locked, appWidgetId);
+        }
+        long walletId = WalletWidgetPreferences.getWallet(context, appWidgetId);
+        if (walletId == WalletWidgetPreferences.NO_WALLET) {
+            return message(context, views, R.string.widget_message_not_configured, appWidgetId);
+        }
+        String[] projection = new String[] {
+                Contract.Wallet.NAME,
+                Contract.Wallet.CURRENCY,
+                Contract.Wallet.START_MONEY,
+                Contract.Wallet.TOTAL_MONEY
+        };
+        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, walletId);
+        Cursor cursor = context.getContentResolver().query(uri, projection, null, null, null);
+        String name = null;
+        String balance = null;
+        if (cursor != null) {
+            try {
+                if (cursor.moveToFirst()) {
+                    name = cursor.getString(cursor.getColumnIndex(Contract.Wallet.NAME));
+                    // The figure the drawer shows is the starting money plus the total, and the
+                    // total on its own is not a balance. Reading it the same way here is what
+                    // keeps the widget and the app from disagreeing about one wallet.
+                    long money = cursor.getLong(cursor.getColumnIndex(Contract.Wallet.START_MONEY))
+                            + cursor.getLong(cursor.getColumnIndex(Contract.Wallet.TOTAL_MONEY));
+                    // A currency this install cannot resolve is handed over as it is, because
+                    // getNotTintedString takes a null one and falls back to two decimals with no
+                    // symbol. That is what every other balance in the app does with it, and a
+                    // widget that refused where the wallet list prints a figure would be the one
+                    // screen calling a readable wallet broken.
+                    CurrencyUnit currency = CurrencyManager.getCurrency(
+                            cursor.getString(cursor.getColumnIndex(Contract.Wallet.CURRENCY)));
+                    balance = MoneyFormatter.getInstance().getNotTintedString(currency, money);
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        if (name == null || balance == null) {
+            // The wallet this placement was pointed at is gone. Also where a restored backup
+            // lands, since a restore gives every wallet a fresh id and the ids held here are
+            // cleared with the swap, so the widget asks to be set up again instead of quietly
+            // showing whichever wallet inherited the old number.
+            return message(context, views, R.string.widget_message_wallet_missing, appWidgetId);
+        }
+        views.setViewVisibility(R.id.widget_message, View.GONE);
+        views.setViewVisibility(R.id.widget_content, View.VISIBLE);
+        views.setTextViewText(R.id.widget_wallet_name, name);
+        views.setTextViewText(R.id.widget_wallet_balance, balance);
+        views.setOnClickPendingIntent(R.id.widget_content, openApp(context, appWidgetId));
+        views.setOnClickPendingIntent(R.id.widget_add_button, newTransaction(context, appWidgetId, walletId));
+        return views;
+    }
+
+    private static RemoteViews message(Context context, RemoteViews views, int messageRes, int appWidgetId) {
+        views.setViewVisibility(R.id.widget_content, View.GONE);
+        views.setViewVisibility(R.id.widget_message, View.VISIBLE);
+        views.setTextViewText(R.id.widget_message, context.getString(messageRes));
+        // The header names the app and then the wallet, and the wallet has to go with the figure.
+        // A locked widget that still said which account it was watching would hand over half of
+        // what the lock is there to keep, and the other states have no wallet to name.
+        views.setTextViewText(R.id.widget_wallet_name, null);
+        views.setOnClickPendingIntent(R.id.widget_message, openApp(context, appWidgetId));
+        return views;
+    }
+
+    /**
+     * Through LauncherActivity and not straight into MainActivity. Its javadoc says every route
+     * into the app passes through it, and the shortcut publishing it does leans on that, so a
+     * widget that jumped the queue would quietly make that false.
+     */
+    private static PendingIntent openApp(Context context, int appWidgetId) {
+        Intent intent = new Intent(context, LauncherActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);
+        return activity(context, requestCode(appWidgetId, 0), intent);
+    }
+
+    private static PendingIntent newTransaction(Context context, int appWidgetId, long walletId) {
+        Intent intent = new Intent(context, NewEditTransactionActivity.class);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        intent.putExtra(NewEditItemActivity.MODE, NewEditItemActivity.Mode.NEW_ITEM);
+        intent.putExtra(NewEditTransactionActivity.TYPE, NewEditTransactionActivity.TYPE_STANDARD);
+        intent.putExtra(NewEditTransactionActivity.WALLET_ID, walletId);
+        return activity(context, requestCode(appWidgetId, 1), intent);
+    }
+
+    private static PendingIntent activity(Context context, int requestCode, Intent intent) {
+        return PendingIntent.getActivity(context, requestCode, intent,
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    }
+
+    /**
+     * Two placements showing two wallets need two pending intents that the system tells apart, and
+     * the extras are not part of what it compares. Only the request code is, so it carries both
+     * the placement and which of this widget's two targets is meant.
+     */
+    private static int requestCode(int appWidgetId, int target) {
+        return appWidgetId * 2 + target;
+    }
+}

--- a/app/src/main/res/drawable/ic_widget_tallybook.xml
+++ b/app/src/main/res/drawable/ic_widget_tallybook.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Tallybook mark for the widget header.
+  ~ Original artwork for the Tallybook fork, released under the project's GPLv3 license.
+  -->
+
+<!--
+  ~ The launcher icon's own foreground, drawn small. The viewport is the icon's 108 so the path
+  ~ is the same one ic_launcher_foreground carries, and only the size it is asked to fill differs.
+  ~ Copied instead of referenced because the launcher icon leaves the wide margin an adaptive icon
+  ~ needs for masking, which would shrink the mark to nothing at header size.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="60"
+    android:viewportHeight="60" >
+    <path
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="7"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"
+        android:pathData="M14,12 L14,48 M25,12 L25,48 M36,12 L36,48 M47,12 L47,48 M7,51 L54,9" />
+</vector>

--- a/app/src/main/res/drawable/widget_background.xml
+++ b/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle" >
+    <corners android:radius="@dimen/widget_background_radius" />
+    <solid android:color="@color/widget_background" />
+</shape>

--- a/app/src/main/res/drawable/widget_header_background.xml
+++ b/app/src/main/res/drawable/widget_header_background.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  ~ The strip along the top of the widget. Rounded on top to sit inside the card's own corners and
+  ~ square on the bottom, where it meets the white.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+       android:shape="rectangle" >
+    <corners
+        android:topLeftRadius="@dimen/widget_background_radius"
+        android:topRightRadius="@dimen/widget_background_radius" />
+    <solid android:color="@color/widget_header_background" />
+</shape>

--- a/app/src/main/res/drawable/widget_preview.xml
+++ b/app/src/main/res/drawable/widget_preview.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  ~ What the widget picker shows on Android 11 and earlier, where previewLayout is not read and
+  ~ the picker would otherwise fall back to the app icon. It stands in for the same thing the
+  ~ layout draws, a wallet name over a balance with the add button beside them.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="180dp"
+    android:height="60dp"
+    android:viewportWidth="180"
+    android:viewportHeight="60" >
+
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,4 L164,4 A12,12 0 0 1 176,16 L176,44 A12,12 0 0 1 164,56 L16,56 A12,12 0 0 1 4,44 L4,16 A12,12 0 0 1 16,4 Z" />
+    <path
+        android:fillColor="#B3424242"
+        android:pathData="M16,4 L164,4 A12,12 0 0 1 176,16 L176,20 L4,20 L4,16 A12,12 0 0 1 16,4 Z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M14,9 L14,15 M20,9 L20,15 M26,9 L26,15 Z" />
+    <path
+        android:fillColor="#DE000000"
+        android:pathData="M16,32 L102,32 L102,45 L16,45 Z" />
+    <path
+        android:fillColor="#DE000000"
+        android:pathData="M152,32 L156,32 L156,36 L160,36 L160,40 L156,40 L156,44 L152,44 L152,40 L148,40 L148,36 L152,36 Z" />
+
+</vector>

--- a/app/src/main/res/layout/layout_panel_widget_configure.xml
+++ b/app/src/main/res/layout/layout_panel_widget_configure.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<merge
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:parentTag="android.widget.LinearLayout"
+    tools:orientation="vertical" >
+
+    <com.oriondev.moneywallet.ui.view.theme.ThemedMaterialEditText
+        android:id="@+id/wallet_edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/material_activity_body_edit_text_margin_top"
+        android:layout_marginBottom="@dimen/material_activity_body_edit_text_margin_bottom"
+        android:hint="@string/hint_wallet"
+        android:inputType="textMultiLine"
+        app:met_mode="floatingLabel"
+        app:met_leftIcon="@drawable/ic_folder_black_24dp" />
+
+    <com.oriondev.moneywallet.ui.view.theme.ThemedCheckBox
+        android:id="@+id/show_when_locked_checkbox"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/material_activity_body_check_box_top_bottom_margin"
+        android:layout_marginBottom="@dimen/material_activity_body_check_box_top_bottom_margin"
+        android:layout_marginLeft="@dimen/material_activity_body_check_box_start_end_margin"
+        android:layout_marginRight="@dimen/material_activity_body_check_box_start_end_margin"
+        android:paddingLeft="@dimen/material_activity_body_check_box_start_padding"
+        android:paddingStart="@dimen/material_activity_body_check_box_start_padding"
+        android:text="@string/hint_widget_show_when_locked"
+        tools:ignore="RtlSymmetry" />
+
+</merge>

--- a/app/src/main/res/layout/widget_wallet.xml
+++ b/app/src/main/res/layout/widget_wallet.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  ~ This layout is also the widget picker preview, named by previewLayout in widget_wallet_info.
+  ~ The wallet and the amount set here are what the picker shows, so they read as a plausible
+  ~ wallet and not as a placeholder. Both are overwritten the moment a placed widget is drawn.
+  ~
+  ~ A strip naming the app over a white card. A tile holding a bare figure says nothing about
+  ~ where the figure came from once it is sitting among a screen of other tiles.
+  ~
+  ~ Two lines and no more. The row a widget gets on a phone is around 70dp and the add button
+  ~ alone is a 44dp touch target, so a third line would push this into a second row and take twice
+  ~ the home screen for the same one number.
+  -->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:orientation="vertical" >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/widget_header_background"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingLeft="@dimen/widget_padding"
+        android:paddingRight="@dimen/widget_padding"
+        android:paddingTop="@dimen/widget_header_padding"
+        android:paddingBottom="@dimen/widget_header_padding" >
+
+        <ImageView
+            android:layout_width="@dimen/widget_header_icon"
+            android:layout_height="@dimen/widget_header_icon"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_widget_tallybook" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/widget_header_spacing"
+            android:layout_marginStart="@dimen/widget_header_spacing"
+            android:text="@string/app_name"
+            android:textColor="@color/widget_header_text"
+            android:textSize="10sp" />
+
+        <TextView
+            android:id="@+id/widget_wallet_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/widget_header_spacing"
+            android:layout_marginStart="@dimen/widget_header_spacing"
+            android:layout_weight="1"
+            android:ellipsize="end"
+            android:gravity="end"
+            android:maxLines="1"
+            android:text="@string/widget_preview_wallet_name"
+            android:textColor="@color/widget_header_text"
+            android:textSize="10sp" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/widget_content"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingLeft="@dimen/widget_padding"
+        android:paddingRight="@dimen/widget_padding"
+        android:paddingTop="@dimen/widget_padding_vertical"
+        android:paddingBottom="@dimen/widget_padding_vertical" >
+
+        <!--
+          ~ The balance shrinks to fit instead of ellipsizing. A cut off figure is the one thing
+          ~ this widget must never show, and the width it has to work in is decided by the user,
+          ~ who can drag it down to the smallest size the provider allows.
+          ~
+          ~ autoSizeTextType is read from API 26 and ignored below it, where the text stays at
+          ~ textSize and a long figure can still be cut. That is two of the versions this app
+          ~ supports and the framework carries no backport of it.
+          -->
+        <TextView
+            android:id="@+id/widget_wallet_balance"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:autoSizeMaxTextSize="20sp"
+            android:autoSizeMinTextSize="12sp"
+            android:autoSizeTextType="uniform"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:text="@string/widget_preview_wallet_balance"
+            android:textColor="@color/widget_text_primary"
+            android:textSize="20sp" />
+
+        <ImageView
+            android:id="@+id/widget_add_button"
+            android:layout_width="@dimen/widget_touch_target"
+            android:layout_height="@dimen/widget_touch_target"
+            android:contentDescription="@string/widget_add_transaction"
+            android:padding="@dimen/widget_button_padding"
+            android:src="@drawable/ic_add_24dp"
+            android:tint="@color/widget_text_primary" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/widget_message"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:paddingLeft="@dimen/widget_padding"
+        android:paddingRight="@dimen/widget_padding"
+        android:text="@string/widget_message_not_configured"
+        android:textColor="@color/widget_text_secondary"
+        android:textSize="13sp"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/widget_wallet_initial.xml
+++ b/app/src/main/res/layout/widget_wallet_initial.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  ~ What the launcher draws between the moment the widget is dropped and the moment the app hands
+  ~ it something to show, which is at least as long as the configuration screen is open.
+  ~
+  ~ Its own file, and not the layout the widget itself uses, because that one carries a sample
+  ~ wallet and a sample balance so the picker has something to show. Drawing those here would put
+  ~ an invented amount of money on the home screen, styled exactly like a real reading, before the
+  ~ user has even said which wallet they meant.
+  -->
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:gravity="center"
+    android:padding="@dimen/widget_padding"
+    android:text="@string/widget_message_not_configured"
+    android:textColor="@color/widget_text_secondary"
+    android:textSize="14sp" />

--- a/app/src/main/res/values-night/widget.xml
+++ b/app/src/main/res/values-night/widget.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  ~ The same tile with the ink turned over, for a phone the user has put in its dark theme. The
+  ~ launcher inflates this layout against the system configuration, so nothing has to ask which
+  ~ theme is on and nothing is stored per widget.
+  ~
+  ~ The strip is a light wash here where the default set has a dark one, because it composites
+  ~ against the card behind it and a dark wash on a dark card is no strip at all.
+  ~
+  ~ Only what changes. widget_header_text is white against both, and the sizes and the radius are
+  ~ not a matter of theme.
+  -->
+<resources>
+    <color name="widget_background">#FF202124</color>
+    <color name="widget_header_background">#33FFFFFF</color>
+    <color name="widget_text_primary">#FFFFFFFF</color>
+    <color name="widget_text_secondary">#B3FFFFFF</color>
+</resources>

--- a/app/src/main/res/values-v31/widget.xml
+++ b/app/src/main/res/values-v31/widget.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  ~ Only the corner radius follows the platform here. The colors are the app's own and do not
+  ~ change with the system palette, so they stay in the default set.
+  -->
+<resources>
+    <dimen name="widget_background_radius">@android:dimen/system_app_widget_background_radius</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -729,5 +729,15 @@
     <string name="notification_channel_name_exchange_rate">"Exchange rates"</string>
     <string name="notification_channel_name_error">"Error"</string>
 
+    <string name="widget_label">"Wallet balance"</string>
+    <string name="widget_description">"The money in one wallet, with a button that adds a transaction to it"</string>
+    <string name="widget_add_transaction">"Add a transaction"</string>
+    <string name="widget_preview_wallet_name">"Wallet"</string>
+    <string name="widget_preview_wallet_balance">"$ 1,240.00"</string>
+    <string name="widget_message_locked">"Tallybook is locked"</string>
+    <string name="widget_message_not_configured">"Set this widget up again to choose a wallet"</string>
+    <string name="widget_message_wallet_missing">"This wallet is gone. Add the widget again to pick another one."</string>
+    <string name="title_activity_widget_configure">"Wallet balance"</string>
+    <string name="hint_widget_show_when_locked">"Show the balance even when the app is locked"</string>
 
 </resources>

--- a/app/src/main/res/values/widget.xml
+++ b/app/src/main/res/values/widget.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  ~ A card under a strip that names the app.
+  ~
+  ~ The strip carries an alpha and is drawn over the card, not over the home screen, so what it
+  ~ composites against is the card behind it and never the wallpaper. That is why values-night
+  ~ turns it over as well: dark ink on a white card becomes light ink on a dark one, and the same
+  ~ value carried across would leave the strip and the card the same shade.
+  -->
+<resources>
+    <color name="widget_background">#FFFFFFFF</color>
+    <color name="widget_header_background">#B3424242</color>
+    <color name="widget_header_text">#FFFFFFFF</color>
+    <color name="widget_text_primary">#DE000000</color>
+    <color name="widget_text_secondary">#8A000000</color>
+    <dimen name="widget_background_radius">16dp</dimen>
+    <dimen name="widget_padding">12dp</dimen>
+    <dimen name="widget_padding_vertical">4dp</dimen>
+    <dimen name="widget_header_padding">4dp</dimen>
+    <dimen name="widget_button_padding">12dp</dimen>
+    <dimen name="widget_touch_target">44dp</dimen>
+    <dimen name="widget_header_icon">12dp</dimen>
+    <dimen name="widget_header_spacing">6dp</dimen>
+</resources>

--- a/app/src/main/res/xml/widget_wallet_info.xml
+++ b/app/src/main/res/xml/widget_wallet_info.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+  ~ minWidth and minHeight are what devices before Android 12 size this by, and targetCellWidth
+  ~ and targetCellHeight replace them from Android 12 on, where the launcher counts grid cells
+  ~ instead of guessing from a width. Both are declared because this app runs from API 24.
+  ~
+  ~ The smallest size allowed has to be one the layout still reads in. The add button is a 48dp
+  ~ target and the padding is 12dp on each side, so anything under 72dp high clips the button, and
+  ~ the width left for the figure is what is asked for minus those same 24dp and the button. At
+  ~ 180dp that leaves 108dp, which the balance can shrink into. Allowing less would guarantee the
+  ~ cut off figure the layout goes out of its way to avoid.
+  ~
+  ~ Two things redraw this, and they cover different causes. WalletWidgetObserver pushes a redraw
+  ~ the moment a wallet or a transaction is written, which is what makes the figure keep up with
+  ~ the app. updatePeriodMillis covers the one change no write announces, a transaction dated
+  ~ ahead coming due, since every balance in this app counts only rows dated at or before now, so
+  ~ a widget touched by nothing can go wrong as the clock passes it.
+  ~
+  ~ Six hours, not minutes. The period exists to bound how long that one case can sit wrong, and
+  ~ a short one would wake the device to redraw a figure that almost never moved.
+  -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:configure="com.oriondev.moneywallet.ui.widget.WalletWidgetConfigureActivity"
+    android:description="@string/widget_description"
+    android:initialLayout="@layout/widget_wallet_initial"
+    android:minHeight="72dp"
+    android:minResizeHeight="72dp"
+    android:minResizeWidth="180dp"
+    android:minWidth="250dp"
+    android:previewImage="@drawable/widget_preview"
+    android:previewLayout="@layout/widget_wallet"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellHeight="1"
+    android:targetCellWidth="3"
+    android:updatePeriodMillis="21600000"
+    android:widgetCategory="home_screen"
+    android:widgetFeatures="reconfigurable" />


### PR DESCRIPTION
The app has never had a home screen widget. This adds one, and it is the thing three people asked for upstream.

It shows the money in one wallet, and it carries a plus button that opens a new transaction already pointed at that wallet. When you drop it on the home screen it asks which wallet you want.

One wallet per widget. Three wallets on your home screen means placing it three times, which is what the home screen is built to do, and each remembers its own wallet.

The figure it shows is the same one the app shows. That is the part most likely to go wrong, because the balance in this app is not simply the sum of what is in a wallet, it leaves out anything dated in the future and anything not confirmed. The widget asks for it the same way the app does, so the two cannot drift apart.

It keeps up on its own. Save anything that moves a balance and the widget has already changed by the time you are back on the home screen. One thing a save cannot announce is a transaction you dated in the future arriving, so it also looks again every few hours.

If you have a pin, a pattern or a fingerprint on the app, the widget does not show the balance. A number on the home screen is readable by anyone who picks up the phone, which is the thing you turned that lock on to stop. You can allow it per widget if you want it anyway, and turning the lock on hides it straight away, not the next time something happens.

It carries a strip naming the app and the wallet, so a bare figure is not a mystery among other tiles, and it drops the wallet name whenever the balance is hidden. The balance shrinks to fit instead of being cut off, and the tile turns over to a dark version when the phone does.

What this touches: nothing that already existed changes for anyone who never adds it.

Fixes #127
