### PR TITLE
Make every write all or nothing, and stop a failed restore losing data

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -47,6 +47,8 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -114,6 +116,19 @@ public class SQLDatabaseTest {
             File external = super.getExternalFilesDir(type);
             return external != null ? new File(external, EXTERNAL_SUBDIR) : null;
         }
+
+        /**
+         * Without this, SQLDatabase.getShared normalizes straight past the wrapper and the shared
+         * helper opens the real ledger, so the whole shared static was untestable. ContextWrapper
+         * answers this from the context it wraps, and every redirect above lives on this object.
+         *
+         * The cost is that the static is process wide, so a case that installs a test helper into
+         * it has to put it back. releaseSharedHelper does that.
+         */
+        @Override
+        public Context getApplicationContext() {
+            return this;
+        }
     }
 
     @Before
@@ -137,6 +152,26 @@ public class SQLDatabaseTest {
         mDatabase = new SQLDatabase(mContext);
         // and ask SQLDatabase which file it actually opened, whichever way it got there
         assertEquals(testDatabase.getPath(), mDatabase.getWritableDatabase().getPath());
+        // point the process wide shared helper at the same test file. These cases run inside the
+        // app's own process, so its providers have already put a helper built on the real context
+        // into that static, and getShared hands back whatever is there. Without this an
+        // inSharedTransaction case reads and writes the real ledger and only its rollback keeps
+        // that from showing. resetShared replaces it unconditionally; releaseSharedHelper puts a
+        // real one back afterwards
+        SQLDatabase.resetShared(mContext);
+        assertEquals(testDatabase.getPath(),
+                SQLDatabase.getShared(mContext).getWritableDatabase().getPath());
+    }
+
+    /**
+     * Puts the process wide shared helper back on the real context. Any case that reached
+     * getShared through the wrapper left a helper pointed at the test database in a static that
+     * outlives this class. The replacement has opened nothing, since SQLiteOpenHelper opens on
+     * first use, so the real ledger is not touched by putting it there.
+     */
+    @After
+    public void releaseSharedHelper() {
+        SQLDatabase.resetShared(InstrumentationRegistry.getInstrumentation().getTargetContext());
     }
 
     @After
