### PR TITLE
Let a budget cover more than one category

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -518,6 +518,56 @@ public class SQLDatabaseTest {
         return mDatabase.updateBudget(id, contentValues);
     }
 
+    private long insertBudgetCovering(int type, Long[] categoryIds, Date startDate, Date endDate, long money,
+                              String currency, Long[] walletIds, String tag) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(Contract.Budget.TYPE, type);
+        contentValues.put(Contract.Budget.CATEGORY_IDS, getObjectIds(categoryIds));
+        contentValues.put(Contract.Budget.START_DATE, DateUtils.getSQLDateString(startDate));
+        contentValues.put(Contract.Budget.END_DATE, DateUtils.getSQLDateString(endDate));
+        contentValues.put(Contract.Budget.MONEY, money);
+        contentValues.put(Contract.Budget.CURRENCY, currency);
+        contentValues.put(Contract.Budget.WALLET_IDS, getObjectIds(walletIds));
+        contentValues.put(Contract.Budget.TAG, tag);
+        return mDatabase.insertBudget(contentValues);
+    }
+
+    private int updateBudgetCovering(long id, int type, Long[] categoryIds, Date startDate, Date endDate,
+                             long money, String currency, Long[] walletIds, String tag) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(Contract.Budget.TYPE, type);
+        contentValues.put(Contract.Budget.CATEGORY_IDS, getObjectIds(categoryIds));
+        contentValues.put(Contract.Budget.START_DATE, DateUtils.getSQLDateString(startDate));
+        contentValues.put(Contract.Budget.END_DATE, DateUtils.getSQLDateString(endDate));
+        contentValues.put(Contract.Budget.MONEY, money);
+        contentValues.put(Contract.Budget.CURRENCY, currency);
+        contentValues.put(Contract.Budget.WALLET_IDS, getObjectIds(walletIds));
+        contentValues.put(Contract.Budget.TAG, tag);
+        return mDatabase.updateBudget(id, contentValues);
+    }
+
+    /**
+     * Reads back what a budget covers, both the way the editor reads it and the way the list row
+     * shows it.
+     *
+     * @param id of the budget.
+     * @param categoryIds every category it should cover, lowest id first, which is the order
+     *                    a query hands them over in.
+     * @param joinedNames the names the list row should show, joined the way the query joins them.
+     * @param progress the figure the budget should now be at.
+     */
+    private void checkBudgetCategories(long id, Long[] categoryIds, String joinedNames, long progress) {
+        Cursor cursor = mDatabase.getBudget(id, null);
+        assertNotNull(cursor);
+        assertEquals(1, cursor.getCount());
+        assertEquals(true, cursor.moveToFirst());
+        assertEquals(getObjectIds(categoryIds), cursor.getString(cursor.getColumnIndex(Contract.Budget.CATEGORY_IDS)));
+        assertEquals(joinedNames, cursor.getString(cursor.getColumnIndex(Contract.Budget.CATEGORY_NAME)));
+        assertEquals((long) categoryIds[0], cursor.getLong(cursor.getColumnIndex(Contract.Budget.CATEGORY_ID)));
+        assertEquals(progress, cursor.getLong(cursor.getColumnIndex(Contract.Budget.PROGRESS)));
+        cursor.close();
+    }
+
     private void checkSavingId(long id, String description, String icon, long startMoney,
                                long endMoney, long walletId, Date exp, boolean completed,
                                String note, String tag) {
@@ -1667,6 +1717,89 @@ public class SQLDatabaseTest {
         checkBudgetId(id7, Schema.BudgetType.INCOMES, null, startDate, endDate, 5000L, "EUR", walletIds1, "tag-1", 0L);
         checkBudgetId(id8, Schema.BudgetType.EXPENSES, null, startDate, endDate, 10000L, "EUR", walletIds2, "tag-2", 0L);
         checkBudgetId(id9, Schema.BudgetType.CATEGORY, id6, startDate, endDate, 13000L, "USD", walletIds3, "tag-3", 0L);
+    }
+
+    @Test
+    public void budgetCoveringSeveralCategoriesCountsThemAll() throws Exception {
+        long wallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long food = insertCategory("Food", "encoded-icon-food", 1, null, true, "tag-food");
+        long rent = insertCategory("Rent", "encoded-icon-rent", 1, null, true, "tag-rent");
+        long petrol = insertCategory("Petrol", "encoded-icon-petrol", 1, null, true, "tag-petrol");
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.MONTH, -3);
+        Date startDate = calendar.getTime();
+        calendar.add(Calendar.MONTH, 6);
+        Date endDate = calendar.getTime();
+        Long[] wallets = new Long[] {wallet};
+        long budget = insertBudgetCovering(Schema.BudgetType.CATEGORY, new Long[] {food, rent}, startDate, endDate, 5000L, "EUR", wallets, "tag-1");
+        insertTransaction(100, new Date(), null, food, Contract.Direction.EXPENSE, Contract.TransactionType.STANDARD, wallet, null, null, null, null, null, true, true, null, null, "tag");
+        insertTransaction(250, new Date(), null, rent, Contract.Direction.EXPENSE, Contract.TransactionType.STANDARD, wallet, null, null, null, null, null, true, true, null, null, "tag");
+        // the control: a category the budget does not cover, in the same wallet and the same
+        // period, so a budget that matched on the wallet alone would swallow it
+        insertTransaction(700, new Date(), null, petrol, Contract.Direction.EXPENSE, Contract.TransactionType.STANDARD, wallet, null, null, null, null, null, true, true, null, null, "tag");
+        checkBudgetCategories(budget, new Long[] {food, rent}, "Food, Rent", -350L);
+    }
+
+    @Test
+    public void budgetNamingOneCategoryStillFillsTheJoinTable() throws Exception {
+        // every caller that predates a budget covering more than one category writes the single
+        // column, and the queries read the join table, so the two have to meet
+        long wallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long food = insertCategory("Food", "encoded-icon-food", 1, null, true, "tag-food");
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.MONTH, -3);
+        Date startDate = calendar.getTime();
+        calendar.add(Calendar.MONTH, 6);
+        Date endDate = calendar.getTime();
+        long budget = insertBudget(Schema.BudgetType.CATEGORY, food, startDate, endDate, 5000L, "EUR", new Long[] {wallet}, "tag-1");
+        insertTransaction(100, new Date(), null, food, Contract.Direction.EXPENSE, Contract.TransactionType.STANDARD, wallet, null, null, null, null, null, true, true, null, null, "tag");
+        checkBudgetCategories(budget, new Long[] {food}, "Food", -100L);
+    }
+
+    @Test
+    public void updateBudgetReplacesTheCategoriesItCovers() throws Exception {
+        long wallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long food = insertCategory("Food", "encoded-icon-food", 1, null, true, "tag-food");
+        long rent = insertCategory("Rent", "encoded-icon-rent", 1, null, true, "tag-rent");
+        long petrol = insertCategory("Petrol", "encoded-icon-petrol", 1, null, true, "tag-petrol");
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.MONTH, -3);
+        Date startDate = calendar.getTime();
+        calendar.add(Calendar.MONTH, 6);
+        Date endDate = calendar.getTime();
+        Long[] wallets = new Long[] {wallet};
+        long budget = insertBudgetCovering(Schema.BudgetType.CATEGORY, new Long[] {food, rent}, startDate, endDate, 5000L, "EUR", wallets, "tag-1");
+        insertTransaction(100, new Date(), null, food, Contract.Direction.EXPENSE, Contract.TransactionType.STANDARD, wallet, null, null, null, null, null, true, true, null, null, "tag");
+        insertTransaction(250, new Date(), null, rent, Contract.Direction.EXPENSE, Contract.TransactionType.STANDARD, wallet, null, null, null, null, null, true, true, null, null, "tag");
+        insertTransaction(700, new Date(), null, petrol, Contract.Direction.EXPENSE, Contract.TransactionType.STANDARD, wallet, null, null, null, null, null, true, true, null, null, "tag");
+        checkBudgetCategories(budget, new Long[] {food, rent}, "Food, Rent", -350L);
+        // food is dropped and petrol is added, so the figure follows the new pair, and the row
+        // that the update flagged deleted for rent comes back instead of being written twice
+        updateBudgetCovering(budget, Schema.BudgetType.CATEGORY, new Long[] {rent, petrol}, startDate, endDate, 5000L, "EUR", wallets, "tag-1");
+        checkBudgetCategories(budget, new Long[] {rent, petrol}, "Petrol, Rent", -950L);
+    }
+
+    @Test(expected = SQLiteDataException.class)
+    public void deleteCategoryReachedOnlyThroughTheJoinTable() throws Exception {
+        // the budget row itself names food, so rent is in the join table and nowhere else
+        long wallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long food = insertCategory("Food", "encoded-icon-food", 1, null, true, "tag-food");
+        long rent = insertCategory("Rent", "encoded-icon-rent", 1, null, true, "tag-rent");
+        insertBudgetCovering(Schema.BudgetType.CATEGORY, new Long[] {food, rent}, new Date(), new Date(), 3000L, "EUR", new Long[] {wallet}, "tag");
+        mDatabase.deleteCategory(rent);
+    }
+
+    @Test
+    public void deleteBudgetTakesItsCategoriesWithIt() throws Exception {
+        long wallet = insertWallet("Test wallet 1", "encoded-icon-1", "EUR", "note-wallet-1", true, 2000L, false, "tag-wallet-1");
+        long food = insertCategory("Food", "encoded-icon-food", 1, null, true, "tag-food");
+        long rent = insertCategory("Rent", "encoded-icon-rent", 1, null, true, "tag-rent");
+        long budget = insertBudgetCovering(Schema.BudgetType.CATEGORY, new Long[] {food, rent}, new Date(), new Date(), 3000L, "EUR", new Long[] {wallet}, "tag");
+        mDatabase.deleteBudget(budget);
+        checkCursorSize(mDatabase.getBudget(budget, null), 0);
+        // with the join rows gone the categories are free again
+        mDatabase.deleteCategory(rent);
+        mDatabase.deleteCategory(food);
     }
 
     @Test(expected = SQLiteDataException.class)

--- a/app/src/main/java/com/oriondev/moneywallet/model/Category.java
+++ b/app/src/main/java/com/oriondev/moneywallet/model/Category.java
@@ -27,7 +27,7 @@ import com.oriondev.moneywallet.storage.database.Contract;
 /**
  * Created by andrea on 02/03/18.
  */
