### PR TITLE
Remove the dead remote sync machinery from the database layer

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -51,8 +51,8 @@
         errorLine1="                return builder.toUpperCase();"
         errorLine2="                               ~~~~~~~~~~~">
         <location
-            file="src/main/java/com/oriondev/moneywallet/picker/IconPicker.java"
-            line="170"
+            file="src/main/java/com/oriondev/moneywallet/utils/IconLoader.java"
+            line="46"
             column="32"/>
     </issue>
 
@@ -62,8 +62,8 @@
         errorLine1="                return trimmed.substring(0, 1).toUpperCase();"
         errorLine2="                                               ~~~~~~~~~~~">
         <location
-            file="src/main/java/com/oriondev/moneywallet/picker/IconPicker.java"
-            line="172"
+            file="src/main/java/com/oriondev/moneywallet/utils/IconLoader.java"
+            line="48"
             column="48"/>
     </issue>
 

--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -135,7 +135,6 @@ public class SQLDatabaseTest {
         targetContext.deleteDatabase(TestStorageContext.PREFIX + SQLDatabase.DATABASE_NAME);
         // create a new database for testing purposes
         mDatabase = new SQLDatabase(mContext);
-        mDatabase.setDeletedObjectCacheEnabled(false);
         // and ask SQLDatabase which file it actually opened, whichever way it got there
         assertEquals(testDatabase.getPath(), mDatabase.getWritableDatabase().getPath());
     }