@@ -1125,6 +1160,299 @@ public class SQLDatabaseTest {
         checkCursorSize(mDatabase.getSaving(id7, null), 0);
         checkCursorSize(mDatabase.getDebt(id8, null), 0);
         checkBudgetId(id9, Schema.BudgetType.CATEGORY, id3, startDate, endDate, 3000L, "EUR", new Long[] {id2}, null, 0L);
+    }
+
+    /**
+     * Puts a file where SQLDatabase.getAttachmentFolder will look for it, by the same route that
+     * method takes. That is deliberate and it is not the identity a sentinel built from the
+     * wrapper would be, because the pair of cases below differ only in whether the transaction
+     * commits. A wrong folder makes the committed case fail, so the path is under test too.
+     */
+    private File writeAttachmentFile(String name) throws Exception {
+        File folder = new File(mContext.getExternalFilesDir(null), Attachment.FOLDER_NAME);
+        assertTrue("cannot create " + folder, folder.exists() || folder.mkdirs());
+        File file = new File(folder, name);
+        assertTrue("cannot create " + file, file.exists() || file.createNewFile());
+        return file;
+    }
+
+    private long walletWithAnAttachedTransaction(String fileName) {
+        long walletId = insertWallet("Attached", "icon", "EUR", "note", true, 0L, false, "tag");
+        long categoryId = insertCategory("category", "icon", 0, null, true, "tag");
+        long attachmentId = insertAttachment(fileName, "name", "mime-type", 90L, "tag");
+        insertTransaction(10, new Date(), "desc", categoryId, Contract.Direction.EXPENSE, 0,
+                walletId, null, null, null, null, null, true, true, null,
+                new Long[] {attachmentId}, null);
+        return walletId;
+    }
+
+    /**
+     * The four cases below are the two sided proof of the transaction wrapper, and each pair needs
+     * both halves. Without the committing case, a wrapper that rolled everything back and
+     * committed nothing would satisfy the rollback case, and no other case in this class would
+     * see it, because they all call SQLDatabase directly and never open a transaction at all.
+     */
+    @Test
+    public void inTransactionCommitsWhatTheBodyWrote() {
+        long walletId = mDatabase.inTransaction(() ->
+                insertWallet("Committed", "icon", "EUR", "note", true, 0L, false, "tag"));
+        assertTrue(walletId > 0L);
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 1);
+    }
+
+    @Test
+    public void inTransactionRollsBackEveryWriteWhenTheBodyThrows() {
+        insertWallet("Written before the transaction", "icon", "EUR", "note", true, 0L, false, "tag");
+        try {
+            mDatabase.<Long>inTransaction(() -> {
+                insertWallet("Rolled back", "icon", "EUR", "note", true, 0L, false, "tag");
+                insertPerson("Rolled back too", "icon", "note", "tag");
+                throw new IllegalStateException("forced from the body");
+            });
+            fail("the body's exception did not leave inTransaction");
+        } catch (IllegalStateException expected) {
+            // it has to reach the caller, since that is how a provider learns its write is undone
+        }
+        // both writes inside the transaction are gone, and the one before it is untouched, so
+        // this fails either way round: on a wrapper that does not roll back, and on one that
+        // rolls back more than the transaction
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 1);
+        checkCursorSize(mDatabase.getPeople(null, null, null, null), 0);
+    }
+
+    /**
+     * The shared helper, its swap, and the lock between them had no coverage at all until the
+     * wrapper started answering getApplicationContext for itself. Removing the lock left every
+     * other case in this class green, which made it a guard nothing could see.
+     */
+    @Test
+    public void theSharedHelperResolvesThroughTheTestWrapper() {
+        // the assertion that everything below rests on. If the wrapper were bypassed here the
+        // shared helper would be the real ledger, and these cases would be writing into it
+        assertEquals(mContext.getDatabasePath(SQLDatabase.DATABASE_NAME).getPath(),
+                SQLDatabase.getShared(mContext).getWritableDatabase().getPath());
+    }
+
+    @Test
+    public void resetSharedReplacesTheInstanceAndGetSharedKeepsIt() {
+        SQLDatabase first = SQLDatabase.getShared(mContext);
+        assertTrue("getShared handed back two helpers for one process",
+                first == SQLDatabase.getShared(mContext));
+        SQLDatabase.resetShared(mContext);
+        assertFalse("resetShared left the old helper installed",
+                first == SQLDatabase.getShared(mContext));
+    }
+
+    @Test
+    public void inSharedTransactionRunsOnTheSharedHelperAndRollsBack() {
+        SQLDatabase shared = SQLDatabase.getShared(mContext);
+        try {
+            SQLDatabase.<Long>inSharedTransaction(mContext, database -> {
+                assertTrue("the body was handed a different helper than the transaction was "
+                        + "opened on", database == shared);
+                ContentValues cv = new ContentValues();
+                cv.put(Schema.Wallet.NAME, "rolled back");
+                cv.put(Schema.Wallet.ICON, "icon");
+                cv.put(Schema.Wallet.CURRENCY, "EUR");
+                cv.put(Schema.Wallet.START_MONEY, 0L);
+                cv.put(Schema.Wallet.COUNT_IN_TOTAL, true);
+                cv.put(Schema.Wallet.ARCHIVED, false);
+                cv.put(Schema.Wallet.INDEX, 0);
+                cv.put(Schema.Wallet.UUID, java.util.UUID.randomUUID().toString());
+                cv.put(Schema.Wallet.LAST_EDIT, System.currentTimeMillis());
+                cv.put(Schema.Wallet.DELETED, false);
+                database.getWritableDatabase().insert(Schema.Wallet.TABLE, null, cv);
+                throw new IllegalStateException("forced from the body");
+            });
+            fail("the body's exception did not leave inSharedTransaction");
+        } catch (IllegalStateException expected) {
+            // as elsewhere
+        }
+        Cursor cursor = shared.getWritableDatabase().query(Schema.Wallet.TABLE, null, null, null,
+                null, null, null);
+        assertNotNull(cursor);
+        try {
+            assertEquals(0, cursor.getCount());
+        } finally {
+            cursor.close();
+        }
+    }
+
+    /**
+     * The only case that fails if the swap lock is deleted, downgraded or inverted. Everything
+     * else in this class is single threaded and stays green without it.
+     */
+    @Test(timeout = 20000)
+    public void resetSharedWaitsForAWriteAlreadyInFlight() throws Exception {
+        final CountDownLatch inside = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+        final CountDownLatch resetReturned = new CountDownLatch(1);
+        Thread writer = new Thread(() -> SQLDatabase.inSharedTransaction(mContext, database -> {
+            inside.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+            return 1L;
+        }));
+        writer.start();
+        assertTrue("the write never entered the transaction", inside.await(10, TimeUnit.SECONDS));
+
+        Thread resetter = new Thread(() -> {
+            SQLDatabase.resetShared(mContext);
+            resetReturned.countDown();
+        });
+        resetter.start();
+        try {
+            // it has to still be waiting. Closing the helper here is what sends the rest of an
+            // unfinished write to a second connection with no transaction on it
+            assertFalse("resetShared swapped the helper while a write was still in flight",
+                    resetReturned.await(1, TimeUnit.SECONDS));
+        } finally {
+            // in a finally for the reason given on the case below
+            release.countDown();
+        }
+        writer.join(10000);
+        assertTrue("resetShared never completed once the write finished",
+                resetReturned.await(10, TimeUnit.SECONDS));
+        resetter.join(10000);
+    }
+
+    /**
+     * The same exclusion for the overload that carries the work. The case above drives the plain
+     * overload, so a version that took the write lock only there would keep it green while every
+     * rename in AbstractBackupImporter ran with a write still open on the file being moved.
+     */
+    @Test(timeout = 20000)
+    public void resetSharedWaitsForAWriteAlreadyInFlightBeforeRunningTheWork() throws Exception {
+        final CountDownLatch inside = new CountDownLatch(1);
+        final CountDownLatch release = new CountDownLatch(1);
+        final CountDownLatch workRan = new CountDownLatch(1);
+        Thread writer = new Thread(() -> SQLDatabase.inSharedTransaction(mContext, database -> {
+            inside.countDown();
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                throw new IllegalStateException(e);
+            }
+            return 1L;
+        }));
+        writer.start();
+        assertTrue("the write never entered the transaction", inside.await(10, TimeUnit.SECONDS));
+
+        Thread resetter = new Thread(() -> SQLDatabase.resetShared(mContext, workRan::countDown));
+        resetter.start();
+        try {
+            assertFalse("the work ran while a write was still in flight, which is the rename "
+                            + "moving the database file out from under an open transaction",
+                    workRan.await(1, TimeUnit.SECONDS));
+        } finally {
+            // in a finally, or a failed assertion leaves the writer parked forever inside an open
+            // transaction holding the read lock, and the next resetShared waits on it for good.
+            // The suite then hangs instead of reporting, which reads as a broken run and not as a
+            // broken guard
+            release.countDown();
+        }
+        writer.join(10000);
+        assertTrue("the work never ran once the write finished",
+                workRan.await(10, TimeUnit.SECONDS));
+        resetter.join(10000);
+    }
+
+    /**
+     * The slot a restore renames the database file in. If the work ran anywhere else the file
+     * would move with a connection open on it, which strands that connection's journal at the
+     * old path and refuses its next write.
+     */
+    @Test
+    public void resetSharedRunsTheWorkWithTheFileClosedAndReplacesTheHelperAfterIt() {
+        SQLDatabase first = SQLDatabase.getShared(mContext);
+        SQLiteDatabase open = first.getWritableDatabase();
+        assertTrue("the helper was not open before the swap", open.isOpen());
+        final boolean[] ran = new boolean[1];
+        SQLDatabase.resetShared(mContext, () -> {
+            ran[0] = true;
+            assertFalse("the work ran with the database still open", open.isOpen());
+            // and before the replacement, which is what leaves the path free for the rename
+            assertTrue("the helper was replaced before the work ran",
+                    SQLDatabase.getShared(mContext) == first);
+        });
+        assertTrue("the work never ran", ran[0]);
+        assertFalse("resetShared left the old helper installed",
+                SQLDatabase.getShared(mContext) == first);
+    }
+
+    @Test
+    public void resetSharedInstallsAWorkingHelperEvenWhenTheWorkThrows() {
+        SQLDatabase first = SQLDatabase.getShared(mContext);
+        try {
+            SQLDatabase.resetShared(mContext, () -> {
+                throw new IllegalStateException("forced from the work");
+            });
+            fail("the work's exception did not leave resetShared");
+        } catch (IllegalStateException expected) {
+            // it has to leave, since the caller is the one that knows what a failed file swap
+            // means. What must not happen is the helper being left closed behind it
+        }
+        SQLDatabase replacement = SQLDatabase.getShared(mContext);
+        assertFalse("the closed helper was left installed after the work threw",
+                replacement == first);
+        assertTrue("the helper installed after the work threw cannot open the database",
+                replacement.getWritableDatabase().isOpen());
+    }
+
+    @Test
+    public void inTransactionRefusesToNest() {
+        // outside the transaction, so the count below fails both ways round: on a wrapper that
+        // does not roll the outer transaction back, and on one that rolls back past it
+        insertWallet("Written before the transaction", "icon", "EUR", "note", true, 0L, false, "tag");
+        try {
+            mDatabase.<Long>inTransaction(() -> {
+                // and this one inside it, so a refusal that rolled back is told apart from a
+                // refusal that merely threw
+                insertWallet("Written before the nested call", "icon", "EUR", "note", true, 0L, false, "tag");
+                return mDatabase.inTransaction(() ->
+                        insertWallet("Nested", "icon", "EUR", "note", true, 0L, false, "tag"));
+            });
+            fail("a nested inTransaction was allowed");
+        } catch (IllegalStateException expected) {
+            // it has to refuse. Android rolls the whole transaction back when an inner frame ends
+            // unsuccessfully and says nothing, so an outer body that swallowed the inner failure
+            // would reach the end of inTransaction believing it had committed
+        }
+        // the refusal left the outer body, so the outer transaction rolled back and took the
+        // wallet written inside it with it, and left the one written before it alone
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 1);
+    }
+
+    @Test
+    public void aRolledBackWalletDeleteLeavesItsAttachmentFileOnDisk() throws Exception {
+        File file = writeAttachmentFile("path1");
+        long walletId = walletWithAnAttachedTransaction("path1");
+        try {
+            mDatabase.<Integer>inTransaction(() -> {
+                mDatabase.deleteWallet(walletId);
+                throw new IllegalStateException("forced after the delete");
+            });
+            fail("the body's exception did not leave inTransaction");
+        } catch (IllegalStateException expected) {
+            // as above
+        }
+        // the rows came back, so a file deleted here would be one the restored rows still name
+        assertTrue("the attachment file was deleted before the commit", file.exists());
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 1);
+        assertRowCount(Schema.Attachment.TABLE, null, 1);
+    }
+
+    @Test
+    public void aCommittedWalletDeleteRemovesItsAttachmentFile() throws Exception {
+        File file = writeAttachmentFile("path1");
+        long walletId = walletWithAnAttachedTransaction("path1");
+        mDatabase.inTransaction(() -> mDatabase.deleteWallet(walletId));
+        assertFalse("the attachment file outlived a committed delete", file.exists());
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 0);
+        assertRowCount(Schema.Attachment.TABLE, null, 0);
     }
 
     @Test(expected = SQLiteDataException.class)

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -165,11 +165,17 @@ public class DataContentProvider extends ContentProvider {
         return matcher;
     }
 
-    private SQLDatabase mDatabase;
+    /**
+     * Read on every use instead of held in a field. A restore swaps the file underneath both
+     * providers and closes the old helper, and a field would then be a closed handle until the
+     * next process start.
+     */
+    private SQLDatabase db() {
+        return SQLDatabase.getShared(getContext());
+    }
 
     @Override
     public boolean onCreate() {
-        initializeDatabase(getContext());
         return true;
     }
 