-public class Category implements Parcelable {
+public class Category implements Parcelable, Identifiable {
 
     private final long mId;
     private final String mName;

--- a/app/src/main/java/com/oriondev/moneywallet/picker/CategoryPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/CategoryPicker.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.os.Parcelable;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
@@ -31,30 +32,64 @@ import androidx.fragment.app.FragmentManager;
 import com.oriondev.moneywallet.model.Category;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.ui.activity.CategoryPickerActivity;
+import com.oriondev.moneywallet.ui.fragment.dialog.MultiCategoryPickerDialog;
 import com.oriondev.moneywallet.ui.fragment.dialog.ParentCategoryPickerDialog;
 
 /**
  * Created by andrea on 02/02/18.
  */
-public class CategoryPicker extends Fragment implements ParentCategoryPickerDialog.Callback {
+public class CategoryPicker extends Fragment implements ParentCategoryPickerDialog.Callback, MultiCategoryPickerDialog.Callback {
 
     private static final String SS_CURRENT_CATEGORY = "ParentCategoryPicker::SavedState::CurrentCategory";
+    private static final String SS_CURRENT_CATEGORIES = "ParentCategoryPicker::SavedState::CurrentCategories";
+    private static final String SS_MULTI_CATEGORY = "ParentCategoryPicker::SavedState::MultiCategory";
     private static final String ARG_DEFAULT_CATEGORY = "ParentCategoryPicker::Arguments::DefaultCategory";
+    private static final String ARG_DEFAULT_CATEGORIES = "ParentCategoryPicker::Arguments::DefaultCategories";
+    private static final String ARG_MULTI_CATEGORY = "ParentCategoryPicker::Arguments::MultiCategory";
 
     private static final int REQUEST_CATEGORY_PICKER = 1;
 
     private Controller mController;
+    private MultiCategoryController mMultiCategoryController;
 
+    private boolean mMultiCategory;
     private Category mCurrentCategory;
+    private Category[] mCurrentCategories;
 
     private ParentCategoryPickerDialog mParentCategoryPickerDialog;
+    private MultiCategoryPickerDialog mMultiCategoryPickerDialog;
 
     public static CategoryPicker createPicker(FragmentManager fragmentManager, String tag, Category defaultCategory) {
         CategoryPicker categoryPicker = (CategoryPicker) fragmentManager.findFragmentByTag(tag);
         if (categoryPicker == null) {
             categoryPicker = new CategoryPicker();
             Bundle arguments = new Bundle();
+            arguments.putBoolean(ARG_MULTI_CATEGORY, false);
             arguments.putParcelable(ARG_DEFAULT_CATEGORY, defaultCategory);
+            categoryPicker.setArguments(arguments);
+            fragmentManager.beginTransaction().add(categoryPicker, tag).commit();
+        }
+        return categoryPicker;
+    }
+
+    /**
+     * A picker over any number of categories at once, for a budget that covers more than one.
+     * It reports through {@link MultiCategoryController} and leaves
+     * {@link #getCurrentCategory()} empty; the single category picker above is untouched and
+     * still reports through {@link Controller}.
+     *
+     * @param fragmentManager manager the picker is added to.
+     * @param tag name it is found again by.
+     * @param defaultCategories categories chosen already, empty or null on a new item.
+     * @return the picker, whether it was created here or found by its tag.
+     */
+    public static CategoryPicker createPicker(FragmentManager fragmentManager, String tag, Category[] defaultCategories) {
+        CategoryPicker categoryPicker = (CategoryPicker) fragmentManager.findFragmentByTag(tag);
+        if (categoryPicker == null) {
+            categoryPicker = new CategoryPicker();
+            Bundle arguments = new Bundle();
+            arguments.putBoolean(ARG_MULTI_CATEGORY, true);
+            arguments.putParcelableArray(ARG_DEFAULT_CATEGORIES, defaultCategories);
             categoryPicker.setArguments(arguments);
             fragmentManager.beginTransaction().add(categoryPicker, tag).commit();
         }
@@ -69,19 +104,29 @@ public class CategoryPicker extends Fragment implements ParentCategoryPickerDial
         } else if (getParentFragment() instanceof Controller) {
             mController = (Controller) getParentFragment();
         }
+        if (context instanceof MultiCategoryController) {
+            mMultiCategoryController = (MultiCategoryController) context;
+        } else if (getParentFragment() instanceof MultiCategoryController) {
+            mMultiCategoryController = (MultiCategoryController) getParentFragment();
+        }
     }
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (savedInstanceState != null) {
+            mMultiCategory = savedInstanceState.getBoolean(SS_MULTI_CATEGORY);
             mCurrentCategory = savedInstanceState.getParcelable(SS_CURRENT_CATEGORY);
+            mCurrentCategories = toCategories(savedInstanceState.getParcelableArray(SS_CURRENT_CATEGORIES));
         } else {
             Bundle arguments = getArguments();
             if (arguments != null) {
+                mMultiCategory = arguments.getBoolean(ARG_MULTI_CATEGORY);
                 mCurrentCategory = arguments.getParcelable(ARG_DEFAULT_CATEGORY);
+                mCurrentCategories = toCategories(arguments.getParcelableArray(ARG_DEFAULT_CATEGORIES));
             } else {
                 mCurrentCategory = null;
+                mCurrentCategories = null;
             }
         }
         mParentCategoryPickerDialog = (ParentCategoryPickerDialog) getChildFragmentManager().findFragmentByTag(getDialogTag());
@@ -89,6 +134,30 @@ public class CategoryPicker extends Fragment implements ParentCategoryPickerDial
             mParentCategoryPickerDialog = ParentCategoryPickerDialog.newInstance();
         }
         mParentCategoryPickerDialog.setCallback(this);
+        mMultiCategoryPickerDialog = (MultiCategoryPickerDialog) getChildFragmentManager().findFragmentByTag(getMultiDialogTag());
+        if (mMultiCategoryPickerDialog == null) {
+            mMultiCategoryPickerDialog = MultiCategoryPickerDialog.newInstance();
+        }
+        mMultiCategoryPickerDialog.setCallback(this);
+    }
+
+    /**
+     * A parcelable array comes back as {@code Parcelable[]} on some devices whatever was put in
+     * it, so the elements are copied one at a time instead of casting the array itself. This is
+     * the same guard {@code WalletPicker} carries for the same reason.
+     *
+     * @param parcelables array read out of a bundle, possibly null.
+     * @return the categories in it, or null when there were none.
+     */
+    private static Category[] toCategories(Parcelable[] parcelables) {
+        if (parcelables == null) {
+            return null;
+        }
+        Category[] categories = new Category[parcelables.length];
+        for (int i = 0; i < parcelables.length; i++) {
+            categories[i] = (Category) parcelables[i];
+        }
+        return categories;
     }
 
     @Override
@@ -98,8 +167,14 @@ public class CategoryPicker extends Fragment implements ParentCategoryPickerDial
     }
 
     private void fireCallbackSafely() {
-        if (mController != null) {
-            mController.onCategoryChanged(getTag(), mCurrentCategory);
+        if (mMultiCategory) {
+            if (mMultiCategoryController != null) {
+                mMultiCategoryController.onCategoryListChanged(getTag(), mCurrentCategories);
+            }
+        } else {
+            if (mController != null) {
+                mController.onCategoryChanged(getTag(), mCurrentCategory);
+            }
         }
     }
 
@@ -107,14 +182,31 @@ public class CategoryPicker extends Fragment implements ParentCategoryPickerDial
         return getTag() + "::DialogFragment";
     }
 
+    private String getMultiDialogTag() {
+        return getTag() + "::MultiDialogFragment";
+    }
+
     @Override
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
+        outState.putBoolean(SS_MULTI_CATEGORY, mMultiCategory);
         outState.putParcelable(SS_CURRENT_CATEGORY, mCurrentCategory);
