### PR TITLE
Go back to Transactions from a drawer section instead of closing the app

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
@@ -229,12 +229,28 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
         if (mDrawer != null && mDrawer.isDrawerOpen()) {
             mDrawer.closeDrawer();
         } else if (mCurrentFragment instanceof NavigableFragment) {
-            if (!((NavigableFragment) mCurrentFragment).navigateBack()) {
+            if (!((NavigableFragment) mCurrentFragment).navigateBack() && !selectTransactionsSection()) {
                 super.onBackPressed();
             }
-        } else {
+        } else if (!selectTransactionsSection()) {
             super.onBackPressed();
         }
+    }
+
+    /**
+     * Move back to the transactions section the way a drawer tap does, so the highlighted
+     * drawer entry and the fragment on screen cannot drift apart.
+     * @return true when the section change has been queued, false when transactions is
+     * already showing or the drawer does not exist yet, in which case the caller should
+     * fall back to the default behavior. The fragment transaction is committed, not run,
+     * so the previous section is still on screen when this returns.
+     */
+    private boolean selectTransactionsSection() {
+        if (mDrawer == null || mCurrentSelection == ID_SECTION_TRANSACTIONS) {
+            return false;
+        }
+        mDrawer.setSelection(ID_SECTION_TRANSACTIONS, true);
+        return true;
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
@@ -360,6 +360,11 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
 
     @Override
     public boolean navigateBack() {
+        if (mSecondaryPanel == null) {
+            // The view has not been built yet, so there is no panel to close and
+            // nothing for this fragment to do with the back press.
+            return false;
+        }
         if (!mExtendedLayout) {
             boolean visible = mSecondaryPanel.getVisibility() == View.VISIBLE;
             hideSecondaryPanel();


### PR DESCRIPTION
Closes #220.

Opening a section from the drawer and pressing Back closed the app instead of going back to Transactions. Only the top level did it, so going into a section and then back out again worked, and the step that was missing was the one from a section back toward Transactions. Eleven of the twelve drawer sections behaved this way.

Back now returns to Transactions from any other section, and only leaves the app from Transactions itself. The drawer highlight moves with it, so the highlighted entry and the screen cannot disagree. Going deeper inside a section is unchanged, and a Back that closes an open detail still does exactly that, so from a category detail it now takes two presses to reach Transactions.

Fixing this needed a second change. Switching section builds the new screen and asks the system to swap it in, and that swap does not happen straight away. For a brief moment the new screen exists while its layout does not, and sending Back twice in quick succession landed in that moment and killed the app. That was only reachable once Back started returning to a section with the drawer shut. The check that prevents it lives in the shared code every screen of this kind is built on, so one guard covers all of them.

Wide screens are worth calling out. On a display wide enough for the two panel layout, Back from a section with a detail open now goes to Transactions and drops the detail, where that press used to leave the app.

Tested on an emulator on Android 16, at phone width and again at tablet width. Every section, the drawer open case, both rotations, and the crash, which was reproduced from a stack trace before the change and is gone after it. The full unit suite passes.