@@ -179,28 +185,28 @@ public class DataContentProvider extends ContentProvider {
         Cursor cursor = null;
         switch (mUriMatcher.match(uri)) {
             case CURRENCY_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getCurrencies(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getCurrencies(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CURRENCIES);
                 break;
             case CURRENCY_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getCurrency(uri.getLastPathSegment(), projection));
+                cursor = new MultiUriCursorWrapper(db().getCurrency(uri.getLastPathSegment(), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 break;
             case WALLET_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getWallets(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getWallets(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
                 break;
             case WALLET_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getWallet(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getWallet(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
                 break;
             case TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransactions(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getTransactions(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
@@ -212,7 +218,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSACTION_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransaction(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getTransaction(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
@@ -224,17 +230,17 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSACTION_ATTACHMENTS:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransactionAttachments(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getTransactionAttachments(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSACTION_PEOPLE:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransactionPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getTransactionPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
                 break;
             case TRANSFER_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransfers(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getTransfers(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
@@ -246,7 +252,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSFER_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransfer(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getTransfer(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
@@ -258,30 +264,30 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSFER_ATTACHMENTS:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransferAttachments(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getTransferAttachments(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSFER_PEOPLE:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransferPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getTransferPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
                 break;
             case CATEGORY_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getCategories(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getCategories(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 break;
             case CATEGORY_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getCategory(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getCategory(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 break;
             case CATEGORY_TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getCategoryTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getCategoryTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 break;
             case DEBT_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getDebts(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getDebts(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
@@ -290,7 +296,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case DEBT_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getDebt(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getDebt(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
@@ -299,7 +305,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case DEBT_PEOPLE:
-                cursor = new MultiUriCursorWrapper(mDatabase.getDebtPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getDebtPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
                 // Saving a debt's master transaction now writes the debt's people, so a write
@@ -307,75 +313,75 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case DEBT_TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getDebtTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getDebtTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case BUDGET_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getBudgets(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getBudgets(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
                 break;
             case BUDGET_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getBudget(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getBudget(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case BUDGET_WALLETS:
-                cursor = new MultiUriCursorWrapper(mDatabase.getBudgetWallets(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getBudgetWallets(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 break;
             case BUDGET_CATEGORIES:
-                cursor = new MultiUriCursorWrapper(mDatabase.getBudgetCategories(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getBudgetCategories(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 break;
             case BUDGET_TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getBudgetTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getBudgetTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case SAVING_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getSavings(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getSavings(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_SAVINGS);
                 break;
             case SAVING_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getSaving(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getSaving(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case SAVING_TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getSavingTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getSavingTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_SAVINGS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case EVENT_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getEvents(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getEvents(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
                 break;
             case EVENT_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getEvent(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getEvent(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case EVENT_TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getEventTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getEventTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case RECURRENT_TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getRecurrentTransactions(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getRecurrentTransactions(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTION_MODELS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
@@ -385,7 +391,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case RECURRENT_TRANSACTION_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getRecurrentTransaction(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getRecurrentTransaction(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTION_MODELS);
@@ -396,7 +402,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case RECURRENT_TRANSFER_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getRecurrentTransfers(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getRecurrentTransfers(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFER_MODELS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
@@ -406,7 +412,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case RECURRENT_TRANSFER_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getRecurrentTransfer(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getRecurrentTransfer(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFER_MODELS);
@@ -417,7 +423,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case TRANSACTION_MODEL_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransactionModels(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getTransactionModels(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTION_MODELS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
@@ -426,7 +432,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case TRANSACTION_MODEL_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransactionModel(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getTransactionModel(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
@@ -435,7 +441,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case TRANSFER_MODEL_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransferModels(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getTransferModels(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFER_MODELS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
@@ -444,7 +450,7 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case TRANSFER_MODEL_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getTransferModel(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getTransferModel(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
@@ -453,37 +459,37 @@ public class DataContentProvider extends ContentProvider {
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case PLACE_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getPlaces(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getPlaces(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case PLACE_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getPlace(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getPlace(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 break;
             case PLACE_TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getPlaceTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getPlaceTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case PERSON_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getPeople(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getPeople(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
                 break;
             case PERSON_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getPerson(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getPerson(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 break;
             case PERSON_TRANSACTION_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getPeopleTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getPeopleTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
                 cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case ATTACHMENT_LIST:
-                cursor = new MultiUriCursorWrapper(mDatabase.getAttachments(projection, selection, selectionArgs, sortOrder));
+                cursor = new MultiUriCursorWrapper(db().getAttachments(projection, selection, selectionArgs, sortOrder));
                 cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case ATTACHMENT_ITEM:
-                cursor = new MultiUriCursorWrapper(mDatabase.getAttachment(ContentUris.parseId(uri), projection));
+                cursor = new MultiUriCursorWrapper(db().getAttachment(ContentUris.parseId(uri), projection));
                 cursor.setNotificationUri(getContentResolver(), uri);
                 break;
         }
@@ -590,225 +596,250 @@ public class DataContentProvider extends ContentProvider {
         return null;
     }
 
+    /**
+     * Every write this provider makes runs inside one transaction, so a method that touches more
+     * than one table cannot leave the database part way through. The observers are told only once
+     * the commit has gone through, since a transaction that rolls back would otherwise have
+     * already announced a change that never happened.
+     */
     @Nullable
     @Override
     public Uri insert(@NonNull Uri uri, ContentValues contentValues) {
+        Uri objectUri = SQLDatabase.inSharedTransaction(getContext(),
+                database -> insertInTransaction(database, uri, contentValues));
+        if (objectUri != null) {
+            PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
+            ContentResolver contentResolver = getContentResolver();
+            if (contentResolver != null) {
+                contentResolver.notifyChange(objectUri, null);
+            }
+        }
+        return objectUri;
+    }
+
+    private Uri insertInTransaction(SQLDatabase database, Uri uri, ContentValues contentValues) {
         String currencyIso = null;
         long objectId = 0L;
         switch (mUriMatcher.match(uri)) {
             case CURRENCY_LIST:
-                currencyIso = mDatabase.insertCurrency(contentValues);
+                currencyIso = database.insertCurrency(contentValues);
                 break;
             case WALLET_LIST:
-                objectId = mDatabase.insertWallet(contentValues);
+                objectId = database.insertWallet(contentValues);
                 break;
             case TRANSACTION_LIST:
-                objectId = mDatabase.insertTransaction(contentValues);
+                objectId = database.insertTransaction(contentValues);
                 break;
             case TRANSFER_LIST:
-                objectId = mDatabase.insertTransfer(contentValues);
+                objectId = database.insertTransfer(contentValues);
                 break;
             case CATEGORY_LIST:
-                objectId = mDatabase.insertCategory(contentValues);
+                objectId = database.insertCategory(contentValues);
                 break;
             case DEBT_LIST:
-                objectId = mDatabase.insertDebt(contentValues);
+                objectId = database.insertDebt(contentValues);
                 break;
             case BUDGET_LIST:
-                objectId = mDatabase.insertBudget(contentValues);
+                objectId = database.insertBudget(contentValues);
                 break;
             case SAVING_LIST:
-                objectId = mDatabase.insertSaving(contentValues);
+                objectId = database.insertSaving(contentValues);
                 break;
             case EVENT_LIST:
-                objectId = mDatabase.insertEvent(contentValues);
+                objectId = database.insertEvent(contentValues);
                 break;
             case RECURRENT_TRANSACTION_LIST:
-                objectId = mDatabase.insertRecurrentTransaction(contentValues);
+                objectId = database.insertRecurrentTransaction(contentValues);
                 break;
             case RECURRENT_TRANSFER_LIST:
-                objectId = mDatabase.insertRecurrentTransfer(contentValues);
+                objectId = database.insertRecurrentTransfer(contentValues);
                 break;
             case TRANSACTION_MODEL_LIST:
-                objectId = mDatabase.insertTransactionModel(contentValues);
+                objectId = database.insertTransactionModel(contentValues);
                 break;
             case TRANSFER_MODEL_LIST:
-                objectId = mDatabase.insertTransferModel(contentValues);
+                objectId = database.insertTransferModel(contentValues);
                 break;
             case PLACE_LIST:
-                objectId = mDatabase.insertPlace(contentValues);
+                objectId = database.insertPlace(contentValues);
                 break;
             case PERSON_LIST:
-                objectId = mDatabase.insertPerson(contentValues);
+                objectId = database.insertPerson(contentValues);
                 break;
             case ATTACHMENT_LIST:
-                objectId = mDatabase.insertAttachment(contentValues);
+                objectId = database.insertAttachment(contentValues);
                 break;
         }
-        if (currencyIso != null || objectId > 0L) {
-            PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
-            ContentResolver contentResolver = getContentResolver();
-            if (currencyIso != null) {
-                Uri objectUri = Uri.withAppendedPath(uri, currencyIso);
-                if (contentResolver != null) {
-                    contentResolver.notifyChange(objectUri, null);
-                }
-                return objectUri;
-            } else if (objectId > 0L) {
-                Uri objectUri = ContentUris.withAppendedId(uri, objectId);
-                if (contentResolver != null) {
-                    contentResolver.notifyChange(objectUri, null);
-                }
-                return objectUri;
-            }
+        if (currencyIso != null) {
+            return Uri.withAppendedPath(uri, currencyIso);
+        }
+        if (objectId > 0L) {
+            return ContentUris.withAppendedId(uri, objectId);
         }
         return null;
     }
 
     @Override
     public int delete(@NonNull Uri uri, String selection, String[] selectionArgs) {
-        int result = 0;
-        Uri notifyUri = null;
-        switch (mUriMatcher.match(uri)) {
-            case CURRENCY_ITEM:
-                notifyUri = DataContentProvider.CONTENT_CURRENCIES;
-                result = mDatabase.deleteCurrency(uri.getLastPathSegment());
-                break;
-            case WALLET_ITEM:
-                notifyUri = DataContentProvider.CONTENT_WALLETS;
-                long deletedWalletId = ContentUris.parseId(uri);
-                result = mDatabase.deleteWallet(deletedWalletId);
-                Context deleteContext = getContext();
-                if (result > 0 && deleteContext != null
-                        && deletedWalletId == PreferenceManager.getCurrentWallet()) {
-                    // the deleted wallet still has its id stored as the current one, and every
-                    // scoped query keeps filtering on it, so all of them come back with
-                    // nothing. reset here rather than in the screen that triggers the delete,
-                    // because every wallet delete passes through this point.
-                    PreferenceManager.setCurrentWallet(deleteContext, PreferenceManager.TOTAL_WALLET_ID);
-                }
-                break;
-            case TRANSACTION_ITEM:
-                notifyUri = DataContentProvider.CONTENT_TRANSACTIONS;
-                result = mDatabase.deleteTransaction(ContentUris.parseId(uri));
-                break;
-            case TRANSFER_ITEM:
-                notifyUri = DataContentProvider.CONTENT_TRANSFERS;
-                result = mDatabase.deleteTransfer(ContentUris.parseId(uri));
-                break;
-            case CATEGORY_ITEM:
-                notifyUri = DataContentProvider.CONTENT_CATEGORIES;
-                result = mDatabase.deleteCategory(ContentUris.parseId(uri));
-                break;
-            case DEBT_ITEM:
-                notifyUri = DataContentProvider.CONTENT_DEBTS;
-                result = mDatabase.deleteDebt(ContentUris.parseId(uri));
-                break;
-            case BUDGET_ITEM:
-                notifyUri = DataContentProvider.CONTENT_BUDGETS;
-                result = mDatabase.deleteBudget(ContentUris.parseId(uri));
-                break;
-            case SAVING_ITEM:
-                notifyUri = DataContentProvider.CONTENT_SAVINGS;
-                result = mDatabase.deleteSaving(ContentUris.parseId(uri));
-                break;
-            case EVENT_ITEM:
-                notifyUri = DataContentProvider.CONTENT_EVENTS;
-                result = mDatabase.deleteEvent(ContentUris.parseId(uri));
-                break;
-            case RECURRENT_TRANSACTION_ITEM:
-                notifyUri = DataContentProvider.CONTENT_RECURRENT_TRANSACTIONS;
-                result = mDatabase.deleteRecurrentTransaction(ContentUris.parseId(uri));
-                break;
-            case RECURRENT_TRANSFER_ITEM:
-                notifyUri = DataContentProvider.CONTENT_RECURRENT_TRANSFERS;
-                result = mDatabase.deleteRecurrentTransfer(ContentUris.parseId(uri));
-                break;
-            case TRANSACTION_MODEL_ITEM:
-                notifyUri = DataContentProvider.CONTENT_TRANSACTION_MODELS;
-                result = mDatabase.deleteTransactionModel(ContentUris.parseId(uri));
-                break;
-            case TRANSFER_MODEL_ITEM:
-                notifyUri = DataContentProvider.CONTENT_TRANSFER_MODELS;
-                result = mDatabase.deleteTransferModel(ContentUris.parseId(uri));
-                break;
-            case PLACE_ITEM:
-                notifyUri = DataContentProvider.CONTENT_PLACES;
-                result = mDatabase.deletePlace(ContentUris.parseId(uri));
-                break;
-            case PERSON_ITEM:
-                notifyUri = DataContentProvider.CONTENT_PEOPLE;
-                result = mDatabase.deletePerson(ContentUris.parseId(uri));
-                break;
-            case ATTACHMENT_ITEM:
-                notifyUri = DataContentProvider.CONTENT_ATTACHMENTS;
-                result = mDatabase.deleteAttachment(ContentUris.parseId(uri));
-                break;
+        // one element so the body running inside the transaction can hand the uri back out. A
+        // lambda cannot assign a local, and deriving it a second time out here would be the same
+        // sixteen cases written twice
+        Uri[] notifyUri = new Uri[1];
+        int result = SQLDatabase.inSharedTransaction(getContext(),
+                database -> deleteInTransaction(database, uri, notifyUri));
+        // out here with the notify, and not in the WALLET_ITEM case where it used to sit, because
+        // it writes a preference and broadcasts to every open screen and neither of those can be
+        // rolled back. Reading the preference after the delete is the same read, nothing in the
+        // database is what it answers from. Every wallet delete still passes through this point,
+        // which is the reason it lives in the provider and not in the screen that starts one
+        Context context = getContext();
+        if (result > 0 && context != null && mUriMatcher.match(uri) == WALLET_ITEM
+                && ContentUris.parseId(uri) == PreferenceManager.getCurrentWallet()) {
+            // the deleted wallet still has its id stored as the current one, and every query the
+            // filter reaches keeps filtering on it, so all of them come back with nothing
+            PreferenceManager.setCurrentWallet(context, PreferenceManager.TOTAL_WALLET_ID);
         }
         ContentResolver contentResolver = getContentResolver();
-        if (contentResolver != null && notifyUri != null) {
+        if (contentResolver != null && notifyUri[0] != null) {
             PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
-            contentResolver.notifyChange(notifyUri, null);
+            contentResolver.notifyChange(notifyUri[0], null);
+        }
+        return result;
+    }
+
+    private int deleteInTransaction(SQLDatabase database, Uri uri, Uri[] notifyUri) {
+        int result = 0;
+        switch (mUriMatcher.match(uri)) {
+            case CURRENCY_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_CURRENCIES;
+                result = database.deleteCurrency(uri.getLastPathSegment());
+                break;
+            case WALLET_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_WALLETS;
+                result = database.deleteWallet(ContentUris.parseId(uri));
+                break;
+            case TRANSACTION_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_TRANSACTIONS;
+                result = database.deleteTransaction(ContentUris.parseId(uri));
+                break;
+            case TRANSFER_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_TRANSFERS;
+                result = database.deleteTransfer(ContentUris.parseId(uri));
+                break;
+            case CATEGORY_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_CATEGORIES;
+                result = database.deleteCategory(ContentUris.parseId(uri));
+                break;
+            case DEBT_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_DEBTS;
+                result = database.deleteDebt(ContentUris.parseId(uri));
+                break;
+            case BUDGET_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_BUDGETS;
+                result = database.deleteBudget(ContentUris.parseId(uri));
+                break;
+            case SAVING_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_SAVINGS;
+                result = database.deleteSaving(ContentUris.parseId(uri));
+                break;
+            case EVENT_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_EVENTS;
+                result = database.deleteEvent(ContentUris.parseId(uri));
+                break;
+            case RECURRENT_TRANSACTION_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_RECURRENT_TRANSACTIONS;
+                result = database.deleteRecurrentTransaction(ContentUris.parseId(uri));
+                break;
+            case RECURRENT_TRANSFER_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_RECURRENT_TRANSFERS;
+                result = database.deleteRecurrentTransfer(ContentUris.parseId(uri));
+                break;
+            case TRANSACTION_MODEL_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_TRANSACTION_MODELS;
+                result = database.deleteTransactionModel(ContentUris.parseId(uri));
+                break;
+            case TRANSFER_MODEL_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_TRANSFER_MODELS;
+                result = database.deleteTransferModel(ContentUris.parseId(uri));
+                break;
+            case PLACE_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_PLACES;
+                result = database.deletePlace(ContentUris.parseId(uri));
+                break;
+            case PERSON_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_PEOPLE;
+                result = database.deletePerson(ContentUris.parseId(uri));
+                break;
+            case ATTACHMENT_ITEM:
+                notifyUri[0] = DataContentProvider.CONTENT_ATTACHMENTS;
+                result = database.deleteAttachment(ContentUris.parseId(uri));
+                break;
         }
         return result;
     }
 
     @Override
     public int update(@NonNull Uri uri, ContentValues values, String selection, String[] selectionArgs) {
-        int result = 0;
-        switch (mUriMatcher.match(uri)) {
-            case CURRENCY_ITEM:
-                result = mDatabase.updateCurrency(uri.getLastPathSegment(), values);
-                break;
-            case WALLET_ITEM:
-                result = mDatabase.updateWallet(ContentUris.parseId(uri), values);
-                break;
-            case TRANSACTION_ITEM:
-                result = mDatabase.updateTransaction(ContentUris.parseId(uri), values);
-                break;
-            case TRANSFER_ITEM:
-                result = mDatabase.updateTransfer(ContentUris.parseId(uri), values);
-                break;
-            case CATEGORY_ITEM:
-                result = mDatabase.updateCategory(ContentUris.parseId(uri), values);
-                break;
-            case DEBT_ITEM:
-                result = mDatabase.updateDebt(ContentUris.parseId(uri), values);
-                break;
-            case BUDGET_ITEM:
-                result = mDatabase.updateBudget(ContentUris.parseId(uri), values);
-                break;
-            case SAVING_ITEM:
-                result = mDatabase.updateSaving(ContentUris.parseId(uri), values);
-                break;
-            case EVENT_ITEM:
-                result = mDatabase.updateEvent(ContentUris.parseId(uri), values);
-                break;
-            case RECURRENT_TRANSACTION_ITEM:
-                result = mDatabase.updateRecurrentTransaction(ContentUris.parseId(uri), values);
-                break;
-            case RECURRENT_TRANSFER_ITEM:
-                result = mDatabase.updateRecurrentTransfer(ContentUris.parseId(uri), values);
-                break;
-            case TRANSACTION_MODEL_ITEM:
-                result = mDatabase.updateTransactionModel(ContentUris.parseId(uri), values);
-                break;
-            case TRANSFER_MODEL_ITEM:
-                result = mDatabase.updateTransferModel(ContentUris.parseId(uri), values);
-                break;
-            case PLACE_ITEM:
-                result = mDatabase.updatePlace(ContentUris.parseId(uri), values);
-                break;
-            case PERSON_ITEM:
-                result = mDatabase.updatePerson(ContentUris.parseId(uri), values);
-                break;
-        }
+        int result = SQLDatabase.inSharedTransaction(getContext(),
+                database -> updateInTransaction(database, uri, values));
         if (result > 0) {
             PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
             ContentResolver contentResolver = getContentResolver();
             if (contentResolver != null) {
                 contentResolver.notifyChange(uri, null);
             }
+        }
+        return result;
+    }
+
+    private int updateInTransaction(SQLDatabase database, Uri uri, ContentValues values) {
+        int result = 0;
+        switch (mUriMatcher.match(uri)) {
+            case CURRENCY_ITEM:
+                result = database.updateCurrency(uri.getLastPathSegment(), values);
+                break;
+            case WALLET_ITEM:
+                result = database.updateWallet(ContentUris.parseId(uri), values);
+                break;
+            case TRANSACTION_ITEM:
+                result = database.updateTransaction(ContentUris.parseId(uri), values);
+                break;
+            case TRANSFER_ITEM:
+                result = database.updateTransfer(ContentUris.parseId(uri), values);
+                break;
+            case CATEGORY_ITEM:
+                result = database.updateCategory(ContentUris.parseId(uri), values);
+                break;
+            case DEBT_ITEM:
+                result = database.updateDebt(ContentUris.parseId(uri), values);
+                break;
+            case BUDGET_ITEM:
+                result = database.updateBudget(ContentUris.parseId(uri), values);
+                break;
+            case SAVING_ITEM:
+                result = database.updateSaving(ContentUris.parseId(uri), values);
+                break;
+            case EVENT_ITEM:
+                result = database.updateEvent(ContentUris.parseId(uri), values);
+                break;
+            case RECURRENT_TRANSACTION_ITEM:
+                result = database.updateRecurrentTransaction(ContentUris.parseId(uri), values);
+                break;
+            case RECURRENT_TRANSFER_ITEM:
+                result = database.updateRecurrentTransfer(ContentUris.parseId(uri), values);
+                break;
+            case TRANSACTION_MODEL_ITEM:
+                result = database.updateTransactionModel(ContentUris.parseId(uri), values);
+                break;
+            case TRANSFER_MODEL_ITEM:
+                result = database.updateTransferModel(ContentUris.parseId(uri), values);
+                break;
+            case PLACE_ITEM:
+                result = database.updatePlace(ContentUris.parseId(uri), values);
+                break;
+            case PERSON_ITEM:
+                result = database.updatePerson(ContentUris.parseId(uri), values);
+                break;
         }
         return result;
     }
@@ -830,11 +861,15 @@ public class DataContentProvider extends ContentProvider {
         return Long.parseLong(segments.get(fixedIndex - 1));
     }
 
-    private void initializeDatabase(Context context) {
-        if (mDatabase != null) {
-            mDatabase.close();
-        }
-        mDatabase = new SQLDatabase(context);
+    /**
+     * Runs a replacement of the database file with the shared helper closed and no write of this
+     * provider's in flight. The runnable does the file work and nothing else.
+     *
+     * Public, and here, because SQLDatabase is package local and the importers that replace the
+     * database file sit in a sub package, so they cannot name it.
+     */
+    public static void replaceDatabaseFile(Context context, Runnable swap) {
+        SQLDatabase.resetShared(context, swap);
     }
 
     @SuppressLint("Recycle")
@@ -844,7 +879,7 @@ public class DataContentProvider extends ContentProvider {
         if (client != null) {
             ContentProvider contentProvider = client.getLocalContentProvider();
             if (contentProvider instanceof DataContentProvider) {
-                ((DataContentProvider) contentProvider).initializeDatabase(context);
+                SQLDatabase.resetShared(context);
                 PreferenceManager.setCurrentWallet(context, PreferenceManager.NO_CURRENT_WALLET);
                 // Same reason the current wallet is cleared just above. Every wallet is inserted
                 // fresh by a restore, so the ids come back naming other wallets, and a widget is

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -19,6 +19,7 @@
 
 package com.oriondev.moneywallet.storage.database;
 
+import android.annotation.SuppressLint;
 import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
@@ -63,6 +64,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * This class implements the default SQLite helper class of the Android Framework.
@@ -79,9 +83,183 @@ import java.util.UUID;
 
     private final Context mContext;
 
+    @SuppressLint("StaticFieldLeak")
+    private static SQLDatabase sShared;
+
+    /**
+     * The one helper both content providers use. Two helpers over the same file are two connection
+     * pools, so a transaction opened through one of them would not enclose a write made through
+     * the other, which is the whole point of having a transaction.
+     *
+     * The application context, and not the caller's. A service reaches resetShared below, and this
+     * field outlives any service, so holding that context would keep a destroyed one alive.
+     *
+     * The context reaches three things here. getDatabasePath, through SQLiteOpenHelper, and
+     * getExternalFilesDir at the attachment folder, which answer the same on the application
+     * context as on a service or a provider. And getString, through the system category names
+     * seeded by onCreate and onUpgrade, which is a resource lookup and so the one place the
+     * choice of context could read differently. It does not here, a provider's own context is
+     * already the application context, so this normalization changes nothing about which strings
+     * a fresh database is seeded with.
+     *
+     * That normalization is also what a test has to defeat to reach this at all. ContextWrapper
+     * answers getApplicationContext from the context it wraps, so a wrapper redirecting the
+     * database and the attachment folder is discarded on this line and the real ledger opens
+     * instead. SQLDatabaseTest's own wrapper overrides getApplicationContext to return itself for
+     * that reason, and its setUp asserts which file this actually opened, which is what catches
+     * that override being dropped before a case reaches the real ledger.
+     */
+    /*package-local*/ static synchronized SQLDatabase getShared(Context context) {
+        if (sShared == null) {
+            sShared = new SQLDatabase(context.getApplicationContext());
+        }
+        return sShared;
+    }
+
+    /**
+     * Closes the shared helper and opens a new one, for after a restore has replaced the file on
+     * disk. Both providers reach this through their own notifyDatabaseIsChanged, and calling it
+     * twice in a row is what AbstractBackupImporter does, so it has to be safe to repeat. It is:
+     * the first call leaves a helper that has opened nothing, since SQLiteOpenHelper opens on
+     * first use, and the second discards it at no cost.
+     *
+     * Why the close has to happen. A restore renames the database aside and writes a new one at
+     * the old path. A write that STARTS after that rename is refused, checked on the emulator and
+     * not reasoned about. It fails with "attempt to write a readonly database", the row does not
+     * land, and the journal is left behind at the path the new database is about to take over.
+     * Closing releases that connection and truncates the journal it left.
+     *
+     * Why no write may be in flight while it happens. A transaction belongs to the SQLiteDatabase,
+     * and every write method here asks the helper for it again per statement, nine times in
+     * deleteWallet alone. Closing under one would send the rest of that write to a newly opened
+     * second connection with no transaction on it, so the first half rolls back and the second
+     * half is already committed. That is what the lock makes unreachable, and it is the only
+     * thing the lock makes unreachable.
+     *
+     * What it does NOT cover, stated because it is easy to read the lock as wider than it is.
+     * SyncContentProvider's own writes do not come through inSharedTransaction, so they are
+     * outside the lock, and the restore's own row inserts are exactly those writes.
+     */
+    /*package-local*/ static void resetShared(Context context) {
+        resetShared(context, null);
+    }
+
+    /**
+     * The same swap, with the caller's own work run in the slot where the file is closed. That
+     * slot is what a restore needs. Renaming the database aside outside it leaves a window where
+     * a transaction opens on the old file and commits into it, since SQLite tests for a moved
+     * database when a transaction opens and not per statement.
+     *
+     * The runnable runs under the write lock, so no DataContentProvider write is in flight, and
+     * under the class monitor, so a thread inside getShared cannot be handed the closed helper
+     * while the file is moving. Those are the only two it excludes. SyncContentProvider's writes
+     * and every query take no lock at all, so they can be running while the file moves. The
+     * runnable must not touch the database or call back into this class, and it must be short,
+     * since every thread that enters getShared blocks behind it.
+     */
+    /*package-local*/ static void resetShared(Context context, Runnable whileClosed) {
+        if (sSwapLock.getReadHoldCount() > 0) {
+            // this thread is inside inSharedTransaction and a read hold cannot be upgraded, so
+            // asking for the write lock here would wait on itself forever, holding an open
+            // transaction and wedging every later write and every later reset in the process.
+            // inTransaction refuses its own version of this mistake for the same reason
+            throw new IllegalStateException("resetShared called from inside a transaction");
+        }
+        sSwapLock.writeLock().lock();
+        try {
+            synchronized (SQLDatabase.class) {
+                try {
+                    if (sShared != null) {
+                        sShared.close();
+                    }
+                    if (whileClosed != null) {
+                        whileClosed.run();
+                    }
+                } finally {
+                    // the close is inside the try for the same reason the finally is here at all.
+                    // Either of them throwing would otherwise leave sShared naming a helper that
+                    // is closed or half closed, and every later getShared would hand that out for
+                    // the rest of the process
+                    sShared = new SQLDatabase(context.getApplicationContext());
+                }
+            }
+        } finally {
+            sSwapLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Held for the whole of one provider write, and exclusively while the shared helper is
+     * swapped. Resolving the helper and running the transaction have to be under the same hold,
+     * or a swap landing between the two would run the transaction on a helper that has just been
+     * closed.
+     */
+    private static final ReentrantReadWriteLock sSwapLock = new ReentrantReadWriteLock();
+
+    /**
+     * Resolves the shared helper and runs the body inside one transaction on it. This is how
+     * DataContentProvider starts every write. SyncContentProvider does not come through here, its
+     * three writes are one statement each, which SQLite already runs atomically, so they take no
+     * transaction and no lock.
+     */
+    /*package-local*/ static <T> T inSharedTransaction(Context context, Function<SQLDatabase, T> body) {
+        sSwapLock.readLock().lock();
+        try {
+            SQLDatabase database = getShared(context);
+            return database.inTransaction(() -> body.apply(database));
+        } finally {
+            sSwapLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Attachment file names removed by the body of the transaction currently running on this
+     * thread. Null when this thread is not inside one.
+     */
+    private final ThreadLocal<List<String>> mPendingAttachmentFiles = new ThreadLocal<>();
+
     /*package-local*/ SQLDatabase(Context context) {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
         mContext = context;
+    }
+
+    /**
+     * Runs a body inside one SQLite transaction and returns what it returned.
+     *
+     * Attachment files the body removed are deleted only once the transaction has committed. A
+     * rollback would otherwise restore rows that point at files already gone from the volume.
+     *
+     * Not reentrant, on purpose. SQLite would reference count the nesting, but Android rolls the
+     * whole transaction back when an inner frame ends without being marked successful and it does
+     * that silently, with no exception at the outer endTransaction. An outer body that caught the
+     * inner failure and carried on would leave here believing it had committed, and would delete
+     * the attachment files of rows the rollback had just restored. Nothing nests today. Whoever
+     * writes the first nested caller has to answer that before this throw comes out.
+     */
+    /*package-local*/ <T> T inTransaction(Supplier<T> body) {
+        if (mPendingAttachmentFiles.get() != null) {
+            throw new IllegalStateException("inTransaction is not reentrant");
+        }
+        SQLiteDatabase database = getWritableDatabase();
+        mPendingAttachmentFiles.set(new ArrayList<>());
+        T result;
+        try {
+            database.beginTransaction();
+            try {
+                result = body.get();
+                database.setTransactionSuccessful();
+            } finally {
+                database.endTransaction();
+            }
+        } catch (RuntimeException | Error e) {
+            // nothing committed, so the names collected on the way here name live rows
+            mPendingAttachmentFiles.remove();
+            throw e;
+        }
+        List<String> pending = mPendingAttachmentFiles.get();
+        mPendingAttachmentFiles.remove();
+        deleteAttachmentFiles(pending);
+        return result;
     }
 
     @Override
@@ -3243,8 +3421,9 @@ import java.util.UUID;
                 // CONFLICT_IGNORE covers the composite key and nothing else, a foreign key is
                 // still enforced and still throws, which happens when the category was deleted
                 // while the editor was open. Dropping that one id leaves the rest of the budget
-                // written, where letting it out would abort the save half way through and take
-                // the categories already restored above with it.
+                // written. Letting it out now rolls the whole save back instead, since both
+                // callers run inside the provider's transaction, so the user would lose the edit
+                // over a category that is already gone.
                 continue;
             }
             if (newId == -1L) {
@@ -5028,20 +5207,42 @@ import java.util.UUID;
         if (attachments.isEmpty()) {
             return;
         }
-        // resolved once, and only once there is something to delete, since it touches the volume.
         // A row goes whether or not its file can be reached: the row is what puts the file into
         // every backup, so keeping the two in step by leaving the row would leave the problem this
         // exists to fix
-        File folder = getAttachmentFolder();
+        List<String> removed = new ArrayList<>();
         for (Map.Entry<Long, String> attachment : attachments.entrySet()) {
             if (isLinkedOutside(attachment.getKey(), linkTable, attachmentColumn, linkSelection,
                     selectionArgs)) {
                 continue;
             }
             deleteAttachment(attachment.getKey());
-            if (folder != null) {
-                deleteAttachmentFile(folder, attachment.getValue());
-            }
+            removed.add(attachment.getValue());
+        }
+        List<String> pending = mPendingAttachmentFiles.get();
+        if (pending != null) {
+            // inside a transaction, so the rows are not committed yet and the files have to wait
+            // for them. inTransaction deletes these once the commit has gone through
+            pending.addAll(removed);
+        } else {
+            deleteAttachmentFiles(removed);
+        }
+    }
+
+    /**
+     * Removes the files behind attachment rows that have already gone. Resolving the folder
+     * touches the volume, so it happens only when there is something to delete.
+     */
+    private void deleteAttachmentFiles(List<String> fileNames) {
+        if (fileNames == null || fileNames.isEmpty()) {
+            return;
+        }
+        File folder = getAttachmentFolder();
+        if (folder == null) {
+            return;
+        }
+        for (String fileName : fileNames) {
+            deleteAttachmentFile(folder, fileName);
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SyncContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SyncContentProvider.java
@@ -124,12 +124,18 @@ public class SyncContentProvider extends ContentProvider {
         return matcher;
     }
 
-    private SQLDatabase mDatabase;
+    /**
+     * The same helper DataContentProvider uses, read on every use instead of held in a field.
+     * One helper means one connection on one file, so the two providers cannot end up with a
+     * transaction on one and a write on the other. A field would be a closed handle after a
+     * restore, since resetShared closes what it replaces.
+     */
+    private SQLDatabase db() {
+        return SQLDatabase.getShared(getContext());
+    }
 
     @Override
     public boolean onCreate() {
-        Context context = getContext();
-        mDatabase = new SQLDatabase(context);
         return true;
     }
 
@@ -193,7 +199,7 @@ public class SyncContentProvider extends ContentProvider {
     public Cursor query(@NonNull Uri uri, @Nullable String[] projection, @Nullable String selection, @Nullable String[] selectionArgs, @Nullable String sortOrder) {
         String table = getTable(uri);
         if (table != null) {
-            return mDatabase.getReadableDatabase().query(table, projection, selection, selectionArgs, null, null, sortOrder);
+            return db().getReadableDatabase().query(table, projection, selection, selectionArgs, null, null, sortOrder);
         }
         return null;
     }
@@ -209,7 +215,7 @@ public class SyncContentProvider extends ContentProvider {
     public Uri insert(@NonNull Uri uri, @Nullable ContentValues values) {
         String table = getTable(uri);
         if (table != null) {
-            long id = mDatabase.getWritableDatabase().insertWithOnConflict(table, null, values, SQLiteDatabase.CONFLICT_REPLACE);
+            long id = db().getWritableDatabase().insertWithOnConflict(table, null, values, SQLiteDatabase.CONFLICT_REPLACE);
             return ContentUris.withAppendedId(uri, id);
         }
         return null;
@@ -219,7 +225,7 @@ public class SyncContentProvider extends ContentProvider {
     public int delete(@NonNull Uri uri, @Nullable String selection, @Nullable String[] selectionArgs) {
         String table = getTable(uri);
         if (table != null) {
-            return mDatabase.getWritableDatabase().delete(table, selection, selectionArgs);
+            return db().getWritableDatabase().delete(table, selection, selectionArgs);
         }
         return 0;
     }
@@ -228,7 +234,7 @@ public class SyncContentProvider extends ContentProvider {
     public int update(@NonNull Uri uri, @Nullable ContentValues values, @Nullable String selection, @Nullable String[] selectionArgs) {
         String table = getTable(uri);
         if (table != null) {
-            return mDatabase.getWritableDatabase().update(table, values, selection, selectionArgs);
+            return db().getWritableDatabase().update(table, values, selection, selectionArgs);
         }
         return 0;
     }
@@ -240,10 +246,7 @@ public class SyncContentProvider extends ContentProvider {
         if (client != null) {
             ContentProvider contentProvider = client.getLocalContentProvider();
             if (contentProvider instanceof SyncContentProvider) {
-                if (((SyncContentProvider) contentProvider).mDatabase != null) {
-                    ((SyncContentProvider) contentProvider).mDatabase.close();
-                }
-                ((SyncContentProvider) contentProvider).mDatabase = new SQLDatabase(context);
+                SQLDatabase.resetShared(context);
             }
             client.close();
         }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/AbstractBackupImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/AbstractBackupImporter.java
@@ -57,6 +57,28 @@ public abstract class AbstractBackupImporter {
      * @param temporaryFolder folder where temporary data can be stored.
      * @param databaseFolder folder where the database is located.
      * @throws ImportException if an error occur while importing the backup file.
+     *
+     * What this does NOT do, because a reader will ask and part of the answer took a device run.
+     * Nothing serializes another thread's DataContentProvider writes against this import. The
+     * recurrence job is the one that needs no user present, it runs off an alarm, and the lock in
+     * BackupHandlerIntentService that serializes backup against restore is not taken anywhere in
+     * that job.
+     *
+     * Such a write is not refused and not held, so it lands wherever the path points at the time.
+     * Between the rename below and the import's first insert that is a database this class has
+     * just emptied. After it, it is the half imported database itself, carrying ids that named
+     * different rows before the restore, and foreign keys are on.
+     *
+     * Refusing them was built and reverted. The refusal reaches the caller as an exception, no
+     * caller on any of these write paths catches it, and injecting that throw into the recurrence
+     * job on an emulator ended the run with FATAL EXCEPTION on the AsyncTask that JobIntentService
+     * dispatches on, with the process gone; the same trigger without it left the process running.
+     * Every component here shares that one process, so the restore dies with it, half written.
+     * Holding the writes instead blocks whichever thread they arrived on, for as long as the
+     * backup is large.
+     *
+     * Closing this properly means never pointing the live path at a database an import is still
+     * filling, which is an import that builds its database elsewhere and swaps it in at the end.
      */
     public void importDatabase(@NonNull File temporaryFolder, @NonNull File databaseFolder) throws ImportException {
         File temporary = createBackupCopyOfCurrentDatabase(databaseFolder);
@@ -67,12 +89,20 @@ public abstract class AbstractBackupImporter {
             // given fresh ids in the order they were read, so the remembered ones now name other
             // categories. Forgetting them leaves every category showing, where the list starts.
             PreferenceManager.setCollapsedCategories(Collections.<String>emptySet());
-        } catch (ImportException e) {
+        } catch (ImportException | RuntimeException e) {
+            // RuntimeException as well. JSONDatabaseImporter converts IOException and
+            // JSONException and catches nothing else, so anything unchecked the provider raises
+            // comes straight through, a full disk being the one to expect. Every one of those
+            // used to skip the rollback and leave the half written import live
             restoreBackupCopyOfDatabase(databaseFolder, temporary);
             throw e;
-        } finally {
-            FileUtils.deleteQuietly(temporary);
         }
+        // deliberately not in a finally. The rollback above deletes the half imported database
+        // before it renames the backup back, so a rollback that throws has already destroyed one
+        // copy, and a finally here would then delete the only one left. Reached only when the
+        // import succeeded, where the copy is the replaced database and is not wanted, or when
+        // the rollback succeeded, where the rename has already consumed it
+        FileUtils.deleteQuietly(temporary);
     }
 
     protected abstract void importDatabase(@NonNull File temporaryFolder) throws ImportException;
@@ -107,13 +137,24 @@ public abstract class AbstractBackupImporter {
         SyncContentProvider.notifyDatabaseIsChanged(mContext);
     }
 
+    /**
+     * Both renames happen with the shared helper closed and no DataContentProvider write in
+     * flight. Moving the database while a connection is open on it strands that connection's
+     * journal at the old path and refuses its next write, and moving it while a transaction is
+     * open is worse, the transaction commits into the file this method is putting aside.
+     */
     private File createBackupCopyOfCurrentDatabase(@NonNull File databaseFolder) throws ImportException {
         File temporary = new File(databaseFolder, TEMP_BACKUP_FILE);
         if (temporary.exists()) {
             FileUtils.deleteQuietly(temporary);
         }
         File database = new File(databaseFolder, SQLDatabaseImporter.DATABASE_NAME);
-        if (database.exists() && !database.renameTo(temporary)) {
+        if (!database.exists()) {
+            return temporary;
+        }
+        boolean[] renamed = new boolean[1];
+        DataContentProvider.replaceDatabaseFile(mContext, () -> renamed[0] = database.renameTo(temporary));
+        if (!renamed[0]) {
             throw new ImportException("Cannot backup the old database file");
         }
         return temporary;
@@ -121,10 +162,14 @@ public abstract class AbstractBackupImporter {
 
     private void restoreBackupCopyOfDatabase(@NonNull File databaseFolder, @NonNull File backup) throws ImportException {
         File database = new File(databaseFolder, SQLDatabaseImporter.DATABASE_NAME);
-        if (database.exists()) {
-            FileUtils.deleteQuietly(database);
-        }
-        if (backup.exists() && !backup.renameTo(database)) {
+        boolean[] restored = new boolean[1];
+        DataContentProvider.replaceDatabaseFile(mContext, () -> {
+            if (database.exists()) {
+                FileUtils.deleteQuietly(database);
+            }
+            restored[0] = !backup.exists() || backup.renameTo(database);
+        });
+        if (!restored[0]) {
             throw new ImportException("Rollback failed, all data is lost");
         }
     }

--- a/app/src/test/java/com/oriondev/moneywallet/storage/database/DataContentProviderTransactionSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/storage/database/DataContentProviderTransactionSourceTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.storage.database;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * The instrumented cases in SQLDatabaseTest prove that inTransaction commits and rolls back. They
+ * cannot see whether the provider still calls it, because they drive SQLDatabase directly and
+ * never go through a provider at all. Dropping the wrapper from one of the three write methods
+ * would leave every one of those cases green while every multi table write through that method
+ * went back to being interruptible half way. That is what this pins.
+ *
+ * It pins two more things the same cases cannot see. That each wrapper resolves the shared helper
+ * ONCE and hands that same object to its body, since a restore on another thread can swap the
+ * shared helper at any moment and a body that re-resolved it per statement could open the
+ * transaction on one helper and write through another. And that the bodies do not tell the
+ * observers, since a notifyChange issued before the commit announces a change that the rollback
+ * then undoes, and nothing takes the announcement back.
+ *
+ * Comments and string literals are both stripped before anything is matched. Comments, so that no
+ * assertion here can be satisfied by a comment describing code the file no longer has. Literals,
+ * because this file is full of them and one carries a comment marker: every CONTENT_ uri is built
+ * from a content scheme whose two slashes read as the start of a line comment. A stripper that
+ * took comments first would cut each of those lines there, so a line that both built a uri and
+ * called notifyChange would survive as the uri alone and the check below would pass with the call
+ * it exists to forbid sitting right there. That is not hypothetical, it was demonstrated against
+ * an earlier version of this file. Literals are matched first for that reason.
+ *
+ * A failure means read the source and decide, not that the provider is broken.
+ */
+public class DataContentProviderTransactionSourceTest {
+
+    /** A java string literal, then a line comment, then a block comment. Literal first. */
+    private static final Pattern STRIPPED = Pattern.compile(
+            "\"(?:\\\\.|[^\"\\\\])*\"|//.*?$|/[*].*?[*]/",
+            Pattern.DOTALL | Pattern.MULTILINE);
+
+    private String readSource() {
+        String path = "src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java";
+        File file = new File(path);
+        if (!file.exists()) {
+            // a runner rooted at the repo root instead of the module, which the precedent
+            // handles the same way
+            file = new File("app/" + path);
+        }
+        if (!file.exists()) {
+            fail("Cannot find DataContentProvider.java at " + file.getAbsolutePath());
+        }
+        try {
+            String source = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            return STRIPPED.matcher(source).replaceAll(" ");
+        } catch (IOException e) {
+            fail("Cannot read DataContentProvider.java: " + e.getMessage());
+            return null;
+        }
+    }
+
+    private String bodyOf(String source, String signature) {
+        int start = source.indexOf(signature);
+        assertTrue(signature + " is gone", start >= 0);
+        int end = source.indexOf("\n    }", start);
+        assertTrue("no end found for " + signature, end > start);
+        return source.substring(start, end);
+    }
+
+    /** Each public write method, and the exact call its body must be reached by. */
+    private static final String[][] WRITE_METHODS = {
+            {"public Uri insert(", "database -> insertInTransaction(database,"},
+            {"public int delete(", "database -> deleteInTransaction(database,"},
+            {"public int update(", "database -> updateInTransaction(database,"},
+    };
+
+    private static final String[] TRANSACTION_BODIES = {
+            "private Uri insertInTransaction(",
+            "private int deleteInTransaction(",
+            "private int updateInTransaction(",
+    };
+
+    @Test
+    public void everyWriteMethodRunsItsBodyInsideATransaction() {
+        String source = readSource();
+        for (String[] method : WRITE_METHODS) {
+            String body = bodyOf(source, method[0]);
+            // inSharedTransaction and not inTransaction directly. It is the one that holds the
+            // swap lock across resolving the helper AND running the transaction, so a restore
+            // replacing the database cannot land between the two and leave the write running on
+            // a helper that has just been closed
+            assertTrue(method[0] + " no longer goes through SQLDatabase.inSharedTransaction, so "
+                            + "a restore can swap the shared helper part way through its write",
+                    body.contains("SQLDatabase.inSharedTransaction(getContext(),"));
+            // the whole call and not its halves. Asserting only that inSharedTransaction appears
+            // leaves every way of handing the body something else, such as passing db() into it
+            // or resolving the static again inside it
+            assertTrue(method[0] + " no longer hands its body the same helper the transaction was "
+                            + "opened on. The exact call it needs is " + method[1],
+                    body.contains(method[1]));
+        }
+    }
+
+    @Test
+    public void nothingInsideATransactionNotifiesTheObservers() {
+        String source = readSource();
+        for (String signature : TRANSACTION_BODIES) {
+            assertFalse(signature + " now calls notifyChange, which would announce a change that "
+                            + "a rollback then undoes",
+                    bodyOf(source, signature).contains("notifyChange("));
+        }
+    }
+
+    @Test
+    public void noBodyResolvesTheSharedHelperForItself() {
+        String source = readSource();
+        for (String signature : TRANSACTION_BODIES) {
+            String body = bodyOf(source, signature);
+            // every way back to the shared helper, not just the one the provider happens to use.
+            // A body that reached it again could be handed a different helper than the one its
+            // transaction was opened on, which is the whole reason the caller resolves it once
+            for (String route : new String[] {"db()", "getShared", "sShared"}) {
+                assertFalse(signature + " reaches the shared helper through " + route
+                                + " instead of using the one its caller resolved and passed in",
+                        body.contains(route));
+            }
+        }
+    }
+
+    @Test
+    public void thePreferenceWriteStaysOutsideTheTransaction() {
+        String source = readSource();
+        assertFalse("deleteInTransaction writes the current wallet preference again. That write "
+                        + "and the broadcast behind it cannot be rolled back, so a commit that "
+                        + "fails would leave the wallet in the ledger and the preference already "
+                        + "moved off it",
+                bodyOf(source, "private int deleteInTransaction(").contains("setCurrentWallet("));
+        assertTrue("delete no longer resets the current wallet after the commit, so deleting the "
+                        + "wallet in use leaves every query filtering on an id that is gone",
+                bodyOf(source, "public int delete(").contains("setCurrentWallet("));
+    }
+}


### PR DESCRIPTION
Deleting a wallet changes nine things in the database one after another, and nothing tied them together. A failure part way through left the ledger half deleted with no way back. More than thirty other operations have the same problem.

Two more come from the same design. Attachment files were removed before the entries naming them were saved, so an operation that failed left entries pointing at files already gone. And restoring a backup moves the live database aside first, so anything being written at that moment went into the file that then gets thrown away, and the app reported it as saved.

This puts every write through a single transaction, so it lands whole or not at all. Attachment files are removed only once their entries are safely saved. The two halves of the app that reach the database now share one connection, because one transaction cannot cover two. And a restore moves the database file with nothing writing to it, so nothing in progress is lost into the discarded copy.

Two data loss problems on the restore path are fixed too. When a restore failed and putting the old database back also failed, the app deleted the only remaining copy of the data. It now keeps it. And a restore that ran out of room part way through skipped putting the old data back at all and left the half finished import in place; it now falls back after any failure, not only the expected kinds.

What this touches: the database layer and the backup restore path. The backup file format does not change.

One limitation: a write started elsewhere in the app while a restore is running still lands in a database the restore is about to replace. Closing it means changing how a restore builds the new database, a separate change. Refusing those writes was tried and reverted, because the refusal crashed the app from a background job and took the running restore down with it.

Tested with the unit and instrumented suites on an emulator, lint clean against the baseline, and a release build.