+        outState.putParcelableArray(SS_CURRENT_CATEGORIES, mCurrentCategories);
     }
 
     public boolean isSelected() {
+        if (mMultiCategory) {
+            return mCurrentCategories != null && mCurrentCategories.length > 0;
+        }
         return mCurrentCategory != null;
+    }
+
+    public Category[] getCurrentCategories() {
+        return mCurrentCategories;
+    }
+
+    public void showMultiPicker() {
+        mMultiCategoryPickerDialog.showPicker(getChildFragmentManager(), getMultiDialogTag(), mCurrentCategories);
     }
 
     public void setCategory(Category category) {
@@ -157,6 +249,13 @@ public class CategoryPicker extends Fragment implements ParentCategoryPickerDial
     public void onDetach() {
         super.onDetach();
         mController = null;
+        mMultiCategoryController = null;
+    }
+
+    @Override
+    public void onCategoriesSelected(Category[] categories) {
+        mCurrentCategories = categories;
+        fireCallbackSafely();
     }
 
     @Override
@@ -168,5 +267,10 @@ public class CategoryPicker extends Fragment implements ParentCategoryPickerDial
     public interface Controller {
 
         void onCategoryChanged(String tag, Category category);
+    }
+
+    public interface MultiCategoryController {
+
+        void onCategoryListChanged(String tag, Category[] categories);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/service/RecurrenceHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/RecurrenceHandlerIntentService.java
@@ -162,6 +162,7 @@ public class RecurrenceHandlerIntentService extends JobIntentService {
         contentValues.put(Contract.Budget.TAG, cursor.getString(cursor.getColumnIndex(Contract.Budget.TAG)));
         contentValues.put(Contract.Budget.RULE_START, cursor.getString(cursor.getColumnIndex(Contract.Budget.RULE_START)));
         contentValues.put(Contract.Budget.WALLET_IDS, cursor.getString(cursor.getColumnIndex(Contract.Budget.WALLET_IDS)));
+        contentValues.put(Contract.Budget.CATEGORY_IDS, cursor.getString(cursor.getColumnIndex(Contract.Budget.CATEGORY_IDS)));
         return contentValues;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
@@ -212,7 +212,23 @@ public class Contract {
     public static final class Budget {
         public static final String ID = Schema.Budget.ID;
         public static final String TYPE = Schema.Budget.TYPE;
+        /**
+         * The first of {@link #CATEGORY_IDS}, kept so a release that predates that list still
+         * shows the budget running on one category instead of on none. Nothing matches
+         * transactions on it any more, that is the join table behind {@link #CATEGORY_IDS}.
+         * A write and an upgrade both leave it naming a category the join table also holds; a
+         * release old enough to write it and not the table can put it out of step, and the next
+         * upgrade puts it back.
+         */
         public static final String CATEGORY_ID = Schema.Budget.CATEGORY;
+        /**
+         * Every category the budget covers, in the same angle bracketed form
+         * {@link #WALLET_IDS} uses, written on an insert or an update and read back on a query.
+         * A query hands them over lowest id first, and so does the editor when it reads the
+         * categories of the budget it is opening, which is what keeps {@link #CATEGORY_ID} on
+         * the same category through an edit and through a period rolled forward.
+         */
+        public static final String CATEGORY_IDS = "budget_category_ids";
         public static final String CATEGORY_NAME = "budget_" + Schema.Category.NAME;
         public static final String CATEGORY_ICON = "budget_" + Schema.Category.ICON;
         public static final String CATEGORY_TYPE = "budget_" + Schema.Category.TYPE;

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -104,6 +104,7 @@ public class DataContentProvider extends ContentProvider {
     private static final int TRANSFER_PEOPLE = 36;
     private static final int DEBT_PEOPLE = 37;
     private static final int BUDGET_WALLETS = 38;
+    private static final int BUDGET_CATEGORIES = 46;
 
     private static final int CATEGORY_TRANSACTION_LIST = 39;
     private static final int DEBT_TRANSACTION_LIST = 40;
@@ -139,6 +140,7 @@ public class DataContentProvider extends ContentProvider {
         matcher.addURI(AUTHORITY, "budgets", BUDGET_LIST);
         matcher.addURI(AUTHORITY, "budgets/#", BUDGET_ITEM);
         matcher.addURI(AUTHORITY, "budgets/#/wallets", BUDGET_WALLETS);
+        matcher.addURI(AUTHORITY, "budgets/#/categories", BUDGET_CATEGORIES);
         matcher.addURI(AUTHORITY, "budgets/#/transactions", BUDGET_TRANSACTION_LIST);
         matcher.addURI(AUTHORITY, "savings", SAVING_LIST);
         matcher.addURI(AUTHORITY, "savings/#", SAVING_ITEM);
@@ -329,6 +331,11 @@ public class DataContentProvider extends ContentProvider {
                 cursor = new MultiUriCursorWrapper(mDatabase.getBudgetWallets(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
+                break;
+            case BUDGET_CATEGORIES:
+                cursor = new MultiUriCursorWrapper(mDatabase.getBudgetCategories(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
+                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 break;
             case BUDGET_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(mDatabase.getBudgetTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
@@ -533,6 +540,8 @@ public class DataContentProvider extends ContentProvider {
                 return "vnd.android.cursor.item/vnd.com.oriondev.moneywallet.storage.budget";
             case BUDGET_WALLETS:
                 return "vnd.android.cursor.dir/vnd.com.oriondev.moneywallet.storage.wallet";
+            case BUDGET_CATEGORIES:
+                return "vnd.android.cursor.dir/vnd.com.oriondev.moneywallet.storage.category";
             case BUDGET_TRANSACTION_LIST:
                 return "vnd.android.cursor.dir/vnd.com.oriondev.moneywallet.storage.transaction";
             case SAVING_LIST:

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DatabaseExporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DatabaseExporter.java
@@ -51,6 +51,8 @@ public interface DatabaseExporter {
 
     void exportBudgetWallets(Cursor cursor) throws ExportException;
 
+    void exportBudgetCategories(Cursor cursor) throws ExportException;
+
     void exportSavings(Cursor cursor) throws ExportException;
 
     void exportRecurrentTransactions(Cursor cursor) throws ExportException;

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DatabaseImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DatabaseImporter.java
@@ -51,6 +51,8 @@ public interface DatabaseImporter {
 
     void importBudgetWallets(ContentResolver contentResolver) throws ImportException;
 
+    void importBudgetCategories(ContentResolver contentResolver) throws ImportException;
+
     void importSavings(ContentResolver contentResolver) throws ImportException;
 
     void importRecurrentTransactions(ContentResolver contentResolver) throws ImportException;

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/LegacyEditionImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/LegacyEditionImporter.java
@@ -63,6 +63,7 @@ public class LegacyEditionImporter {
         mDatabaseImporter.importDebtPeople(contentResolver);
         mDatabaseImporter.importBudgets(contentResolver);
         mDatabaseImporter.importBudgetWallets(contentResolver);
+        mDatabaseImporter.importBudgetCategories(contentResolver);
         mDatabaseImporter.importSavings(contentResolver);
         mDatabaseImporter.importRecurrentTransactions(contentResolver);
         mDatabaseImporter.importRecurrentTransfers(contentResolver);

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -22,6 +22,7 @@ package com.oriondev.moneywallet.storage.database;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
+import android.database.sqlite.SQLiteConstraintException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
 import android.database.sqlite.SQLiteOpenHelper;
@@ -73,7 +74,7 @@ import java.util.UUID;
     private static final String TAG = "SQLDatabase";
 
     /*package-local*/ static final String DATABASE_NAME = "database.db";
-    private static final int DATABASE_VERSION = 4;
+    private static final int DATABASE_VERSION = 5;
 
     private static final String ENABLE_FOREIGN_KEYS = "PRAGMA foreign_keys=ON";
 
@@ -110,6 +111,7 @@ import java.util.UUID;
         db.execSQL(Schema.CREATE_TABLE_DEBT_PEOPLE);
         db.execSQL(Schema.CREATE_TABLE_BUDGET);
         db.execSQL(Schema.CREATE_TABLE_BUDGET_WALLET);
+        db.execSQL(Schema.CREATE_TABLE_BUDGET_CATEGORY);
         db.execSQL(Schema.CREATE_TABLE_SAVING);
         db.execSQL(Schema.CREATE_TABLE_TRANSACTION);
         db.execSQL(Schema.CREATE_TABLE_TRANSACTION_PEOPLE);
@@ -167,6 +169,24 @@ import java.util.UUID;
             if (!hasColumn(db, Schema.Budget.TABLE, Schema.Budget.RULE_START)) {
                 db.execSQL(Schema.CREATE_BUDGET_RULE_START_COLUMN);
             }
+        }
+        if (oldVersion < 5) {
+            // a budget can now cover more than one category, and the join table is what the
+            // queries match on. This runs a second time whenever a release that predates the
+            // table is installed over this database and then upgraded again, because onDowngrade
+            // leaves the schema alone and only stamps the version back. The table survives that
+            // round trip, so the create is guarded and the fill covers only the budgets that hold
+            // no live row. Anything the older release wrote to the single column of a budget
+            // that already covers categories is therefore ignored, which is the safe direction,
+            // the older release could only ever see one of them and reading its column would
+            // drop the rest. The align then puts that column back on the first category the
+            // budget covers, so no live budget comes out of an upgrade carrying a column its own
+            // categories do not name.
+            db.execSQL(Schema.CREATE_TABLE_BUDGET_CATEGORY);
+            db.execSQL(Schema.FILL_BUDGET_CATEGORY_FROM_COLUMN);
+            db.execSQL(Schema.ALIGN_BUDGET_CATEGORY_COLUMN);
+            db.execSQL(Schema.CLEAR_BUDGET_CATEGORY_OF_OTHER_TYPES);
+            db.execSQL(Schema.CLEAR_BUDGET_COLUMN_OF_OTHER_TYPES);
         }
     }
 
@@ -2113,11 +2133,31 @@ import java.util.UUID;
                 cursor.close();
             }
         }
-        // check if category is in use in some budget
+        // check if category is in use in some budget. Both places have to be asked. The column
+        // carries ON DELETE CASCADE, so a category it names and this check misses does not fail,
+        // it takes the whole budget row with it. And a budget covering several categories reaches
+        // all but the first of them through the join table alone, which the column cannot see.
         projection = new String[] {Schema.Budget.ID};
         where = Schema.Budget.CATEGORY + " = ? AND " + Schema.Budget.DELETED + " = 0";
         whereArgs = new String[]{String.valueOf(categoryId)};
         cursor = getReadableDatabase().query(Schema.Budget.TABLE, projection, where, whereArgs, null, null, null);
+        if (cursor != null) {
+            try {
+                if (cursor.moveToFirst()) {
+                    throw new SQLiteDataException(Contract.ErrorCode.CATEGORY_IN_USE,
+                            String.format(Locale.ENGLISH, "The category (id: %d) cannot be deleted because it is in use in %d budgets", categoryId, cursor.getCount()));
+                }
+            } finally {
+                cursor.close();
+            }
+        }
+        projection = new String[] {"bc." + Schema.BudgetCategory.BUDGET};
+        where = "bc." + Schema.BudgetCategory.CATEGORY + " = ? AND bc." +
+                Schema.BudgetCategory.DELETED + " = 0 AND b." + Schema.Budget.DELETED + " = 0";
+        whereArgs = new String[]{String.valueOf(categoryId)};
+        cursor = getReadableDatabase().query(Schema.BudgetCategory.TABLE + " AS bc JOIN " +
+                Schema.Budget.TABLE + " AS b ON bc." + Schema.BudgetCategory.BUDGET + " = b." +
+                Schema.Budget.ID, projection, where, whereArgs, null, null, null);
         if (cursor != null) {
             try {
                 if (cursor.moveToFirst()) {
@@ -2811,7 +2851,20 @@ import java.util.UUID;
                 "b." + Schema.Budget.ID + " AS " + Contract.Budget.ID + ", " +
                 "b." + Schema.Budget.TYPE + " AS " + Contract.Budget.TYPE + ", " +
                 "b." + Schema.Budget.CATEGORY + " AS " + Contract.Budget.CATEGORY_ID + ", " +
-                "c." + Schema.Category.NAME + " AS " + Contract.Budget.CATEGORY_NAME + ", " +
+                "(SELECT GROUP_CONCAT(n, ', ') FROM (SELECT c2." + Schema.Category.NAME +
+                " AS n FROM " + Schema.BudgetCategory.TABLE + " AS bc2 JOIN " +
+                Schema.Category.TABLE + " AS c2 ON bc2." + Schema.BudgetCategory.CATEGORY +
+                " = c2." + Schema.Category.ID + " AND c2." + Schema.Category.DELETED +
+                " = 0 WHERE bc2." + Schema.BudgetCategory.BUDGET + " = b." + Schema.Budget.ID +
+                " AND bc2." + Schema.BudgetCategory.DELETED + " = 0 ORDER BY c2." +
+                Schema.Category.NAME + ")) AS " + Contract.Budget.CATEGORY_NAME + ", " +
+                "(SELECT GROUP_CONCAT(i) FROM (SELECT '<' || bc3." + Schema.BudgetCategory.CATEGORY +
+                " || '>' AS i FROM " + Schema.BudgetCategory.TABLE + " AS bc3 JOIN " +
+                Schema.Category.TABLE + " AS c3 ON bc3." + Schema.BudgetCategory.CATEGORY +
+                " = c3." + Schema.Category.ID + " AND c3." + Schema.Category.DELETED +
+                " = 0 WHERE bc3." + Schema.BudgetCategory.BUDGET + " = b." + Schema.Budget.ID +
+                " AND bc3." + Schema.BudgetCategory.DELETED + " = 0 ORDER BY bc3." +
+                Schema.BudgetCategory.CATEGORY + ")) AS " + Contract.Budget.CATEGORY_IDS + ", " +
                 "c." + Schema.Category.ICON + " AS " + Contract.Budget.CATEGORY_ICON + ", " +
                 "c." + Schema.Category.TYPE + " AS " + Contract.Budget.CATEGORY_TYPE + ", " +
                 "c." + Schema.Category.SHOW_REPORT + " AS " + Contract.Budget.CATEGORY_SHOW_REPORT + ", " +
@@ -2904,9 +2957,9 @@ import java.util.UUID;
                 Schema.Transaction.WALLET + " AND DATETIME(t." + Schema.Transaction.DATE +
                 ") <= DATETIME('now', 'localtime') AND DATE(t." + Schema.Transaction.DATE +
                 ") >= DATE(b." + Schema.Budget.START_DATE + ") AND DATE(t." +
-                Schema.Transaction.DATE + ") <=  DATE(b." + Schema.Budget.END_DATE + ") AND (b."
-                + Schema.Budget.CATEGORY + " = t." + Schema.Transaction.CATEGORY + " OR b." +
-                Schema.Budget.CATEGORY + " = t._parent_category)) GROUP BY b." + Schema.Budget.ID +
+                Schema.Transaction.DATE + ") <=  DATE(b." + Schema.Budget.END_DATE + ") AND (t."
+                + Schema.Transaction.CATEGORY + " IN " + budgetCategoriesOf("b") +
+                " OR t._parent_category IN " + budgetCategoriesOf("b") + ")) GROUP BY b." + Schema.Budget.ID +
                 ", _wallet_id) AS b LEFT JOIN " + Schema.Category.TABLE + " AS c ON b." +
                 Schema.Budget.CATEGORY + " = c." + Schema.Category.ID + " AND c." +
                 Schema.Category.DELETED + " = 0 GROUP BY b." + Schema.Budget.ID;
@@ -2938,6 +2991,35 @@ import java.util.UUID;
                 "ON bw." + Schema.BudgetWallet.WALLET + " = w." + Schema.Wallet.ID + " AND bw." +
                 Schema.BudgetWallet.DELETED + " = 0 AND w." + Schema.Wallet.DELETED + " = 0 AND " +
                 Schema.BudgetWallet.BUDGET + " = " + String.valueOf(id);
+        return queryFrom(subQuery, projection, selection, selectionArgs, sortOrder);
+    }
+
+    /**
+     * This method is called by the content provider when the user is querying all the categories
+     * covered by a given budget.
+     *
+     * @param id of the budget.
+     * @param projection column names that are requested to be part of the cursor.
+     * @param selection string that may contains additional filters for the query.
+     * @param selectionArgs string array that may contains the arguments for the selection string.
+     * @param sortOrder string that may contains column name to use to sort the cursor.
+     * @return a cursor with zero or more rows.
+     */
+    /*package-local*/ Cursor getBudgetCategories(long id, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        String subQuery = "SELECT " +
+                "c." + Schema.Category.ID + " AS " + Contract.Category.ID + ", " +
+                "c." + Schema.Category.NAME + " AS " + Contract.Category.NAME + ", " +
+                "c." + Schema.Category.ICON + " AS " + Contract.Category.ICON + ", " +
+                "c." + Schema.Category.TYPE + " AS " + Contract.Category.TYPE + ", " +
+                "c." + Schema.Category.PARENT + " AS " + Contract.Category.PARENT + ", " +
+                "c." + Schema.Category.SHOW_REPORT + " AS " + Contract.Category.SHOW_REPORT + ", " +
+                "c." + Schema.Category.INDEX + " AS " + Contract.Category.INDEX + ", " +
+                "c." + Schema.Category.TAG + " AS " + Contract.Category.TAG + " " +
+                "FROM " + Schema.BudgetCategory.TABLE + " AS bc JOIN " + Schema.Category.TABLE +
+                " AS c ON bc." + Schema.BudgetCategory.CATEGORY + " = c." + Schema.Category.ID +
+                " AND bc." + Schema.BudgetCategory.DELETED + " = 0 AND c." +
+                Schema.Category.DELETED + " = 0 AND bc." + Schema.BudgetCategory.BUDGET + " = " +
+                String.valueOf(id);
         return queryFrom(subQuery, projection, selection, selectionArgs, sortOrder);
     }
 
@@ -3065,9 +3147,9 @@ import java.util.UUID;
                 ") AS b LEFT JOIN " + Schema.Transaction.TABLE + " AS t ON b._wallet_id = t." +
                 Schema.Transaction.WALLET + " AND t." + Schema.Transaction.DELETED + " = 0 JOIN " +
                 Schema.Category.TABLE + " AS tc ON t." + Schema.Transaction.CATEGORY + " = tc." +
-                Schema.Category.ID + " AND tc." + Schema.Category.DELETED + " = 0 WHERE (b." +
-                Schema.Budget.CATEGORY + " = " + Schema.Transaction.CATEGORY + " OR b." +
-                Schema.Budget.CATEGORY + " = tc."+ Schema.Category.PARENT + ") " +
+                Schema.Category.ID + " AND tc." + Schema.Category.DELETED + " = 0 WHERE (" +
+                Schema.Transaction.CATEGORY + " IN " + budgetCategoriesOf("b") + " OR tc." +
+                Schema.Category.PARENT + " IN " + budgetCategoriesOf("b") + ") " +
                 "AND DATETIME(t." + Schema.Transaction.DATE + ") <= DATETIME('now', 'localtime') " +
                 "AND DATE(t." + Schema.Transaction.DATE + ") >= DATE(b." +
                 Schema.Budget.START_DATE + ") AND DATE(t." + Schema.Transaction.DATE +
@@ -3110,9 +3192,14 @@ import java.util.UUID;
             throw new SQLiteDataException(Contract.ErrorCode.WALLETS_NOT_FOUND, "No wallet id provided");
         }
         checkWalletsConsistency(walletIds);
+        long[] categoryIds = budgetCategoryIds(contentValues);
         ContentValues cv = new ContentValues();
         cv.put(Schema.Budget.TYPE, contentValues.getAsInteger(Contract.Budget.TYPE));
-        cv.put(Schema.Budget.CATEGORY, contentValues.getAsLong(Contract.Budget.CATEGORY_ID));
+        if (categoryIds == null) {
+            cv.putNull(Schema.Budget.CATEGORY);
+        } else {
+            cv.put(Schema.Budget.CATEGORY, categoryIds[0]);
+        }
         cv.put(Schema.Budget.START_DATE, contentValues.getAsString(Contract.Budget.START_DATE));
         cv.put(Schema.Budget.END_DATE, contentValues.getAsString(Contract.Budget.END_DATE));
         cv.put(Schema.Budget.MONEY, contentValues.getAsLong(Contract.Budget.MONEY));
@@ -3135,6 +3222,7 @@ import java.util.UUID;
                 cvw.put(Schema.BudgetWallet.DELETED, false);
                 getWritableDatabase().insert(Schema.BudgetWallet.TABLE, null, cvw);
             }
+            writeBudgetCategories(budgetId, categoryIds);
         }
         return budgetId;
     }
@@ -3190,9 +3278,14 @@ import java.util.UUID;
             throw new SQLiteDataException(Contract.ErrorCode.WALLETS_NOT_FOUND, "No wallet id provided");
         }
         checkWalletsConsistency(walletIds);
+        long[] categoryIds = budgetCategoryIds(contentValues);
         ContentValues cv = new ContentValues();
         cv.put(Schema.Budget.TYPE, contentValues.getAsInteger(Contract.Budget.TYPE));
-        cv.put(Schema.Budget.CATEGORY, contentValues.getAsLong(Contract.Budget.CATEGORY_ID));
+        if (categoryIds == null) {
+            cv.putNull(Schema.Budget.CATEGORY);
+        } else {
+            cv.put(Schema.Budget.CATEGORY, categoryIds[0]);
+        }
         cv.put(Schema.Budget.START_DATE, contentValues.getAsString(Contract.Budget.START_DATE));
         cv.put(Schema.Budget.END_DATE, contentValues.getAsString(Contract.Budget.END_DATE));
         cv.put(Schema.Budget.MONEY, contentValues.getAsLong(Contract.Budget.MONEY));
@@ -3242,8 +3335,85 @@ import java.util.UUID;
                     getWritableDatabase().update(Schema.BudgetWallet.TABLE, cv, where, whereArgs);
                 }
             }
+            cv = new ContentValues();
+            cv.put(Schema.BudgetCategory.DELETED, true);
+            cv.put(Schema.BudgetCategory.LAST_EDIT, System.currentTimeMillis());
+            where = Schema.BudgetCategory.BUDGET + " = ?";
+            whereArgs = new String[]{String.valueOf(budgetId)};
+            getWritableDatabase().update(Schema.BudgetCategory.TABLE, cv, where, whereArgs);
+            writeBudgetCategories(budgetId, categoryIds);
         }
         return rows;
+    }
+
+    /**
+     * The categories a budget is being written with, and none at all for a budget of a type that
+     * does not cover them. A caller that names them all wins; one that names a single category,
+     * which is every caller that predates a budget covering more than one, is read as a list of
+     * that one. Both {@link #insertBudget(ContentValues)} and
+     * {@link #updateBudget(long, ContentValues)} take the first of whatever comes back as the
+     * value of {@link Schema.Budget#CATEGORY}, so a write leaves the column naming a category
+     * the join table also holds.
+     *
+     * @param contentValues bundle handed to the insert or the update.
+     * @return the category ids, or null on a budget that covers no category at all.
+     */
+    private long[] budgetCategoryIds(ContentValues contentValues) {
+        Integer type = contentValues.getAsInteger(Contract.Budget.TYPE);
+        if (type == null || type != Schema.BudgetType.CATEGORY) {
+            // a budget of any other type covers no category, whatever the caller passed. Without
+            // this, a period rolled forward from a budget that used to cover them hands them to
+            // every period it opens, because the roll copies both keys off the cursor and never
+            // looks at the type.
+            return null;
+        }
+        long[] categoryIds = parseIds(contentValues.getAsString(Contract.Budget.CATEGORY_IDS));
+        if (categoryIds != null && categoryIds.length > 0) {
+            return categoryIds;
+        }
+        Long categoryId = contentValues.getAsLong(Contract.Budget.CATEGORY_ID);
+        return categoryId == null ? null : new long[] {categoryId};
+    }
+
+    /**
+     * Puts one row in the join table per category the budget covers. A row flagged deleted by an
+     * update and named again here comes back instead of being inserted a second time, which is
+     * what the wallets above do and what the composite primary key requires.
+     *
+     * @param budgetId id of the budget being written.
+     * @param categoryIds categories it covers, null on a budget that covers none.
+     */
+    private void writeBudgetCategories(long budgetId, long[] categoryIds) {
+        if (categoryIds == null) {
+            return;
+        }
+        for (long categoryId : categoryIds) {
+            ContentValues cv = new ContentValues();
+            cv.put(Schema.BudgetCategory.BUDGET, budgetId);
+            cv.put(Schema.BudgetCategory.CATEGORY, categoryId);
+            cv.put(Schema.BudgetCategory.UUID, UUID.randomUUID().toString());
+            cv.put(Schema.BudgetCategory.LAST_EDIT, System.currentTimeMillis());
+            cv.put(Schema.BudgetCategory.DELETED, false);
+            long newId;
+            try {
+                newId = getWritableDatabase().insertWithOnConflict(Schema.BudgetCategory.TABLE, null, cv, SQLiteDatabase.CONFLICT_IGNORE);
+            } catch (SQLiteConstraintException e) {
+                // CONFLICT_IGNORE covers the composite key and nothing else, a foreign key is
+                // still enforced and still throws, which happens when the category was deleted
+                // while the editor was open. Dropping that one id leaves the rest of the budget
+                // written, where letting it out would abort the save half way through and take
+                // the categories already restored above with it.
+                continue;
+            }
+            if (newId == -1L) {
+                cv = new ContentValues();
+                cv.put(Schema.BudgetCategory.LAST_EDIT, System.currentTimeMillis());
+                cv.put(Schema.BudgetCategory.DELETED, false);
+                String where = Schema.BudgetCategory.BUDGET + " = ? AND " + Schema.BudgetCategory.CATEGORY + " = ?";
+                String[] whereArgs = new String[]{String.valueOf(budgetId), String.valueOf(categoryId)};
+                getWritableDatabase().update(Schema.BudgetCategory.TABLE, cv, where, whereArgs);
+            }
+        }
     }
 
     /**
@@ -3472,6 +3642,17 @@ import java.util.UUID;
             getWritableDatabase().update(Schema.BudgetWallet.TABLE, cv, where, whereArgs);
         } else {
             getWritableDatabase().delete(Schema.BudgetWallet.TABLE, where, whereArgs);
+        }
+        // remove all BudgetCategory
+        where = Schema.BudgetCategory.BUDGET + " = ?";
+        whereArgs = new String[]{String.valueOf(budgetId)};
+        if (mCacheDeletedObjects) {
+            ContentValues cv = new ContentValues();
+            cv.put(Schema.BudgetCategory.DELETED, true);
+            cv.put(Schema.BudgetCategory.LAST_EDIT, System.currentTimeMillis());
+            getWritableDatabase().update(Schema.BudgetCategory.TABLE, cv, where, whereArgs);
+        } else {
+            getWritableDatabase().delete(Schema.BudgetCategory.TABLE, where, whereArgs);
         }
         // remove the debt item
         where = Schema.Budget.ID + " = ?";
@@ -5241,6 +5422,20 @@ import java.util.UUID;
             return ids;
         }
         return null;
+    }
+
+    /**
+     * The categories one budget covers, as a subquery to match a transaction against. It reads
+     * the join table and not {@link Schema.Budget#CATEGORY}, which holds only the first of them.
+     *
+     * @param budgetAlias alias the enclosing query gave the budgets table.
+     * @return a parenthesised SELECT of category ids, ready to sit on the right of an IN.
+     */
+    private static String budgetCategoriesOf(String budgetAlias) {
+        return "(SELECT bc." + Schema.BudgetCategory.CATEGORY + " FROM " +
+                Schema.BudgetCategory.TABLE + " AS bc WHERE bc." + Schema.BudgetCategory.BUDGET +
+                " = " + budgetAlias + "." + Schema.Budget.ID + " AND bc." +
+                Schema.BudgetCategory.DELETED + " = 0)";
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabaseExporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabaseExporter.java
@@ -25,6 +25,7 @@ import android.net.Uri;
 
 import com.oriondev.moneywallet.storage.database.model.Attachment;
 import com.oriondev.moneywallet.storage.database.model.Budget;
+import com.oriondev.moneywallet.storage.database.model.BudgetCategory;
 import com.oriondev.moneywallet.storage.database.model.BudgetWallet;
 import com.oriondev.moneywallet.storage.database.model.Category;
 import com.oriondev.moneywallet.storage.database.model.Currency;
@@ -202,6 +203,16 @@ public class SQLDatabaseExporter {
         object.mUUID = cursor.getString(cursor.getColumnIndex(Schema.Budget.UUID));
         object.mLastEdit = cursor.getLong(cursor.getColumnIndex(Schema.Budget.LAST_EDIT));
         object.mDeleted = cursor.getInt(cursor.getColumnIndex(Schema.Budget.DELETED)) == 1;
+        return object;
+    }
+
+    public static BudgetCategory getBudgetCategory(Cursor cursor) {
+        BudgetCategory object = new BudgetCategory();
+        object.mBudget = cursor.isNull(cursor.getColumnIndex(Schema.BudgetCategory.BUDGET)) ? null : cursor.getLong(cursor.getColumnIndex(Schema.BudgetCategory.BUDGET));
+        object.mCategory = cursor.isNull(cursor.getColumnIndex(Schema.BudgetCategory.CATEGORY)) ? null : cursor.getLong(cursor.getColumnIndex(Schema.BudgetCategory.CATEGORY));
+        object.mUUID = cursor.getString(cursor.getColumnIndex(Schema.BudgetCategory.UUID));
+        object.mLastEdit = cursor.getLong(cursor.getColumnIndex(Schema.BudgetCategory.LAST_EDIT));
+        object.mDeleted = cursor.getInt(cursor.getColumnIndex(Schema.BudgetCategory.DELETED)) == 1;
         return object;
     }
 
@@ -493,6 +504,13 @@ public class SQLDatabaseExporter {
     public static Cursor getAllBudgetWallets(ContentResolver contentResolver) {
         Uri uri = SyncContentProvider.CONTENT_BUDGET_WALLET;
         String selection = Schema.BudgetWallet.DELETED + " = 0";
+        return contentResolver.query(uri, null, selection, null, null);
+    }
+
+
+    public static Cursor getAllBudgetCategories(ContentResolver contentResolver) {
+        Uri uri = SyncContentProvider.CONTENT_BUDGET_CATEGORY;
+        String selection = Schema.BudgetCategory.DELETED + " = 0";
         return contentResolver.query(uri, null, selection, null, null);
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabaseImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabaseImporter.java
@@ -25,6 +25,7 @@ import android.content.ContentValues;
 import android.net.Uri;
 
 import com.oriondev.moneywallet.storage.database.model.*;
+import java.util.UUID;
 
 /**
  * Created by andrea on 27/10/18.
@@ -190,6 +191,41 @@ public class SQLDatabaseImporter {
         contentValues.put(Schema.Budget.LAST_EDIT, budget.mLastEdit);
         contentValues.put(Schema.Budget.DELETED, budget.mDeleted);
         Uri uri = SyncContentProvider.CONTENT_BUDGET;
+        uri = contentResolver.insert(uri, contentValues);
+        return ContentUris.parseId(uri);
+    }
+
+    /**
+     * Puts the single category a budget carries into the join table. A backup written before the
+     * budget_categories array existed, and the legacy database, both name one category on the
+     * budget row itself, and the queries match on the join table alone, so a restore that skipped
+     * this would leave every category budget matching nothing at all.
+     *
+     * @param contentResolver resolver the restore is writing through.
+     * @param budgetId id the budget was given by this restore.
+     * @param categoryId category it names, ignored when null.
+     */
+    public static void insertBudgetCategory(ContentResolver contentResolver, long budgetId, Long categoryId) {
+        if (categoryId == null) {
+            return;
+        }
+        BudgetCategory budgetCategory = new BudgetCategory();
+        budgetCategory.mBudget = budgetId;
+        budgetCategory.mCategory = categoryId;
+        budgetCategory.mUUID = UUID.randomUUID().toString();
+        budgetCategory.mLastEdit = System.currentTimeMillis();
+        budgetCategory.mDeleted = false;
+        insert(contentResolver, budgetCategory);
+    }
+
+    public static long insert(ContentResolver contentResolver, BudgetCategory budgetCategory) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(Schema.BudgetCategory.BUDGET, budgetCategory.mBudget);
+        contentValues.put(Schema.BudgetCategory.CATEGORY, budgetCategory.mCategory);
+        contentValues.put(Schema.BudgetCategory.UUID, budgetCategory.mUUID);
+        contentValues.put(Schema.BudgetCategory.LAST_EDIT, budgetCategory.mLastEdit);
+        contentValues.put(Schema.BudgetCategory.DELETED, budgetCategory.mDeleted);
+        Uri uri = SyncContentProvider.CONTENT_BUDGET_CATEGORY;
         uri = contentResolver.insert(uri, contentValues);
         return ContentUris.parseId(uri);
     }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Schema.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Schema.java
@@ -159,6 +159,12 @@ package com.oriondev.moneywallet.storage.database;
         /*package-local*/ static final String WALLET = "_wallet";
     }
 
+    /*package-local*/ static final class BudgetCategory extends BaseTable {
+        /*package-local*/ static final String TABLE = "budget_categories";
+        /*package-local*/ static final String BUDGET = "_budget";
+        /*package-local*/ static final String CATEGORY = "_category";
+    }
+
     /*package-local*/ static final class Saving extends BaseTable {
         /*package-local*/ static final String TABLE = "savings";
         /*package-local*/ static final String ID = "saving_id";
@@ -507,6 +513,20 @@ package com.oriondev.moneywallet.storage.database;
             "(" + Wallet.ID + ") ON UPDATE NO ACTION ON DELETE CASCADE " +
             ")";
 
+    /*package-local*/ static final String CREATE_TABLE_BUDGET_CATEGORY = "CREATE TABLE IF NOT EXISTS " +
+            BudgetCategory.TABLE + " (" +
+            BudgetCategory.BUDGET + " INTEGER NOT NULL, " +
+            BudgetCategory.CATEGORY + " INTEGER NOT NULL, " +
+            BudgetCategory.UUID + " TEXT NOT NULL UNIQUE, " +
+            BudgetCategory.LAST_EDIT + " INTEGER NOT NULL, " +
+            BudgetCategory.DELETED + " INTEGER NOT NULL DEFAULT 0, " +
+            "PRIMARY KEY (" + BudgetCategory.BUDGET + ", " + BudgetCategory.CATEGORY + ")," +
+            "FOREIGN KEY (" + BudgetCategory.BUDGET + ") REFERENCES " + Budget.TABLE +
+            "(" + Budget.ID + ") ON UPDATE NO ACTION ON DELETE CASCADE, " +
+            "FOREIGN KEY (" + BudgetCategory.CATEGORY + ") REFERENCES " + Category.TABLE +
+            "(" + Category.ID + ") ON UPDATE NO ACTION ON DELETE CASCADE " +
+            ")";
+
     /*package-local*/ static final String CREATE_TABLE_SAVING = "CREATE TABLE " + Saving.TABLE + " (" +
             Saving.ID + " INTEGER PRIMARY KEY AUTOINCREMENT, " +
             Saving.DESCRIPTION + " TEXT, " +
@@ -782,4 +802,67 @@ package com.oriondev.moneywallet.storage.database;
 
     /*package-local*/ static final String CREATE_BUDGET_RULE_START_COLUMN = "ALTER TABLE " +
             Budget.TABLE + " ADD COLUMN " + Budget.RULE_START + " DATETIME";
+
+    /**
+     * Fills the join table from the single category a budget used to carry. It covers only the
+     * budgets that have no live row yet, which is what makes it safe to run a second time, a
+     * budget that already covers categories keeps them instead of gaining whatever the column
+     * happens to say now. See the upgrade in SQLDatabase for when that second run happens.
+     *
+     * REPLACE and not IGNORE because a budget can hold a row for this very category that is
+     * flagged deleted, which is what changing a budget away from covering categories and back
+     * leaves behind. IGNORE would drop the insert on the composite key and leave the budget with
+     * a column and no live category at all.
+     */
+    /*package-local*/ static final String FILL_BUDGET_CATEGORY_FROM_COLUMN = "INSERT OR REPLACE INTO " +
+            BudgetCategory.TABLE + " (" + BudgetCategory.BUDGET + ", " + BudgetCategory.CATEGORY +
+            ", " + BudgetCategory.UUID + ", " + BudgetCategory.LAST_EDIT + ", " +
+            BudgetCategory.DELETED + ") SELECT b." + Budget.ID + ", b." + Budget.CATEGORY +
+            ", b." + Budget.UUID + " || '-category-' || b." + Budget.CATEGORY +
+            ", strftime('%s','now') * 1000, 0 FROM " + Budget.TABLE + " AS b WHERE b." +
+            Budget.CATEGORY + " IS NOT NULL AND b." + Budget.DELETED + " = 0 AND b." + Budget.ID +
+            " NOT IN (SELECT " + BudgetCategory.BUDGET + " FROM " + BudgetCategory.TABLE +
+            " WHERE " + BudgetCategory.DELETED + " = 0)";
+
+    /**
+     * Points the single column at the first of the categories a budget covers, once the join
+     * table is filled. It corrects a column, and never gives one to a budget that has none:
+     * a budget carrying no category has had its type changed away from covering them, and
+     * writing one back would leave a row saying it covers a category it does not.
+     *
+     * What it corrects is a release that predates the table writing the column while the table
+     * kept the real set. Leaving that would put a category no screen shows behind the budget,
+     * chosen for its icon and refusing to be deleted, with nothing to say why.
+     */
+    /*package-local*/ static final String ALIGN_BUDGET_CATEGORY_COLUMN = "UPDATE " + Budget.TABLE +
+            " SET " + Budget.CATEGORY + " = (SELECT MIN(" + BudgetCategory.CATEGORY + ") FROM " +
+            BudgetCategory.TABLE + " WHERE " + BudgetCategory.BUDGET + " = " + Budget.TABLE + "." +
+            Budget.ID + " AND " + BudgetCategory.DELETED + " = 0) WHERE " + Budget.CATEGORY +
+            " IS NOT NULL AND " + Budget.ID + " IN (SELECT " + BudgetCategory.BUDGET + " FROM " +
+            BudgetCategory.TABLE + " WHERE " + BudgetCategory.DELETED + " = 0)";
+
+    /**
+     * Flags the join rows of any budget that no longer covers categories at all. A release that
+     * predates the table can change a budget's type without seeing them, and rows left live
+     * there hold their categories against deletion while no screen shows the budget covering
+     * anything. Flagged and not deleted, which is what an ordinary edit does to the same rows.
+     * Nothing brings them back on its own, a budget turned back into one that covers categories
+     * is saved through an editor that asks the user to pick them again.
+     */
+    /*package-local*/ static final String CLEAR_BUDGET_CATEGORY_OF_OTHER_TYPES = "UPDATE " +
+            BudgetCategory.TABLE + " SET " + BudgetCategory.DELETED + " = 1, " +
+            BudgetCategory.LAST_EDIT + " = strftime('%s','now') * 1000 WHERE " +
+            BudgetCategory.DELETED + " = 0 AND " + BudgetCategory.BUDGET + " IN (SELECT " +
+            Budget.ID + " FROM " + Budget.TABLE + " WHERE " + Budget.TYPE + " != " +
+            BudgetType.CATEGORY + ")";
+
+    /**
+     * Takes the single column off any budget that no longer covers categories, for the same
+     * reason its rows are flagged. The column carries ON DELETE CASCADE, so one left behind on a
+     * budget of another type both refuses its category deletion and puts that budget behind a
+     * cascade it does not claim.
+     */
+    /*package-local*/ static final String CLEAR_BUDGET_COLUMN_OF_OTHER_TYPES = "UPDATE " +
+            Budget.TABLE + " SET " + Budget.CATEGORY + " = NULL WHERE " + Budget.CATEGORY +
+            " IS NOT NULL AND " + Budget.TYPE + " != " + BudgetType.CATEGORY;
 }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SyncContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SyncContentProvider.java
@@ -54,6 +54,7 @@ public class SyncContentProvider extends ContentProvider {
     public static final Uri CONTENT_DEBT_PEOPLE = Uri.parse("content://" + AUTHORITY + "/debt_people");
     public static final Uri CONTENT_BUDGET = Uri.parse("content://" + AUTHORITY + "/budget");
     public static final Uri CONTENT_BUDGET_WALLET = Uri.parse("content://" + AUTHORITY + "/budget_wallets");
+    public static final Uri CONTENT_BUDGET_CATEGORY = Uri.parse("content://" + AUTHORITY + "/budget_categories");
     public static final Uri CONTENT_SAVING = Uri.parse("content://" + AUTHORITY + "/savings");
     public static final Uri CONTENT_RECURRENT_TRANSACTION = Uri.parse("content://" + AUTHORITY + "/recurrent_transactions");
     public static final Uri CONTENT_RECURRENT_TRANSFER = Uri.parse("content://" + AUTHORITY + "/recurrent_transfers");
@@ -78,6 +79,7 @@ public class SyncContentProvider extends ContentProvider {
     private static final int TABLE_DEBT_PEOPLE = 9;
     private static final int TABLE_BUDGETS = 10;
     private static final int TABLE_BUDGET_WALLETS = 11;
+    private static final int TABLE_BUDGET_CATEGORIES = 24;
     private static final int TABLE_SAVINGS = 12;
     private static final int TABLE_RECURRENT_TRANSACTIONS = 13;
     private static final int TABLE_RECURRENT_TRANSFERS = 14;
@@ -106,6 +108,7 @@ public class SyncContentProvider extends ContentProvider {
         matcher.addURI(AUTHORITY, "debt_people", TABLE_DEBT_PEOPLE);
         matcher.addURI(AUTHORITY, "budget", TABLE_BUDGETS);
         matcher.addURI(AUTHORITY, "budget_wallets", TABLE_BUDGET_WALLETS);
+        matcher.addURI(AUTHORITY, "budget_categories", TABLE_BUDGET_CATEGORIES);
         matcher.addURI(AUTHORITY, "savings", TABLE_SAVINGS);
         matcher.addURI(AUTHORITY, "recurrent_transactions", TABLE_RECURRENT_TRANSACTIONS);
         matcher.addURI(AUTHORITY, "recurrent_transfers", TABLE_RECURRENT_TRANSFERS);
@@ -154,6 +157,8 @@ public class SyncContentProvider extends ContentProvider {
                 return Schema.Budget.TABLE;
             case TABLE_BUDGET_WALLETS:
                 return Schema.BudgetWallet.TABLE;
+            case TABLE_BUDGET_CATEGORIES:
+                return Schema.BudgetCategory.TABLE;
             case TABLE_SAVINGS:
                 return Schema.Saving.TABLE;
             case TABLE_RECURRENT_TRANSACTIONS:

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/DefaultBackupExporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/DefaultBackupExporter.java
@@ -76,6 +76,7 @@ public class DefaultBackupExporter extends AbstractBackupExporter {
             exporter.exportDebtPeople(SQLDatabaseExporter.getAllDebtPeople(contentResolver));
             exporter.exportBudgets(SQLDatabaseExporter.getAllBudget(contentResolver));
             exporter.exportBudgetWallets(SQLDatabaseExporter.getAllBudgetWallets(contentResolver));
+            exporter.exportBudgetCategories(SQLDatabaseExporter.getAllBudgetCategories(contentResolver));
             exporter.exportSavings(SQLDatabaseExporter.getAllSavings(contentResolver));
             exporter.exportRecurrentTransactions(SQLDatabaseExporter.getAllRecurrentTransactions(contentResolver));
             exporter.exportRecurrentTransfers(SQLDatabaseExporter.getAllRecurrentTransfers(contentResolver));

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/DefaultBackupImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/DefaultBackupImporter.java
@@ -83,6 +83,7 @@ public class DefaultBackupImporter extends AbstractBackupImporter {
             importer.importDebtPeople(contentResolver);
             importer.importBudgets(contentResolver);
             importer.importBudgetWallets(contentResolver);
+            importer.importBudgetCategories(contentResolver);
             importer.importSavings(contentResolver);
             importer.importRecurrentTransactions(contentResolver);
             importer.importRecurrentTransfers(contentResolver);

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/LegacyBackupImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/LegacyBackupImporter.java
@@ -113,6 +113,7 @@ public class LegacyBackupImporter extends AbstractBackupImporter {
             mDatabaseImporter.importDebtPeople(contentResolver);
             mDatabaseImporter.importBudgets(contentResolver);
             mDatabaseImporter.importBudgetWallets(contentResolver);
+            mDatabaseImporter.importBudgetCategories(contentResolver);
             mDatabaseImporter.importSavings(contentResolver);
             mDatabaseImporter.importRecurrentTransactions(contentResolver);
             mDatabaseImporter.importRecurrentTransfers(contentResolver);

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDataInputFactory.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDataInputFactory.java
@@ -241,6 +241,16 @@ import java.util.Map;
         return budget;
     }
 
+    /*package-local*/ BudgetCategory getBudgetCategory(JSONObject object) {
+        BudgetCategory budgetCategory = new BudgetCategory();
+        budgetCategory.mBudget = mCacheBudgets.get(object.optString(JSONDatabase.BudgetCategory.BUDGET, null));
+        budgetCategory.mCategory = mCacheCategories.get(object.optString(JSONDatabase.BudgetCategory.CATEGORY, null));
+        budgetCategory.mUUID = object.optString(JSONDatabase.BudgetCategory.ID, null);
+        budgetCategory.mLastEdit = object.optLong(JSONDatabase.BudgetCategory.LAST_EDIT, 0L);
+        budgetCategory.mDeleted = object.optBoolean(JSONDatabase.BudgetCategory.DELETED, false);
+        return budgetCategory;
+    }
+
     /*package-local*/ BudgetWallet getBudgetWallet(JSONObject object) {
         BudgetWallet budgetWallet = new BudgetWallet();
         budgetWallet.mBudget = mCacheBudgets.get(object.optString(JSONDatabase.BudgetWallet.BUDGET, null));

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDataOutputFactory.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDataOutputFactory.java
@@ -21,6 +21,7 @@ package com.oriondev.moneywallet.storage.database.json;
 
 import com.oriondev.moneywallet.storage.database.model.Attachment;
 import com.oriondev.moneywallet.storage.database.model.Budget;
+import com.oriondev.moneywallet.storage.database.model.BudgetCategory;
 import com.oriondev.moneywallet.storage.database.model.BudgetWallet;
 import com.oriondev.moneywallet.storage.database.model.Category;
 import com.oriondev.moneywallet.storage.database.model.Currency;
@@ -211,6 +212,16 @@ import java.util.HashMap;
         object.put(JSONDatabase.Budget.LAST_EDIT, budget.mLastEdit);
         object.put(JSONDatabase.Budget.DELETED, budget.mDeleted);
         mCacheBudgets.put(budget.mId, budget.mUUID);
+        return object;
+    }
+
+    /*package-local*/ JSONObject getObject(BudgetCategory budgetCategory) throws JSONException {
+        JSONObject object = new JSONObject();
+        object.put(JSONDatabase.BudgetCategory.BUDGET, mCacheBudgets.get(budgetCategory.mBudget));
+        object.put(JSONDatabase.BudgetCategory.CATEGORY, mCacheCategories.get(budgetCategory.mCategory));
+        object.put(JSONDatabase.BudgetCategory.ID, budgetCategory.mUUID);
+        object.put(JSONDatabase.BudgetCategory.LAST_EDIT, budgetCategory.mLastEdit);
+        object.put(JSONDatabase.BudgetCategory.DELETED, budgetCategory.mDeleted);
         return object;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDatabase.java
@@ -25,9 +25,13 @@ package com.oriondev.moneywallet.storage.database.json;
 /*package-local*/ class JSONDatabase {
 
     /*package-local*/ static final int MIN_SUPPORTED_VERSION = 1;
-    /*package-local*/ static final int MAX_SUPPORTED_VERSION = 2;
+    /*package-local*/ static final int MAX_SUPPORTED_VERSION = 3;
 
-    /*package-local*/ static final int VERSION = 2;
+    // version 3 adds the budget_categories array, so that a budget covering more than one
+    // category keeps every one of them through a backup. A release that predates it refuses a
+    // version 3 file by its header instead of failing part way through the arrays, which is what
+    // it would do with an array it does not expect in the middle of the stream.
+    /*package-local*/ static final int VERSION = 3;
 
     /*package-local*/ static class Header {
         /*package-local*/ static final String OBJECT = "header";
@@ -169,6 +173,15 @@ package com.oriondev.moneywallet.storage.database.json;
         /*package-local*/ static final String ID = "id";
         /*package-local*/ static final String BUDGET = "budget";
         /*package-local*/ static final String WALLET = "wallet";
+        /*package-local*/ static final String LAST_EDIT = "last_edit";
+        /*package-local*/ static final String DELETED = "deleted";
+    }
+
+    /*package-local*/ static final class BudgetCategory {
+        /*package-local*/ static final String ARRAY = "budget_categories";
+        /*package-local*/ static final String ID = "id";
+        /*package-local*/ static final String BUDGET = "budget";
+        /*package-local*/ static final String CATEGORY = "category";
         /*package-local*/ static final String LAST_EDIT = "last_edit";
         /*package-local*/ static final String DELETED = "deleted";
     }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDatabaseExporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDatabaseExporter.java
@@ -238,6 +238,22 @@ public class JSONDatabaseExporter implements DatabaseExporter {
     }
 
     @Override
+    public void exportBudgetCategories(Cursor cursor) throws ExportException {
+        try {
+            mWriter.writeName(JSONDatabase.BudgetCategory.ARRAY);
+            mWriter.beginArray();
+            while (cursor.moveToNext()) {
+                BudgetCategory budgetCategory = SQLDatabaseExporter.getBudgetCategory(cursor);
+                JSONObject object = mFactory.getObject(budgetCategory);
+                mWriter.writeJSONObject(object);
+            }
+            mWriter.endArray();
+        } catch (IOException | JSONException e) {
+            throw new ExportException(e.getMessage());
+        }
+    }
+
+    @Override
     public void exportSavings(Cursor cursor) throws ExportException {
         try {
             mWriter.writeName(JSONDatabase.Saving.ARRAY);

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDatabaseImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/json/JSONDatabaseImporter.java
@@ -26,6 +26,7 @@ import com.oriondev.moneywallet.storage.database.ImportException;
 import com.oriondev.moneywallet.storage.database.SQLDatabaseImporter;
 import com.oriondev.moneywallet.storage.database.model.Attachment;
 import com.oriondev.moneywallet.storage.database.model.Budget;
+import com.oriondev.moneywallet.storage.database.model.BudgetCategory;
 import com.oriondev.moneywallet.storage.database.model.BudgetWallet;
 import com.oriondev.moneywallet.storage.database.model.Category;
 import com.oriondev.moneywallet.storage.database.model.Currency;
@@ -285,6 +286,9 @@ public class JSONDatabaseImporter implements DatabaseImporter {
                     Budget budget = mFactory.getBudget(object);
                     long id = SQLDatabaseImporter.insert(contentResolver, budget);
                     mFactory.cacheBudget(budget.mUUID, id);
+                    if (mVersion < 3) {
+                        SQLDatabaseImporter.insertBudgetCategory(contentResolver, id, budget.mCategory);
+                    }
                 }
                 mReader.endArray();
             } else {
@@ -311,6 +315,28 @@ public class JSONDatabaseImporter implements DatabaseImporter {
             }
         } catch (IOException | JSONException e) {
             throw new ImportException(e.getMessage());
+        }
+    }
+
+    @Override
+    public void importBudgetCategories(ContentResolver contentResolver) throws ImportException {
+        // budget categories are stored starting from backup version >= 3
+        if (mVersion >= 3) {
+            try {
+                if (JSONDatabase.BudgetCategory.ARRAY.equals(mReader.readName())) {
+                    mReader.beginArray();
+                    while (mReader.hasArrayAnotherObject()) {
+                        JSONObject object = mReader.readObject();
+                        BudgetCategory budgetCategory = mFactory.getBudgetCategory(object);
+                        SQLDatabaseImporter.insert(contentResolver, budgetCategory);
+                    }
+                    mReader.endArray();
+                } else {
+                    throw new ImportException("Wrong array name (expected = 'budget_categories')");
+                }
+            } catch (IOException | JSONException e) {
+                throw new ImportException(e.getMessage());
+            }
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/legacy/LegacyDatabaseImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/legacy/LegacyDatabaseImporter.java
@@ -401,6 +401,7 @@ public class LegacyDatabaseImporter implements DatabaseImporter {
                     budget.mLastEdit = getLongSafely(cursor, LegacyDatabaseSchema.Budget.LAST_EDIT);
                     try {
                         long id = SQLDatabaseImporter.insert(contentResolver, budget);
+                        SQLDatabaseImporter.insertBudgetCategory(contentResolver, id, budget.mCategory);
                         // for each linked wallet, insert a link in the new database
                         for (Long legacyId : legacyIds) {
                             BudgetWallet budgetWallet = new BudgetWallet();
@@ -448,6 +449,12 @@ public class LegacyDatabaseImporter implements DatabaseImporter {
     @Override
     public void importBudgetWallets(ContentResolver contentResolver) throws ImportException {
         // not supported in legacy database
+    }
+
+    @Override
+    public void importBudgetCategories(ContentResolver contentResolver) throws ImportException {
+        // a legacy budget names one category on its own row, and importBudgets above puts that
+        // into the join table as it goes, so there is nothing left to read here
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/model/BudgetCategory.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/model/BudgetCategory.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.storage.database.model;
+
+/**
+ * Created by andrea on 27/10/18.
+ */
+public class BudgetCategory extends BaseItem {
+
+    public Long mBudget;
+    public Long mCategory;
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivity.java
@@ -70,7 +70,7 @@ import java.util.Date;
  */
 public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyPicker.Controller,
                                                                         BudgetTypePicker.Controller,
-                                                                        CategoryPicker.Controller,
+                                                                        CategoryPicker.MultiCategoryController,
                                                                         DateTimePicker.Controller,
                                                                         RecurrencePicker.Controller,
                                                                         WalletPicker.MultiWalletController {
@@ -325,7 +325,7 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
             @NonNull
             @Override
             public String getErrorMessage() {
-                return getString(R.string.error_input_missing_category);
+                return getString(R.string.error_input_missing_categories);
             }
 
             @Override
@@ -352,7 +352,7 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
 
             @Override
             public void onClick(View v) {
-                mCategoryPicker.showPicker();
+                mCategoryPicker.showMultiPicker();
             }
 
         });
@@ -395,7 +395,7 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
         super.onViewCreated(savedInstanceState);
         long money = 0L;
         Contract.BudgetType type = null;
-        Category category = null;
+        Category[] categories = null;
         Date startDate = null;
         Date endDate = null;
         String rule = null;
@@ -421,14 +421,6 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
                 if (cursor != null) {
                     if (cursor.moveToFirst()) {
                         type = Contract.BudgetType.fromValue(cursor.getInt(cursor.getColumnIndex(Contract.Budget.TYPE)));
-                        if (type == Contract.BudgetType.CATEGORY) {
-                            category = new Category(
-                                    cursor.getLong(cursor.getColumnIndex(Contract.Budget.CATEGORY_ID)),
-                                    cursor.getString(cursor.getColumnIndex(Contract.Budget.CATEGORY_NAME)),
-                                    IconLoader.parse(cursor.getString(cursor.getColumnIndex(Contract.Budget.CATEGORY_ICON))),
-                                    Contract.CategoryType.fromValue(cursor.getInt(cursor.getColumnIndex(Contract.Budget.CATEGORY_TYPE)))
-                            );
-                        }
                         money = cursor.getLong(cursor.getColumnIndex(Contract.Budget.MONEY));
                         startDate = DateUtils.getDateFromSQLDateString(cursor.getString(cursor.getColumnIndex(Contract.Budget.START_DATE)));
                         endDate = DateUtils.getDateFromSQLDateString(cursor.getString(cursor.getColumnIndex(Contract.Budget.END_DATE)));
@@ -439,6 +431,35 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
                         }
                     }
                     cursor.close();
+                }
+                // The budget row names its categories in one column of ids and one of joined
+                // names, neither of which rebuilds the objects the picker holds, so they are
+                // asked for on their own. This is the same reason the wallets are queried again
+                // below.
+                if (type == Contract.BudgetType.CATEGORY) {
+                    Uri categoriesUri = Uri.withAppendedPath(uri, "categories");
+                    String[] categoryProjection = new String[] {
+                            Contract.Category.ID,
+                            Contract.Category.NAME,
+                            Contract.Category.ICON,
+                            Contract.Category.TYPE
+                    };
+                    // lowest id first, which is the order a budget row hands its categories
+                    // over in, so the one that ends up back in Contract.Budget.CATEGORY_ID on a
+                    // save is the same one that was there before the edit
+                    Cursor categoryCursor = contentResolver.query(categoriesUri, categoryProjection, null, null, Contract.Category.ID + " ASC");
+                    if (categoryCursor != null) {
+                        categories = new Category[categoryCursor.getCount()];
+                        for (int i = 0; categoryCursor.moveToPosition(i); i++) {
+                            categories[i] = new Category(
+                                    categoryCursor.getLong(categoryCursor.getColumnIndex(Contract.Category.ID)),
+                                    categoryCursor.getString(categoryCursor.getColumnIndex(Contract.Category.NAME)),
+                                    IconLoader.parse(categoryCursor.getString(categoryCursor.getColumnIndex(Contract.Category.ICON))),
+                                    Contract.CategoryType.fromValue(categoryCursor.getInt(categoryCursor.getColumnIndex(Contract.Category.TYPE)))
+                            );
+                        }
+                        categoryCursor.close();
+                    }
                 }
                 // the previous cursor contains only a column with the list of ids of linked wallets.
                 // we need instead to buildMaterialDialog the full wallet object so we must perform a separated
@@ -510,7 +531,7 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
         FragmentManager fragmentManager = getSupportFragmentManager();
         mMoneyPicker = MoneyPicker.createPicker(fragmentManager, TAG_MONEY_PICKER, null, money);
         mBudgetTypePicker = BudgetTypePicker.createPicker(fragmentManager, TAG_BUDGET_TYPE_PICKER, type);
-        mCategoryPicker = CategoryPicker.createPicker(fragmentManager, TAG_CATEGORY_PICKER, category);
+        mCategoryPicker = CategoryPicker.createPicker(fragmentManager, TAG_CATEGORY_PICKER, categories);
         mStartDatePicker = DateTimePicker.createPicker(fragmentManager, TAG_START_DATE_PICKER, startDate);
         mEndDatePicker = DateTimePicker.createPicker(fragmentManager, TAG_END_DATE_PICKER, endDate);
         mWalletsPicker = WalletPicker.createPicker(fragmentManager, TAG_WALLETS_PICKER, wallets);
@@ -799,8 +820,9 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
             ContentValues contentValues = new ContentValues();
             contentValues.put(Contract.Budget.TYPE, mBudgetTypePicker.getCurrentType().getValue());
             if (mBudgetTypePicker.getCurrentType() == Contract.BudgetType.CATEGORY) {
-                contentValues.put(Contract.Budget.CATEGORY_ID, mCategoryPicker.getCurrentCategory().getId());
+                contentValues.put(Contract.Budget.CATEGORY_IDS, Contract.getObjectIds(mCategoryPicker.getCurrentCategories()));
             } else {
+                contentValues.putNull(Contract.Budget.CATEGORY_IDS);
                 contentValues.putNull(Contract.Budget.CATEGORY_ID);
             }
             if (mRepeatCheckBox.isChecked() && isSupersededPeriod()) {
@@ -894,9 +916,16 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
     }
 
     @Override
-    public void onCategoryChanged(String tag, Category category) {
-        if (category != null) {
-            mCategoryEditText.setText(category.getName());
+    public void onCategoryListChanged(String tag, Category[] categories) {
+        if (categories != null && categories.length > 0) {
+            StringBuilder builder = new StringBuilder();
+            for (Category category : categories) {
+                if (builder.length() > 0) {
+                    builder.append(", ");
+                }
+                builder.append(category.getName());
+            }
+            mCategoryEditText.setText(builder.toString());
         } else {
             mCategoryEditText.setText(null);
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/MultiCategoryPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/MultiCategoryPickerDialog.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.fragment.dialog;
+
+import android.app.Activity;
+import android.app.Dialog;
+import android.database.Cursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.collection.LongSparseArray;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.afollestad.materialdialogs.DialogAction;
+import com.afollestad.materialdialogs.MaterialDialog;
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.model.Category;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.ui.adapter.recycler.ParentCategorySelectorCursorAdapter;
+import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+
+/**
+ * Picks any number of categories at once, for a budget that covers more than one.
+ *
+ * The list holds to one direction. With nothing chosen it offers every income and expense
+ * category; from the first choice on it offers only the ones of that direction, so a budget
+ * mixing the two cannot be built at all instead of being refused once it is saved. Clearing the
+ * last choice opens it back up. System categories are never offered, which is what the single
+ * picker does by default too.
+ */
+public class MultiCategoryPickerDialog extends DialogFragment implements ParentCategorySelectorCursorAdapter.Controller, LoaderManager.LoaderCallbacks<Cursor> {
+
+    private static final String SS_SELECTED_CATEGORIES = "MultiCategoryPickerDialog::SavedState::SelectedCategories";
+
+    private static final int DEFAULT_LOADER_ID = 1;
+
+    public static MultiCategoryPickerDialog newInstance() {
+        return new MultiCategoryPickerDialog();
+    }
+
+    private Callback mCallback;
+
+    private LongSparseArray<Category> mSelectedCategories;
+
+    private RecyclerView mRecyclerView;
+    private TextView mMessageTextView;
+
+    private ParentCategorySelectorCursorAdapter mCursorAdapter;
+
+    @Override
+    @NonNull
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        Activity activity = getActivity();
+        if (activity == null) {
+            return super.onCreateDialog(savedInstanceState);
+        }
+        if (savedInstanceState != null) {
+            mSelectedCategories = new LongSparseArray<>();
+            Parcelable[] parcelables = savedInstanceState.getParcelableArray(SS_SELECTED_CATEGORIES);
+            if (parcelables != null) {
+                for (Parcelable parcelable : parcelables) {
+                    Category category = (Category) parcelable;
+                    mSelectedCategories.append(category.getId(), category);
+                }
+            }
+        }
+        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .title(R.string.dialog_category_picker_title)
+                .positiveText(android.R.string.ok)
+                .negativeText(android.R.string.cancel)
+                .customView(R.layout.dialog_advanced_list, false)
+                .onPositive(new MaterialDialog.SingleButtonCallback() {
+
+                    @Override
+                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        if (mCallback != null) {
+                            mCallback.onCategoriesSelected(selectedCategories());
+                        }
+                    }
+
+                })
+                .build();
+        mCursorAdapter = new ParentCategorySelectorCursorAdapter(this);
+        View view = dialog.getCustomView();
+        if (view != null) {
+            mRecyclerView = view.findViewById(R.id.recycler_view);
+            mMessageTextView = view.findViewById(R.id.message_text_view);
+            mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
+            mRecyclerView.setAdapter(mCursorAdapter);
+            mMessageTextView.setText(R.string.message_no_category_found);
+        }
+        mRecyclerView.setVisibility(View.GONE);
+        mMessageTextView.setVisibility(View.GONE);
+        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        return dialog;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putParcelableArray(SS_SELECTED_CATEGORIES, selectedCategories());
+    }
+
+    private Category[] selectedCategories() {
+        Category[] categories = new Category[mSelectedCategories.size()];
+        for (int i = 0; i < mSelectedCategories.size(); i++) {
+            categories[i] = mSelectedCategories.valueAt(i);
+        }
+        return categories;
+    }
+
+    /**
+     * The direction every category on offer has to be, taken from the ones already chosen.
+     *
+     * @return the type they share, or null while nothing is chosen.
+     */
+    private Contract.CategoryType selectedType() {
+        return mSelectedCategories.size() > 0 ? mSelectedCategories.valueAt(0).getType() : null;
+    }
+
+    public void setCallback(Callback callback) {
+        mCallback = callback;
+    }
+
+    public void showPicker(FragmentManager fragmentManager, String tag, Category[] categories) {
+        mSelectedCategories = new LongSparseArray<>();
+        if (categories != null) {
+            for (Category category : categories) {
+                mSelectedCategories.append(category.getId(), category);
+            }
+        }
+        show(fragmentManager, tag);
+    }
+
+    @NonNull
+    @Override
+    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+        Activity activity = getActivity();
+        if (activity != null) {
+            Uri uri = DataContentProvider.CONTENT_CATEGORIES;
+            String[] projection = new String[] {
+                    Contract.Category.ID,
+                    Contract.Category.NAME,
+                    Contract.Category.ICON,
+                    Contract.Category.TYPE
+            };
+            Contract.CategoryType type = selectedType();
+            String selection;
+            String[] selectionArgs;
+            if (type != null) {
+                selection = Contract.Category.TYPE + " = ?";
+                selectionArgs = new String[] {String.valueOf(type.getValue())};
+            } else {
+                selection = Contract.Category.TYPE + " != ?";
+                selectionArgs = new String[] {String.valueOf(Contract.CategoryType.SYSTEM.getValue())};
+            }
+            String sortOrder = Contract.Category.TYPE + " ASC, " + Contract.Category.GROUP_INDEX +
+                    " ASC, " + Contract.Category.GROUP_NAME + " ASC, " + Contract.Category.GROUP_ID +
+                    " ASC, " + Contract.Category.PARENT + " IS NULL DESC, " + Contract.Category.NAME + " ASC";
+            return new CursorLoader(activity, uri, projection, selection, selectionArgs, sortOrder);
+        }
+        throw new RuntimeException("Activity is null");
+    }
+
+    @Override
+    public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
+        mCursorAdapter.swapCursor(cursor);
+        if (cursor != null && cursor.getCount() > 0) {
+            mRecyclerView.setVisibility(View.VISIBLE);
+            mMessageTextView.setVisibility(View.GONE);
+        } else {
+            mRecyclerView.setVisibility(View.GONE);
+            mMessageTextView.setVisibility(View.VISIBLE);
+        }
+    }
+
+    @Override
+    public void onLoaderReset(@NonNull Loader<Cursor> loader) {
+        mCursorAdapter.swapCursor(null);
+    }
+
+    @Override
+    public void onCategorySelected(Category category) {
+        Contract.CategoryType before = selectedType();
+        if (before != null && category.getType() != before
+                && mSelectedCategories.indexOfKey(category.getId()) < 0) {
+            // the list is narrowed to one direction by the loader, and a loader runs on another
+            // thread, so a second tap landing before the narrowed rows arrive would otherwise put a
+            // category of the other direction in beside the first
+            return;
+        }
+        if (mSelectedCategories.indexOfKey(category.getId()) >= 0) {
+            mSelectedCategories.remove(category.getId());
+        } else {
+            mSelectedCategories.append(category.getId(), category);
+        }
+        if (before != selectedType()) {
+            // the first choice narrows the list to that direction, and dropping the last opens it
+            // back up, so the rows on offer have to be asked for again
+            getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        } else {
+            mCursorAdapter.notifyDataSetChanged();
+        }
+    }
+
+    @Override
+    public boolean isCategorySelected(long id) {
+        return mSelectedCategories.indexOfKey(id) >= 0;
+    }
+
+    public interface Callback {
+
+        void onCategoriesSelected(Category[] categories);
+    }
+}

--- a/app/src/main/res/layout/layout_panel_new_edit_budget.xml
+++ b/app/src/main/res/layout/layout_panel_new_edit_budget.xml
@@ -41,7 +41,7 @@
         android:id="@+id/category_edit_text"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="@string/hint_category"
+        android:hint="@string/hint_categories"
         android:inputType="textNoSuggestions"
         app:met_mode="floatingLabel"
         app:met_leftIcon="@drawable/ic_table_large_24dp" />

--- a/app/src/main/res/layout/layout_panel_show_budget_item.xml
+++ b/app/src/main/res/layout/layout_panel_show_budget_item.xml
@@ -55,7 +55,7 @@
             android:layout_marginTop="@dimen/material_activity_body_edit_text_margin_top"
             android:layout_marginBottom="@dimen/material_activity_body_edit_text_margin_bottom"
             app:mtv_mode="floatingLabel"
-            app:mtv_floatingLabelText="@string/hint_category"
+            app:mtv_floatingLabelText="@string/hint_categories"
             app:mtv_leftIcon="@drawable/ic_table_large_24dp"
             app:mtv_bottomLineEnabled="true"
             tools:text="Category name here" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,7 @@
     <string name="hint_start_money">"Initial amount"</string>
     <string name="hint_not_exclude_wallet">"Show this wallet in the total count"</string>
     <string name="hint_category">"Category"</string>
+    <string name="hint_categories">"Categories"</string>
     <string name="hint_parent_category">"Parent category"</string>
     <string name="hint_show_category_report">"Show this category inside the reports"</string>
     <string name="hint_show_category_report_on">"This category is included inside the reports"</string>
@@ -297,6 +298,7 @@
     <string name="error_input_missing_end_date">Select an end date</string>
     <string name="error_input_invalid_date_range">"Invalid date range"</string>
     <string name="error_input_missing_category">"Select a category"</string>
+    <string name="error_input_missing_categories">"Select at least one category"</string>
     <string name="error_input_missing_description">"Provide a description"</string>
     <string name="error_input_missing_format">"Select a file format"</string>
     <string name="error_input_missing_input_file">"Select an input file"</string>


### PR DESCRIPTION
A budget could only ever be about one category. Anyone budgeting across several had to keep several budgets and add the figures up by hand.

A budget can now cover as many as you want. You pick them the way you already pick wallets, from a list where tapping adds a category and tapping it again takes it back off. Everything spent in any of them counts toward the one figure.

The list holds to one direction at a time. Once you pick an income category it stops offering expense ones, and the other way round, because a budget mixing the two has no single direction for its progress to run in.

The budget row and the detail screen now name every category a budget covers, "Food, Rent", where they named the one before.

Budgets you already have are untouched. The upgrade hands each of them the category it already had, so every figure reads the same after it as before. That was tested against a ledger of 457 transactions, and against a budget switched back and forth on an older version of the app.

One thing worth knowing before you take a backup. A backup written by this version cannot be restored on an older one; it is refused by the version stamped in it, cleanly, instead of failing part way through. Backups written by older versions still restore here, and the budgets inside them keep the category they name.

Deleting a category is still refused while a budget covers it. That was already true of the one category a budget had, and it now covers the rest.
