### PR TITLE
Hold every report screen to the same rule for a hidden category

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -2547,4 +2547,26 @@ public class SQLDatabaseTest {
         checkCursorSize(mDatabase.getAttachments(null, null, null, null), 0);
     }
 
+    @Test
+    public void reportFilterDropsAHiddenCategoryAndAHiddenParent() throws Exception {
+        long wallet = insertWallet("Wallet", "icon", "EUR", null, true, 0L, false, "tag-wallet");
+        long shown = insertCategory("Shown", "icon", 0, null, true, "tag-shown");
+        long hidden = insertCategory("Hidden", "icon", 0, null, false, "tag-hidden");
+        long shownChild = insertCategory("Shown child", "icon", 0, shown, true, "tag-shown-child");
+        long hiddenChild = insertCategory("Hidden child", "icon", 0, shown, false, "tag-hidden-child");
+        long childOfHidden = insertCategory("Child of hidden", "icon", 0, hidden, true, "tag-child-of-hidden");
+        Date date = new Date();
+        insertTransaction(100L, date, "on a shown category", shown, Contract.Direction.EXPENSE, 0, wallet, null, null, null, null, null, true, true, null, null, "tag-1");
+        insertTransaction(100L, date, "on a hidden category", hidden, Contract.Direction.EXPENSE, 0, wallet, null, null, null, null, null, true, true, null, null, "tag-2");
+        insertTransaction(100L, date, "on a shown child", shownChild, Contract.Direction.EXPENSE, 0, wallet, null, null, null, null, null, true, true, null, null, "tag-3");
+        insertTransaction(100L, date, "on a hidden child", hiddenChild, Contract.Direction.EXPENSE, 0, wallet, null, null, null, null, null, true, true, null, null, "tag-4");
+        insertTransaction(100L, date, "on a shown child of a hidden category", childOfHidden, Contract.Direction.EXPENSE, 0, wallet, null, null, null, null, null, true, true, null, null, "tag-5");
+        // the reports keep the two rows whose own category and parent are both shown
+        String[] projection = new String[] {Contract.Transaction.ID, Contract.Transaction.CATEGORY_ID};
+        checkCursorSize(mDatabase.getTransactions(projection, Contract.Transaction.REPORT_FILTER, null, null), 2);
+        // reading the own flag alone keeps the child of a hidden category, which is the third row
+        checkCursorSize(mDatabase.getTransactions(projection, Contract.Transaction.CATEGORY_SHOW_REPORT + " = 1", null, null), 3);
+        checkCursorSize(mDatabase.getTransactions(projection, null, null, null), 5);
+    }
+
 }

--- a/app/src/main/java/com/oriondev/moneywallet/background/OverviewDataLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/OverviewDataLoader.java
@@ -96,7 +96,7 @@ public class OverviewDataLoader extends AbstractGenericLoader<OverviewData> {
             selectionArgs = new String[] {String.valueOf(currentWallet)};
         }
         selection += " AND " + Contract.Transaction.CONFIRMED + " = '1' AND " + Contract.Transaction.COUNT_IN_TOTAL + " = '1'";
-        selection += " AND " + Contract.Transaction.CATEGORY_SHOW_REPORT + " = '1'";
+        selection += " AND " + Contract.Transaction.REPORT_FILTER;
         selection += " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('now', 'localtime')";
         selection += " AND DATETIME(" + Contract.Transaction.DATE + ") >= DATETIME('" + DateUtils.getSQLDateTimeString(mOverviewSetting.getStartDate()) + "')";
         selection += " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('" + DateUtils.getSQLDateTimeString(mOverviewSetting.getEndDate()) + "')";

--- a/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailFlowLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailFlowLoader.java
@@ -90,6 +90,7 @@ public class PeriodDetailFlowLoader extends AbstractGenericLoader<PeriodDetailFl
             selectionArgs = new String[] {String.valueOf(currentWallet)};
         }
         selection += " AND " + Contract.Transaction.CONFIRMED + " = '1' AND " + Contract.Transaction.COUNT_IN_TOTAL + " = '1'";