@@ -198,6 +197,24 @@ public class SQLDatabaseTest {
         assertEquals(true, cursorSize >= minSize);
         cursor.close();
         return cursorSize;
+    }
+
+    /**
+     * Rows straight from the table, with no deleted = 0 filter on the way. Every accessor this
+     * class otherwise reads through carries that filter, so a row flagged as deleted and a row
+     * that is gone look the same through them, and only a direct read separates the two. The
+     * selection is where a caller names the flag it is asking about.
+     */
+    private void assertRowCount(String table, String selection, int expected) {
+        Cursor cursor = mDatabase.getReadableDatabase()
+                .query(table, null, selection, null, null, null, null);
+        assertNotNull(cursor);
+        try {
+            // named, because every caller passes the same expected count and the same selection
+            assertEquals(table, expected, cursor.getCount());
+        } finally {
+            cursor.close();
+        }
     }
 
     private void checkCursorSize(Cursor cursor, int expectedSize) {
@@ -2646,6 +2663,28 @@ public class SQLDatabaseTest {
         checkDebtId(id7, Contract.DebtType.DEBT.getValue(), "icon", "desc", date, null, id1, null, null, 10000L, false, new Long[] {id6}, null);
         checkTransactionId(id8, 10, date, "desc", id3, Contract.Direction.INCOME, 0, id1, null, null, null, null, null, true, true, new Long[] {id4}, null);
         checkTransferId(id9, "desc", date, id1, id2, null, 10, 10, 0, null, null, null, true, true, null, null);
+        // Every accessor the checks above read through filters on deleted = 0, so a row flagged
+        // as deleted and a row that is gone look identical through all of them. Ask the tables
+        // for the flag instead. The fixture gave person 5 a row in each of the four tables
+        // asserted below.
+        //
+        // The five deletes in deletePerson used to share one boolean and could only go soft
+        // together. That boolean is gone and nothing couples them now, so any subset of the five
+        // can regress on its own, and this sees only the subsets that include the person delete,
+        // because a real delete of the person row cascades every flagged link row away.
+        //
+        // The person table is asserted last on purpose. Put it first and a maintainer fixing the
+        // person delete brings the cascade back, which hides every link delete still writing a
+        // flag and lets the test go green with four of the five wrong. Last, each fix uncovers
+        // the next failure.
+        //
+        // EventPeople is the one other table deletePerson writes, and it is not asserted here
+        // because the fixture never links person 5 to an event, so the count would come back
+        // zero whichever branch ran.
+        assertRowCount(Schema.DebtPeople.TABLE, Schema.DebtPeople.DELETED + " = 1", 0);
+        assertRowCount(Schema.TransactionPeople.TABLE, Schema.TransactionPeople.DELETED + " = 1", 0);
+        assertRowCount(Schema.TransferPeople.TABLE, Schema.TransferPeople.DELETED + " = 1", 0);
+        assertRowCount(Schema.Person.TABLE, Schema.Person.DELETED + " = 1", 0);
     }
 
     @Test

--- a/app/src/main/java/com/oriondev/moneywallet/picker/IconPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/IconPicker.java
@@ -29,7 +29,6 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import android.text.Editable;
-import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.MenuItem;
 import android.widget.EditText;
@@ -43,6 +42,7 @@ import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.model.VectorIcon;
 import com.oriondev.moneywallet.ui.activity.IconListActivity;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.Utils;
 
 /**
@@ -147,7 +147,7 @@ public class IconPicker extends Fragment implements ColorChooserDialog.ColorCall
             @Override
             public void onTextChanged(CharSequence sequence, int i, int i1, int i2) {
                 if (mCurrentIcon instanceof ColorIcon) {
-                    String text = getColorIconString(sequence.toString());
+                    String text = IconLoader.getColorIconString(sequence.toString());
                     mCurrentIcon = new ColorIcon((ColorIcon) mCurrentIcon, text);
                     fireCallbackSafely();
                 }
@@ -159,20 +159,6 @@ public class IconPicker extends Fragment implements ColorChooserDialog.ColorCall
             }
 
         });
-    }
-
-    public static String getColorIconString(String source) {
-        String trimmed = source != null ? source.trim().replaceAll(" +", " ") : null;
-        if (!TextUtils.isEmpty(trimmed)) {
-            String[] parts = trimmed.split(" ");
-            if (parts.length >= 2 && !parts[0].isEmpty() && !parts[1].isEmpty()) {
-                String builder = String.valueOf(parts[0].charAt(0)) + parts[1].charAt(0);
-                return builder.toUpperCase();
-            } else {
-                return trimmed.substring(0, 1).toUpperCase();
-            }
-        }
-        return "?";
     }
 
     public Icon getCurrentIcon() {
@@ -279,7 +265,7 @@ public class IconPicker extends Fragment implements ColorChooserDialog.ColorCall
     public void onColorSelection(@NonNull ColorChooserDialog dialog, int selectedColor) {
         mLastBackgroundColor = Utils.getHexColor(selectedColor);
         if (mCurrentIcon instanceof ColorIcon) {
-            String text = getColorIconString(mBindEditText != null ? mBindEditText.getText().toString() : null);
+            String text = IconLoader.getColorIconString(mBindEditText != null ? mBindEditText.getText().toString() : null);
             mCurrentIcon = new ColorIcon(mLastBackgroundColor, text);
             fireCallbackSafely();
         }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -43,8 +43,6 @@ import java.util.List;
  */
 public class DataContentProvider extends ContentProvider {
 
-    private static final boolean IS_REMOTE_SYNC_ENABLED = false;
-
     /*package-local*/ static final String AUTHORITY = BuildConfig.APPLICATION_ID + ".storage.data";
 
     public static final Uri CONTENT_CURRENCIES = Uri.parse("content://" + AUTHORITY + "/currencies");
@@ -837,7 +835,6 @@ public class DataContentProvider extends ContentProvider {
             mDatabase.close();
         }
         mDatabase = new SQLDatabase(context);
-        mDatabase.setDeletedObjectCacheEnabled(IS_REMOTE_SYNC_ENABLED);
     }
 
     @SuppressLint("Recycle")

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -36,7 +36,6 @@ import com.oriondev.moneywallet.model.ColorIcon;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.model.RecurrenceSetting;
-import com.oriondev.moneywallet.picker.IconPicker;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.DateUtils;
 import com.oriondev.moneywallet.utils.IconLoader;
@@ -79,22 +78,10 @@ import java.util.UUID;
     private static final String ENABLE_FOREIGN_KEYS = "PRAGMA foreign_keys=ON";
 
     private final Context mContext;
-    private boolean mCacheDeletedObjects;
 
     /*package-local*/ SQLDatabase(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
         mContext = context;
-        mCacheDeletedObjects = true;
-    }
-
-    /**
-     * The delete cache is used to correctly sync deleted objects with a remote backend.
-     * If the sync is not enabled, the database will permanently remove deleted objects
-     * and not simply flag them as deleted.
-     * @param cacheEnabled true if cache is enabled, false otherwise.
-     */
-    /*package-local*/ void setDeletedObjectCacheEnabled(boolean cacheEnabled) {
-        mCacheDeletedObjects = cacheEnabled;
     }
 
     @Override
@@ -417,14 +404,7 @@ import java.util.UUID;
             }
         }
         where = Schema.Currency.ISO + " = ?";
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Currency.DELETED, true);
-            cv.put(Schema.Currency.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Currency.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Currency.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Currency.TABLE, where, whereArgs);
     }
 
     /**
@@ -591,103 +571,40 @@ import java.util.UUID;
         // we can start to delete all the transactions related to this wallet
         String where = Schema.Transaction.WALLET + " = ?";
         String[] whereArgs = new String[]{String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Transaction.DELETED, true);
-            cv.put(Schema.Transaction.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.Transaction.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.Transaction.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.Transaction.TABLE, where, whereArgs);
         // now we can delete all the transaction models
         where = Schema.TransactionModel.WALLET + " = ?";
         whereArgs = new String[]{String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransactionModel.DELETED, true);
-            cv.put(Schema.TransactionModel.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.TransactionModel.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.TransactionModel.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.TransactionModel.TABLE, where, whereArgs);
         // now we can delete all the transfer models
         where = Schema.TransferModel.WALLET_FROM + " = ? OR " + Schema.TransferModel.WALLET_TO + " = ?";
         whereArgs = new String[]{String.valueOf(walletId), String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransferModel.DELETED, true);
-            cv.put(Schema.TransferModel.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.TransferModel.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.TransferModel.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.TransferModel.TABLE, where, whereArgs);
         // now we can delete all the recurrent transactions
         where = Schema.RecurrentTransaction.WALLET + " = ?";
         whereArgs = new String[]{String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.RecurrentTransaction.DELETED, true);
-            cv.put(Schema.RecurrentTransaction.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.RecurrentTransaction.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.RecurrentTransaction.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.RecurrentTransaction.TABLE, where, whereArgs);
         // now we can delete all the recurrent transfers
         where = Schema.RecurrentTransfer.WALLET_FROM + " = ? OR " + Schema.RecurrentTransfer.WALLET_TO + " = ?";
         whereArgs = new String[]{String.valueOf(walletId), String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.RecurrentTransfer.DELETED, true);
-            cv.put(Schema.RecurrentTransfer.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.RecurrentTransfer.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.RecurrentTransfer.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.RecurrentTransfer.TABLE, where, whereArgs);
         // now we can delete all the savings
         where = Schema.Saving.WALLET + " = ?";
         whereArgs = new String[]{String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Saving.DELETED, true);
-            cv.put(Schema.Saving.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.Saving.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.Saving.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.Saving.TABLE, where, whereArgs);
         // now we can delete all the debts
         where = Schema.Debt.WALLET + " = ?";
         whereArgs = new String[]{String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Debt.DELETED, true);
-            cv.put(Schema.Debt.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.Debt.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.Debt.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.Debt.TABLE, where, whereArgs);
         // now we can delete all the budget wallets
         where = Schema.BudgetWallet.WALLET + " = ?";
         whereArgs = new String[]{String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.BudgetWallet.DELETED, true);
-            cv.put(Schema.BudgetWallet.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.BudgetWallet.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.BudgetWallet.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.BudgetWallet.TABLE, where, whereArgs);
         // TODO: [MEDIUM] A budget that has only this wallet must be removed
         // finally we can delete the wallet itself
         where = Schema.Wallet.ID + " = ?";
         whereArgs = new String[]{String.valueOf(walletId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Wallet.DELETED, true);
-            cv.put(Schema.Wallet.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Wallet.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Wallet.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Wallet.TABLE, where, whereArgs);
     }
 
     /**
@@ -1078,23 +995,20 @@ import java.util.UUID;
                     }
                 }
             }
-            if (!mCacheDeletedObjects) {
-                // remove all deleted TransactionPeople
-                where = Schema.TransactionPeople.TRANSACTION + " = ? AND " + Schema.TransactionPeople.DELETED + " = 1";
-                whereArgs = new String[]{String.valueOf(transactionId)};
-                getWritableDatabase().delete(Schema.TransactionPeople.TABLE, where, whereArgs);
-                // remove all deleted TransactionAttachment
-                where = Schema.TransactionAttachment.TRANSACTION + " = ? AND " + Schema.TransactionAttachment.DELETED + " = 1";
-                whereArgs = new String[]{String.valueOf(transactionId)};
-                getWritableDatabase().delete(Schema.TransactionAttachment.TABLE, where, whereArgs);
-            }
+            // remove all deleted TransactionPeople
+            where = Schema.TransactionPeople.TRANSACTION + " = ? AND " + Schema.TransactionPeople.DELETED + " = 1";
+            whereArgs = new String[]{String.valueOf(transactionId)};
+            getWritableDatabase().delete(Schema.TransactionPeople.TABLE, where, whereArgs);
+            // remove all deleted TransactionAttachment
+            where = Schema.TransactionAttachment.TRANSACTION + " = ? AND " + Schema.TransactionAttachment.DELETED + " = 1";
+            whereArgs = new String[]{String.valueOf(transactionId)};
+            getWritableDatabase().delete(Schema.TransactionAttachment.TABLE, where, whereArgs);
         }
         return rows;
     }
 
     /**
-     * Delete a transaction from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted. The transaction is NOT removed if part of a transfer.
+     * Delete a transaction from the database. The transaction is NOT removed if part of a transfer.
      * @param transactionId id of the transaction to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
      * @throws SQLiteDataException if the transaction is part of a transfer.
@@ -1138,36 +1052,15 @@ import java.util.UUID;
         // remove all TransactionPeople
         String where = Schema.TransactionPeople.TRANSACTION + " = ?";
         String[] whereArgs = new String[]{String.valueOf(transactionId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransactionPeople.DELETED, true);
-            cv.put(Schema.TransactionPeople.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.TransactionPeople.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.TransactionPeople.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.TransactionPeople.TABLE, where, whereArgs);
         // now remove all TransactionAttachment
         where = Schema.TransactionAttachment.TRANSACTION + " = ?";
         whereArgs = new String[]{String.valueOf(transactionId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransactionAttachment.DELETED, true);
-            cv.put(Schema.TransactionAttachment.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.TransactionAttachment.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.TransactionAttachment.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.TransactionAttachment.TABLE, where, whereArgs);
         // finally we can remove the transfer item
         where = Schema.Transaction.ID + " = ?";
         whereArgs = new String[]{String.valueOf(transactionId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Transaction.DELETED, true);
-            cv.put(Schema.Transaction.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Transaction.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Transaction.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Transaction.TABLE, where, whereArgs);
     }
 
     private int deleteTransactionItems(Cursor cursor) {
@@ -1587,14 +1480,7 @@ import java.util.UUID;
             } else {
                 where = Schema.Transaction.ID + " = ?";
                 whereArgs = new String[] {String.valueOf(transactionIds[2])};
-                if (mCacheDeletedObjects) {
-                    cv = new ContentValues();
-                    cv.put(Schema.Transaction.LAST_EDIT, System.currentTimeMillis());
-                    cv.put(Schema.Transaction.DELETED, true);
-                    getWritableDatabase().update(Schema.Transaction.TABLE, cv, where, whereArgs);
-                } else {
-                    getWritableDatabase().delete(Schema.Transaction.TABLE, where, whereArgs);
-                }
+                getWritableDatabase().delete(Schema.Transaction.TABLE, where, whereArgs);
                 transactionIds[2] = null;
             }
         } else if (contentValues.getAsLong(Contract.Transfer.TRANSACTION_TAX_MONEY) != 0L) {
@@ -1702,16 +1588,14 @@ import java.util.UUID;
                     }
                 }
             }
-            if (!mCacheDeletedObjects) {
-                // remove all deleted TransactionPeople
-                where = Schema.TransferPeople.TRANSFER + " = ? AND " + Schema.TransferPeople.DELETED + " = 1";
-                whereArgs = new String[]{String.valueOf(transferId)};
-                getWritableDatabase().delete(Schema.TransferPeople.TABLE, where, whereArgs);
-                // remove all deleted TransactionAttachment
-                where = Schema.TransferAttachment.TRANSFER + " = ? AND " + Schema.TransferAttachment.DELETED + " = 1";
-                whereArgs = new String[]{String.valueOf(transferId)};
-                getWritableDatabase().delete(Schema.TransferAttachment.TABLE, where, whereArgs);
-            }
+            // remove all deleted TransactionPeople
+            where = Schema.TransferPeople.TRANSFER + " = ? AND " + Schema.TransferPeople.DELETED + " = 1";
+            whereArgs = new String[]{String.valueOf(transferId)};
+            getWritableDatabase().delete(Schema.TransferPeople.TABLE, where, whereArgs);
+            // remove all deleted TransactionAttachment
+            where = Schema.TransferAttachment.TRANSFER + " = ? AND " + Schema.TransferAttachment.DELETED + " = 1";
+            whereArgs = new String[]{String.valueOf(transferId)};
+            getWritableDatabase().delete(Schema.TransferAttachment.TABLE, where, whereArgs);
         }
         return rows;
     }
@@ -1741,36 +1625,15 @@ import java.util.UUID;
         // now remove all TransferPeople
         String where = Schema.TransferPeople.TRANSFER + " = ?";
         String[] whereArgs = new String[]{String.valueOf(transferId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransferPeople.DELETED, true);
-            cv.put(Schema.TransferPeople.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.TransferPeople.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.TransferPeople.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.TransferPeople.TABLE, where, whereArgs);
         // now remove all TransferAttachment
         where = Schema.TransferAttachment.TRANSFER + " = ?";
         whereArgs = new String[]{String.valueOf(transferId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransferAttachment.DELETED, true);
-            cv.put(Schema.TransferAttachment.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.TransferAttachment.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.TransferAttachment.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.TransferAttachment.TABLE, where, whereArgs);
         // finally we can remove the transfer item
         where = Schema.Transfer.ID + " = ?";
         whereArgs = new String[]{String.valueOf(transferId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Transfer.DELETED, true);
-            cv.put(Schema.Transfer.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Transfer.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Transfer.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Transfer.TABLE, where, whereArgs);
     }
 
     /**
@@ -2174,14 +2037,7 @@ import java.util.UUID;
         // if this line has been reached, the category can be removed
         where = Schema.Category.ID + " = ?";
         whereArgs = new String[]{String.valueOf(categoryId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Category.DELETED, true);
-            cv.put(Schema.Category.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Category.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Category.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Category.TABLE, where, whereArgs);
     }
 
     /**
@@ -2547,7 +2403,7 @@ import java.util.UUID;
             if (!(icon instanceof ColorIcon)) {
                 return null;
             }
-            return new ColorIcon((ColorIcon) icon, IconPicker.getColorIconString(description)).toString();
+            return new ColorIcon((ColorIcon) icon, IconLoader.getColorIconString(description)).toString();
         } catch (Exception e) {
             // IconLoader returns null on malformed json and throws on a type it does not know,
             // which is the case this catches. The rename still lands, the icon keeps its letters.
@@ -2593,12 +2449,10 @@ import java.util.UUID;
                 }
             }
         }
-        if (!mCacheDeletedObjects) {
-            // remove all deleted DebtPeople
-            where = Schema.DebtPeople.DEBT + " = ? AND " + Schema.DebtPeople.DELETED + " = 1";
-            whereArgs = new String[]{String.valueOf(debtId)};
-            getWritableDatabase().delete(Schema.DebtPeople.TABLE, where, whereArgs);
-        }
+        // remove all deleted DebtPeople
+        where = Schema.DebtPeople.DEBT + " = ? AND " + Schema.DebtPeople.DELETED + " = 1";
+        whereArgs = new String[]{String.valueOf(debtId)};
+        getWritableDatabase().delete(Schema.DebtPeople.TABLE, where, whereArgs);
     }
 
     /**
@@ -2783,8 +2637,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a debt from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted.
+     * Delete a debt from the database.
      *
      * @param debtId id of the debt to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -2795,25 +2648,11 @@ import java.util.UUID;
         // remove all DebtPeople
         String where = Schema.DebtPeople.DEBT + " = ?";
         String[] whereArgs = new String[]{String.valueOf(debtId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.DebtPeople.DELETED, true);
-            cv.put(Schema.DebtPeople.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.DebtPeople.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.DebtPeople.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.DebtPeople.TABLE, where, whereArgs);
         // remove the debt item
         where = Schema.Debt.ID + " = ?";
         whereArgs = new String[]{String.valueOf(debtId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Debt.DELETED, true);
-            cv.put(Schema.Debt.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Debt.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Debt.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Debt.TABLE, where, whereArgs);
     }
 
     /**
@@ -3628,8 +3467,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a budget from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted.
+     * Delete a budget from the database.
      *
      * @param budgetId id of the budget to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -3638,36 +3476,15 @@ import java.util.UUID;
         // remove all BudgetWallet
         String where = Schema.BudgetWallet.BUDGET + " = ?";
         String[] whereArgs = new String[]{String.valueOf(budgetId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.BudgetWallet.DELETED, true);
-            cv.put(Schema.BudgetWallet.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.BudgetWallet.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.BudgetWallet.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.BudgetWallet.TABLE, where, whereArgs);
         // remove all BudgetCategory
         where = Schema.BudgetCategory.BUDGET + " = ?";
         whereArgs = new String[]{String.valueOf(budgetId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.BudgetCategory.DELETED, true);
-            cv.put(Schema.BudgetCategory.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.BudgetCategory.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.BudgetCategory.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.BudgetCategory.TABLE, where, whereArgs);
         // remove the debt item
         where = Schema.Budget.ID + " = ?";
         whereArgs = new String[]{String.valueOf(budgetId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Budget.DELETED, true);
-            cv.put(Schema.Budget.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Budget.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Budget.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Budget.TABLE, where, whereArgs);
     }
 
     /**
@@ -3841,8 +3658,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a saving from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted.
+     * Delete a saving from the database.
      *
      * @param savingId id of the saving to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -3853,14 +3669,7 @@ import java.util.UUID;
         // delete the saving item
         String where = Schema.Saving.ID + " = ?";
         String[] whereArgs = new String[]{String.valueOf(savingId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Saving.DELETED, true);
-            cv.put(Schema.Saving.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Saving.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Saving.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Saving.TABLE, where, whereArgs);
     }
 
     /**
@@ -3977,8 +3786,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a event from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted.
+     * Delete a event from the database.
      *
      * @param eventId id of the event to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -4029,25 +3837,11 @@ import java.util.UUID;
         // remove all EventPeople
         where = Schema.EventPeople.EVENT + " = ?";
         whereArgs = new String[]{String.valueOf(eventId)};
-        if (mCacheDeletedObjects) {
-            cv = new ContentValues();
-            cv.put(Schema.EventPeople.DELETED, true);
-            cv.put(Schema.EventPeople.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.EventPeople.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.EventPeople.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.EventPeople.TABLE, where, whereArgs);
         // finally remove the event item
         where = Schema.Event.ID + " = ?";
         whereArgs = new String[]{String.valueOf(eventId)};
-        if (mCacheDeletedObjects) {
-            cv = new ContentValues();
-            cv.put(Schema.Event.DELETED, true);
-            cv.put(Schema.Event.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Event.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Event.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Event.TABLE, where, whereArgs);
     }
 
     /*package-local*/ Cursor getRecurrentTransaction(long transactionId, String[] projection) {
@@ -4237,9 +4031,8 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a recurrent transaction from the database. If the 'mCacheDeletedObjects' flag is
-     * enabled the data is not removed but simply flagged as deleted. All the related transactions
-     * are updated with the removal of the reference to this recurring transaction.
+     * Delete a recurrent transaction from the database. All the related transactions are updated with
+     * the removal of the reference to this recurring transaction.
      *
      * @param transactionId id of the recurring transaction to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -4256,14 +4049,7 @@ import java.util.UUID;
         // now is possible to remove the recurrent transaction itself
         selection = Schema.RecurrentTransaction.ID + " = ?";
         selectionArgs = new String[]{String.valueOf(transactionId)};
-        if (mCacheDeletedObjects) {
-            contentValues = new ContentValues();
-            contentValues.put(Schema.RecurrentTransaction.DELETED, true);
-            contentValues.put(Schema.RecurrentTransaction.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.RecurrentTransaction.TABLE, contentValues, selection, selectionArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.RecurrentTransaction.TABLE, selection, selectionArgs);
-        }
+        return getWritableDatabase().delete(Schema.RecurrentTransaction.TABLE, selection, selectionArgs);
     }
 
     /*package-local*/ Cursor getRecurrentTransfer(long transferId, String[] projection) {
@@ -4521,9 +4307,8 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a recurrent transfer from the database. If the 'mCacheDeletedObjects' flag is
-     * enabled the data is not removed but simply flagged as deleted. All the related transfers
-     * are updated with the removal of the reference to this recurring transfer.
+     * Delete a recurrent transfer from the database. All the related transfers are updated with
+     * the removal of the reference to this recurring transfer.
      *
      * @param transferId id of the recurring transfer to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -4540,14 +4325,7 @@ import java.util.UUID;
         // now is possible to remove the recurrent transfer itself
         selection = Schema.RecurrentTransfer.ID + " = ?";
         selectionArgs = new String[]{String.valueOf(transferId)};
-        if (mCacheDeletedObjects) {
-            contentValues = new ContentValues();
-            contentValues.put(Schema.RecurrentTransfer.DELETED, true);
-            contentValues.put(Schema.RecurrentTransfer.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.RecurrentTransfer.TABLE, contentValues, selection, selectionArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.RecurrentTransfer.TABLE, selection, selectionArgs);
-        }
+        return getWritableDatabase().delete(Schema.RecurrentTransfer.TABLE, selection, selectionArgs);
     }
 
     /*package-local*/ long insertRecurrentTransferOccurrence(long transferId, ContentValues contentValues) {
@@ -4683,8 +4461,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a transaction model from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted.
+     * Delete a transaction model from the database.
      *
      * @param modelId id of the transaction model to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -4692,14 +4469,7 @@ import java.util.UUID;
     /*package-local*/ int deleteTransactionModel(long modelId) {
         String where = Schema.TransactionModel.ID + " = ?";
         String[] whereArgs = new String[]{String.valueOf(modelId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransactionModel.DELETED, true);
-            cv.put(Schema.TransactionModel.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.TransactionModel.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.TransactionModel.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.TransactionModel.TABLE, where, whereArgs);
     }
 
     /**
@@ -4834,8 +4604,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a transfer model from the database. If the 'mCacheDeletedObjects' flag is enabled the
-     * data is not removed but simply flagged as deleted.
+     * Delete a transfer model from the database.
      *
      * @param modelId id of the transfer model to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -4843,14 +4612,7 @@ import java.util.UUID;
     /*package-local*/ int deleteTransferModel(long modelId) {
         String where = Schema.TransferModel.ID + " = ?";
         String[] whereArgs = new String[]{String.valueOf(modelId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransferModel.DELETED, true);
-            cv.put(Schema.TransferModel.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.TransferModel.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.TransferModel.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.TransferModel.TABLE, where, whereArgs);
     }
 
     /**
@@ -4957,8 +4719,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a place from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted.
+     * Delete a place from the database.
      *
      * @param placeId id of the place to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -5016,14 +4777,7 @@ import java.util.UUID;
         // finally remove the place item
         where = Schema.Place.ID + " = ?";
         whereArgs = new String[]{String.valueOf(placeId)};
-        if (mCacheDeletedObjects) {
-            cv = new ContentValues();
-            cv.put(Schema.Place.DELETED, true);
-            cv.put(Schema.Place.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Place.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Place.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Place.TABLE, where, whereArgs);
     }
 
     /**
@@ -5126,8 +4880,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete a person from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted.
+     * Delete a person from the database.
      *
      * @param personId id of the person to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -5136,58 +4889,23 @@ import java.util.UUID;
         // remove all the TransactionPeople
         String where = Schema.TransactionPeople.PERSON + " = ?";
         String[] whereArgs = new String[]{String.valueOf(personId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransactionPeople.DELETED, true);
-            cv.put(Schema.TransactionPeople.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.TransactionPeople.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.TransactionPeople.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.TransactionPeople.TABLE, where, whereArgs);
         // remove all the TransferPeople
         where = Schema.TransferPeople.PERSON + " = ?";
         whereArgs = new String[]{String.valueOf(personId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.TransferPeople.DELETED, true);
-            cv.put(Schema.TransferPeople.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.TransferPeople.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.TransferPeople.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.TransferPeople.TABLE, where, whereArgs);
         // remove all the EventPeople
         where = Schema.EventPeople.PERSON + " = ?";
         whereArgs = new String[]{String.valueOf(personId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.EventPeople.DELETED, true);
-            cv.put(Schema.EventPeople.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.EventPeople.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.EventPeople.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.EventPeople.TABLE, where, whereArgs);
         // remove all the DebtPeople
         where = Schema.DebtPeople.PERSON + " = ?";
         whereArgs = new String[]{String.valueOf(personId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.DebtPeople.DELETED, true);
-            cv.put(Schema.DebtPeople.LAST_EDIT, System.currentTimeMillis());
-            getWritableDatabase().update(Schema.DebtPeople.TABLE, cv, where, whereArgs);
-        } else {
-            getWritableDatabase().delete(Schema.DebtPeople.TABLE, where, whereArgs);
-        }
+        getWritableDatabase().delete(Schema.DebtPeople.TABLE, where, whereArgs);
         // finally remove the person item
         where = Schema.Person.ID + " = ?";
         whereArgs = new String[]{String.valueOf(personId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Person.DELETED, true);
-            cv.put(Schema.Person.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Person.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Person.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Person.TABLE, where, whereArgs);
     }
 
     /**
@@ -5266,8 +4984,7 @@ import java.util.UUID;
     }
 
     /**
-     * Delete an attachment from the database. If the 'mCacheDeletedObjects' flag is enabled the data
-     * is not removed but simply flagged as deleted.
+     * Delete an attachment from the database.
      *
      * @param attachmentId id of the attachment to remove.
      * @return the number of rows affected by the deletion (must be 1 for success).
@@ -5275,14 +4992,7 @@ import java.util.UUID;
     /*package-local*/ int deleteAttachment(long attachmentId) {
         String where = Schema.Attachment.ID + " = ?";
         String[] whereArgs = new String[]{String.valueOf(attachmentId)};
-        if (mCacheDeletedObjects) {
-            ContentValues cv = new ContentValues();
-            cv.put(Schema.Attachment.DELETED, true);
-            cv.put(Schema.Attachment.LAST_EDIT, System.currentTimeMillis());
-            return getWritableDatabase().update(Schema.Attachment.TABLE, cv, where, whereArgs);
-        } else {
-            return getWritableDatabase().delete(Schema.Attachment.TABLE, where, whereArgs);
-        }
+        return getWritableDatabase().delete(Schema.Attachment.TABLE, where, whereArgs);
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SystemCategory.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SystemCategory.java
@@ -23,7 +23,7 @@ import android.content.Context;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.ColorIcon;
-import com.oriondev.moneywallet.picker.IconPicker;
+import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.Utils;
 
 import java.util.ArrayList;
@@ -68,7 +68,7 @@ import java.util.List;
     }
 
     /*package-local*/ String getIcon(Context context) {
-        String source = IconPicker.getColorIconString(context.getString(mName));
+        String source = IconLoader.getColorIconString(context.getString(mName));
         return new ColorIcon(mColor, source).toString();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SystemCategoryLocalizer.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SystemCategoryLocalizer.java
@@ -31,7 +31,6 @@ import android.util.Log;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.ColorIcon;
 import com.oriondev.moneywallet.model.Icon;
-import com.oriondev.moneywallet.picker.IconPicker;
 import com.oriondev.moneywallet.utils.IconLoader;
 
 import java.util.ArrayList;
@@ -245,7 +244,7 @@ public class SystemCategoryLocalizer {
             if (!(icon instanceof ColorIcon)) {
                 return null;
             }
-            return new ColorIcon((ColorIcon) icon, IconPicker.getColorIconString(currentName)).toString();
+            return new ColorIcon((ColorIcon) icon, IconLoader.getColorIconString(currentName)).toString();
         } catch (Exception e) {
             Log.e(TAG, "unreadable icon on a system category, keeping the old one", e);
             return null;

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
@@ -12,10 +12,10 @@ import com.oriondev.moneywallet.model.Category;
 import com.oriondev.moneywallet.model.ColorIcon;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
-import com.oriondev.moneywallet.picker.IconPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.database.TransactionContentValuesBuilder;
+import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.DateUtils;
 import com.oriondev.moneywallet.utils.Utils;
 
@@ -317,7 +317,7 @@ public abstract class AbstractDataImporter {
 
     private String generateRandomIcon(String name) {
         int randomColor = Utils.getRandomMDColor();
-        String iconText = IconPicker.getColorIconString(name);
+        String iconText = IconLoader.getColorIconString(name);
         Icon icon = new ColorIcon(randomColor, iconText);
         return icon.toString();
     }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/legacy/LegacyDatabaseImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/legacy/LegacyDatabaseImporter.java
@@ -31,7 +31,6 @@ import com.oriondev.moneywallet.model.ColorIcon;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.model.RecurrenceSetting;
-import com.oriondev.moneywallet.picker.IconPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.database.DatabaseImporter;
@@ -51,6 +50,7 @@ import com.oriondev.moneywallet.storage.database.model.Transfer;
 import com.oriondev.moneywallet.storage.database.model.Wallet;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.DateUtils;
+import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.MoneyFormatter;
 import com.oriondev.moneywallet.utils.Utils;
 
@@ -784,13 +784,13 @@ public class LegacyDatabaseImporter implements DatabaseImporter {
                 String legacyIcon = cursor.getString(index);
                 Icon icon = LegacyIconMapper.getLegacyIcon(legacyIcon, name);
                 if (icon == null) {
-                    icon = new ColorIcon(Utils.getRandomMDColor(), IconPicker.getColorIconString(name));
+                    icon = new ColorIcon(Utils.getRandomMDColor(), IconLoader.getColorIconString(name));
                 }
                 return icon.toString();
             }
         }*/
         int randomColor = Utils.getRandomMDColor();
-        String iconText = IconPicker.getColorIconString(name);
+        String iconText = IconLoader.getColorIconString(name);
         Icon icon = new ColorIcon(randomColor, iconText);
         return icon.toString();
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/TutorialActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/TutorialActivity.java
@@ -41,9 +41,9 @@ import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Category;
 import com.oriondev.moneywallet.model.ColorIcon;
 import com.oriondev.moneywallet.model.Icon;
-import com.oriondev.moneywallet.picker.IconPicker;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.Utils;
 
 import java.util.ArrayList;
@@ -157,7 +157,7 @@ public class TutorialActivity extends AppIntro2 {
 
     private static Category getDefaultCategory(Context context, int nameRes, Contract.CategoryType type, String tag, int color) {
         String name = context.getString(nameRes);
-        String label = IconPicker.getColorIconString(name);
+        String label = IconLoader.getColorIconString(name);
         Icon icon = new ColorIcon(Utils.getHexColor(color), label);
         return new Category(-1L, context.getString(nameRes), icon, type, tag);
     }

--- a/app/src/main/java/com/oriondev/moneywallet/utils/IconLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/IconLoader.java
@@ -19,6 +19,7 @@
 
 package com.oriondev.moneywallet.utils;
 
+import android.text.TextUtils;
 import android.widget.ImageView;
 
 import com.oriondev.moneywallet.model.ColorIcon;
@@ -35,6 +36,20 @@ import org.json.JSONObject;
 public class IconLoader {
 
     public static final Icon UNKNOWN = new ColorIcon("#FFC107", "?");
+
+    public static String getColorIconString(String source) {
+        String trimmed = source != null ? source.trim().replaceAll(" +", " ") : null;
+        if (!TextUtils.isEmpty(trimmed)) {
+            String[] parts = trimmed.split(" ");
+            if (parts.length >= 2 && !parts[0].isEmpty() && !parts[1].isEmpty()) {
+                String builder = String.valueOf(parts[0].charAt(0)) + parts[1].charAt(0);
+                return builder.toUpperCase();
+            } else {
+                return trimmed.substring(0, 1).toUpperCase();
+            }
+        }
+        return "?";
+    }
 
     public static Icon parse(String icon) {
         if (icon != null) {


### PR DESCRIPTION
The database layer has carried two ways to delete something since the first commit. It can remove the row, or leave it in place with a flag saying it is gone. The second is for syncing with a remote server this app has never had. A private setting picks which one runs, and it has been set to the real delete from day one, so half of forty branches in the project's largest file has never run in any build anyone has installed.

This removes that half. Nothing the app does changes.

Three things stay, on purpose.

The flag column itself stays and is still written, because a backup file carries it and restoring an old backup can still bring in rows already marked as gone.

Every filter that keeps those rows out of the lists stays untouched, all twenty three of them.

And a cleanup step stays, the one that removes the links a save has just marked as gone. That step is easy to mistake for the sync machinery, since it reads the same setting, but it sits on the opposite side of it and it is what every build has done.

The file loses 290 lines.

Separately, five storage layer files were reaching into the icon picker for one small helper that turns a name into the initials shown on a default icon. It has nothing to do with picking an icon, so it moved to where the rest of the icon handling lives, and the storage layer stopped depending on the user interface.

What I tested. The unit suite and the database suite pass at the same counts on this branch and on master. On an emulator I did the same seven things twice, against a build of master and against this branch, each starting from an identical copy of the same ledger: changing who is on a transaction, deleting that person, deleting a category that has children and then one that does not, and deleting a wallet that cannot go and then one that can. Every table came out the same on both sides.