+        selection += " AND " + Contract.Transaction.REPORT_FILTER;
         selection += " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('now', 'localtime')";
         selection += " AND " + Contract.Transaction.DIRECTION + " = " + (mIncomes ? Contract.Direction.INCOME : Contract.Direction.EXPENSE);
         if (mStartDate != null) {
@@ -129,8 +130,6 @@ public class PeriodDetailFlowLoader extends AbstractGenericLoader<PeriodDetailFl
                     } else {
                         Category category = categoryCache.get(categoryId);
                         if (category != null) {
-                            // if category is null it means that the category must not be showed
-                            // inside the reports
                             CategoryMoney categoryMoney = new CategoryMoney(
                                     categoryId,
                                     category.getName(),
@@ -170,8 +169,8 @@ public class PeriodDetailFlowLoader extends AbstractGenericLoader<PeriodDetailFl
         return new PeriodDetailFlowData(totalMoney, pieDataList, categoryMoneyList);
     }
 
-    /** The caller checked the parent against the report filter, so a child counted here is also
-     * counted in the parent row above it. */
+    /** The caller checked that the parent has a row, so a child counted here is also counted in
+     * the parent row above it. */
     private void addChildMoney(Map<Long, Map<Long, CategoryMoney>> childMoneyMap,
                                long parentId, long childId, Category child, String iso, long money) {
         Map<Long, CategoryMoney> children = childMoneyMap.get(parentId);
@@ -199,9 +198,8 @@ public class PeriodDetailFlowLoader extends AbstractGenericLoader<PeriodDetailFl
 
     /**
      * Sorted by name, because the map has no order of its own and rows that move between two loads
-     * of one period read as a defect. Whatever reached no child this screen can name leads the
-     * list under the category's own name, which is money filed on the category itself plus money
-     * on a child hidden from the reports, so the rows always add up to the category.
+     * of one period read as a defect. Money filed on the category itself leads the list under the
+     * category's own name, so the rows always add up to the category.
      */
     private void attachChildren(CategoryMoney parent, Map<Long, CategoryMoney> children, Money direct) {
         if (children == null) {
@@ -225,19 +223,16 @@ public class PeriodDetailFlowLoader extends AbstractGenericLoader<PeriodDetailFl
     }
 
     /**
-     * A child hidden from the reports is left out, and the caller counts its money against the
-     * parent's row instead. That keeps the name off this screen and the rows still adding up. The
-     * money stays in the total, as it did before this screen named any child.
+     * Both caches name rows and neither decides what counts. A category hidden from the reports is
+     * already out, because REPORT_FILTER drops its transactions before they reach this loader.
      */
     private Map<Long, Category> loadChildCategoryCache() {
-        return loadCategories(Contract.Category.PARENT + " IS NOT NULL AND " +
-                Contract.Category.SHOW_REPORT + " = '1'");
+        return loadCategories(Contract.Category.PARENT + " IS NOT NULL");
     }
 
     @SuppressLint("UseSparseArrays")
     private Map<Long, Category> loadCategoryCache() {
-        return loadCategories(Contract.Category.PARENT + " IS NULL AND " +
-                Contract.Category.SHOW_REPORT + " = '1'");
+        return loadCategories(Contract.Category.PARENT + " IS NULL");
     }
 
     @SuppressLint("UseSparseArrays")

--- a/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailSummaryLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailSummaryLoader.java
@@ -88,6 +88,7 @@ public class PeriodDetailSummaryLoader extends AbstractGenericLoader<PeriodDetai
             selectionArgs = new String[] {String.valueOf(currentWallet)};
         }
         selection += " AND " + Contract.Transaction.CONFIRMED + " = '1' AND " + Contract.Transaction.COUNT_IN_TOTAL + " = '1'";
+        selection += " AND " + Contract.Transaction.REPORT_FILTER;
         selection += " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('now', 'localtime')";
         selection += " AND DATETIME(" + Contract.Transaction.DATE + ") >= DATETIME('" + DateUtils.getSQLDateTimeString(mStartDate) + "')";
         selection += " AND DATETIME(" + Contract.Transaction.DATE + ") <= DATETIME('" + DateUtils.getSQLDateTimeString(mEndDate) + "')";

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
@@ -70,6 +70,13 @@ public class Contract {
         public static final String CATEGORY_TYPE = "transaction_" + Schema.Category.TYPE;
         public static final String CATEGORY_TAG = "transaction_" + Schema.Category.TAG;
         public static final String CATEGORY_SHOW_REPORT = "transaction_" + Schema.Category.SHOW_REPORT;
+        public static final String CATEGORY_PARENT_SHOW_REPORT = "transaction_" + Category.PARENT_SHOW_REPORT;
+        /**
+         * A transaction belongs in the reports only when its own category is included and, for a
+         * transaction filed on a subcategory, the parent is included too. Both report screens
+         * filter on this, so a category hidden on one of them cannot still be counted on the other.
+         */
+        public static final String REPORT_FILTER = "(" + CATEGORY_SHOW_REPORT + " = 1 AND IFNULL(" + CATEGORY_PARENT_SHOW_REPORT + ", 1) = 1)";
         public static final String DIRECTION = Schema.Transaction.DIRECTION;
         public static final String TYPE = Schema.Transaction.TYPE;
         public static final String WALLET_ID = Schema.Transaction.WALLET;

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -727,6 +727,7 @@ import java.util.UUID;
                 "c." + Schema.Category.TYPE + " AS " + Contract.Transaction.CATEGORY_TYPE + ", " +
                 "c." + Schema.Category.TAG + " AS " + Contract.Transaction.CATEGORY_TAG + ", " +
                 "c." + Schema.Category.SHOW_REPORT + " AS " + Contract.Transaction.CATEGORY_SHOW_REPORT + ", " +
+                "pc." + Schema.Category.SHOW_REPORT + " AS " + Contract.Transaction.CATEGORY_PARENT_SHOW_REPORT + ", " +
                 "t." + Schema.Transaction.DIRECTION + " AS " + Contract.Transaction.DIRECTION + ", " +
                 "t." + Schema.Transaction.TYPE + " AS " + Contract.Transaction.TYPE + ", " +
                 "t." + Schema.Transaction.WALLET + " AS " + Contract.Transaction.WALLET_ID + ", " +
@@ -760,6 +761,8 @@ import java.util.UUID;
                 "GROUP_CONCAT('<' || pe." + Schema.Person.ID + " || '>') AS " + Contract.Transaction.PEOPLE_IDS + " " +
                 "FROM " + Schema.Transaction.TABLE + " AS t LEFT JOIN " + Schema.Category.TABLE +
                 " AS c ON t." + Schema.Transaction.CATEGORY + " = c." + Schema.Category.ID + " AND c." +
+                Schema.Category.DELETED + " = 0 LEFT JOIN " + Schema.Category.TABLE + " AS pc ON c." +
+                Schema.Category.PARENT + " = pc." + Schema.Category.ID + " AND pc." +
                 Schema.Category.DELETED + " = 0 JOIN " + Schema.Wallet.TABLE + " AS w ON t." +
                 Schema.Transaction.WALLET + " = w." + Schema.Wallet.ID + " AND w." +
                 Schema.Wallet.DELETED + " = 0 LEFT JOIN " + Schema.TransactionPeople.TABLE + " AS tp ON t." +

--- a/app/src/main/java/com/oriondev/moneywallet/storage/wrapper/TransactionHeaderCursor.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/wrapper/TransactionHeaderCursor.java
@@ -187,8 +187,10 @@ public class TransactionHeaderCursor extends AbstractHeaderCursor<TransactionHea
          * that same amount as a plus or a minus.
          *
          * Direction is all that is read here, so the two halves of a transfer land in both, and a
-         * debt taken on lands in the incoming one. That is what PeriodDetailSummaryLoader counts
-         * too, which is the report a reader reaches from this header, so the two agree.
+         * debt taken on lands in the incoming one. PeriodDetailSummaryLoader, the report a reader
+         * reaches from this header, splits a row the same way, so a row lands on the same side in
+         * both. It counts fewer rows than this does, since it drops a category kept out of the
+         * reports and a header counts every row on the list under it.
          */
         /*package-local*/ void add(String currency, long money, int direction) {
             if (direction == Contract.Direction.INCOME) {

--- a/app/src/test/java/com/oriondev/moneywallet/background/ReportLoaderSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/background/ReportLoaderSourceTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.background;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * The three report loaders each build their own selection string, so the rule about a category
+ * kept out of the reports lives in one constant and is appended three times. SQLDatabaseTest
+ * covers what that constant selects. Nothing covers whether a loader still appends it, and a
+ * loader that stops puts back the defect where one period reads differently on the overview list,
+ * on the two flow tabs and on the summary tab.
+ *
+ * This reads the source, so it is a tripwire against a revert and not a proof of behavior. It
+ * cannot see a loader that appends the filter and then reassigns selection underneath it, or one
+ * that builds a string it never queries with, because no loader is executed here.
+ *
+ * Comments are stripped before anything is matched, so the assertion cannot be satisfied by a
+ * comment naming the constant the loader no longer appends. String literals are NOT stripped,
+ * unlike the precedent, because the statement being matched contains one. Whitespace is collapsed,
+ * so the statement may be wrapped, but the spelling is pinned exactly and a respelling fails with
+ * no defect present. A failure means read the loader and decide.
+ */
+public class ReportLoaderSourceTest {
+
+    private static final Pattern COMMENTS = Pattern.compile("//.*?$|/[*].*?[*]/", Pattern.DOTALL | Pattern.MULTILINE);
+
+    private static final String[] LOADERS = new String[] {
+            "OverviewDataLoader",
+            "PeriodDetailFlowLoader",
+            "PeriodDetailSummaryLoader"
+    };
+
+    private static final String APPEND =
+            "selection += \" AND \" + Contract.Transaction.REPORT_FILTER;";
+
+    @Test
+    public void everyReportLoaderAppliesTheReportFilter() {
+        for (String loader : LOADERS) {
+            assertTrue("a report screen that stops filtering on REPORT_FILTER counts a category "
+                    + "kept out of the reports again, and disagrees with the other two: " + loader,
+                    readSource(loader).contains(APPEND));
+        }
+    }
+
+    private String readSource(String loader) {
+        String path = "src/main/java/com/oriondev/moneywallet/background/" + loader + ".java";
+        File file = new File(path);
+        if (!file.exists()) {
+            // a runner rooted at the repo root instead of the module, which the precedent
+            // handles the same way
+            file = new File("app/" + path);
+        }
+        if (!file.exists()) {
+            fail("Cannot find " + loader + ".java at " + file.getAbsolutePath());
+        }
+        try {
+            String source = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            return COMMENTS.matcher(source).replaceAll(" ").replaceAll("\\s+", " ");
+        } catch (IOException e) {
+            fail("Cannot read " + loader + ".java: " + e.getMessage());
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
Closes #221.

A category can be kept out of the reports, and the checkbox is offered for a subcategory as readily as for a top level one. Three report screens each read that setting their own way, so one period showed different totals depending on where you looked.

The overview period list read the setting on the category a transaction is actually filed on. The screen you reach by tapping a period row looked at the category above it instead. Hide a subcategory and its money left the period row and stayed on the screen that row opens. Hide a top level category and leave its subcategories alone and the opposite happened, the money stayed in the period row and disappeared from the screen. The summary tab of that same screen had never read the setting at all, so it was a third answer.

All three now follow one rule. Money counts toward the reports only when the category it is filed on is included and, when that category sits under another, the one above it is included too. Hiding a category now hides what is filed underneath it, which is what most people mean when they hide one.

One thing worth knowing: a transaction list still shows every row and its header still totals every row, so once a category is kept out of the reports a report total and the list header it is reached from no longer match. That is what the setting asks for, and the two matched before only because of this bug.

Tested on an emulator against a ledger of 457 transactions. With one subcategory hidden the period row read 628.23, the expenses on the screen it opens read 4,155.17 and the summary tab read 628.23 of net incomes, three figures that reconcile. Before the change the same row read 628.23 against 4,589.15 and 194.25. With a parent hidden and its children shown the row read 2,018.48 against 2,764.92, where before it read 194.25 against the same 2,764.92. With nothing hidden every screen reads what it read before.
