### PR TITLE
Save an imported file as one piece, and stop a refused row disappearing

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -20,13 +20,19 @@
 package com.oriondev.moneywallet.storage.database;
 
 import android.app.Instrumentation;
+import android.content.ContentResolver;
+import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.database.ContentObserver;
 import android.database.Cursor;
 import android.database.DatabaseErrorHandler;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteException;
+import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 
 import androidx.test.filters.LargeTest;
@@ -43,6 +49,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
@@ -53,6 +60,8 @@ import java.util.concurrent.TimeUnit;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertSame;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 
@@ -1403,27 +1412,304 @@ public class SQLDatabaseTest {
     }
 
     @Test
-    public void inTransactionRefusesToNest() {
-        // outside the transaction, so the count below fails both ways round: on a wrapper that
-        // does not roll the outer transaction back, and on one that rolls back past it
+    public void aNestedInTransactionRollsBackWithTheOuterOne() {
+        // outside the transaction, so the count below fails both ways round: on a nested call that
+        // committed on its own, and on one that rolled back past the wallet written before
         insertWallet("Written before the transaction", "icon", "EUR", "note", true, 0L, false, "tag");
         try {
             mDatabase.<Long>inTransaction(() -> {
-                // and this one inside it, so a refusal that rolled back is told apart from a
-                // refusal that merely threw
                 insertWallet("Written before the nested call", "icon", "EUR", "note", true, 0L, false, "tag");
-                return mDatabase.inTransaction(() ->
+                long nested = mDatabase.inTransaction(() ->
                         insertWallet("Nested", "icon", "EUR", "note", true, 0L, false, "tag"));
+                // the nested call has to have written something for the count below to be
+                // testing a rollback. A build that refused to nest never reaches this line, and
+                // one that ran the body and threw the row away would fail here
+                assertTrue("the nested call inserted nothing", nested > 0L);
+                // its own type. IllegalStateException is what a build that refuses to nest throws
+                // from the line above, and a catch on that type below cannot tell the two apart
+                throw new ImportStopped();
             });
-            fail("a nested inTransaction was allowed");
-        } catch (IllegalStateException expected) {
-            // it has to refuse. Android rolls the whole transaction back when an inner frame ends
-            // unsuccessfully and says nothing, so an outer body that swallowed the inner failure
-            // would reach the end of inTransaction believing it had committed
+            fail("the body's exception did not leave inTransaction");
+        } catch (ImportStopped expected) {
+            // this is the failure the import path has to survive, a row is refused after earlier
+            // rows have gone in through the provider, each of those opening a transaction of its
+            // own. Only the wallet written before the outer transaction may be left
         }
-        // the refusal left the outer body, so the outer transaction rolled back and took the
-        // wallet written inside it with it, and left the one written before it alone
         checkCursorSize(mDatabase.getWallets(null, null, null, null), 1);
+    }
+
+    /** How the case below ends its import, told apart from anything the app itself raises. */
+    private static class ImportStopped extends RuntimeException {
+    }
+
+    /** The values an import builds for a wallet it has to create before it can use one. */
+    private ContentValues walletValues(String name) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(Contract.Wallet.NAME, name);
+        contentValues.put(Contract.Wallet.ICON, "icon");
+        contentValues.put(Contract.Wallet.CURRENCY, "EUR");
+        contentValues.put(Contract.Wallet.COUNT_IN_TOTAL, true);
+        contentValues.put(Contract.Wallet.START_MONEY, 0L);
+        contentValues.put(Contract.Wallet.ARCHIVED, false);
+        return contentValues;
+    }
+
+    /**
+     * A transaction naming a wallet and a category that are not there. Every column the table
+     * insists on is filled, so the only thing wrong with this row is the two ids, and the insert
+     * fails on them and not on something left out.
+     */
+    private ContentValues transactionValuesOnMissingRows() {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(Contract.Transaction.WALLET_ID, 987654321L);
+        contentValues.put(Contract.Transaction.CATEGORY_ID, 987654321L);
+        contentValues.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(new Date()));
+        contentValues.put(Contract.Transaction.MONEY, 1000L);
+        contentValues.put(Contract.Transaction.DIRECTION, Contract.Direction.EXPENSE);
+        contentValues.put(Contract.Transaction.TYPE, Contract.TransactionType.STANDARD);
+        contentValues.put(Contract.Transaction.CONFIRMED, true);
+        contentValues.put(Contract.Transaction.COUNT_IN_TOTAL, true);
+        return contentValues;
+    }
+
+    /**
+     * The whole of what this change buys an import, driven the way an import drives it: rows in
+     * through the provider, one refused part way, and nothing left behind.
+     */
+    @Test
+    public void aRowTheProviderRefusesTakesEveryRowBeforeItBackOut() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        try {
+            DataContentProvider.runInOneTransaction(mContext, () -> {
+                Uri saved = contentResolver.insert(DataContentProvider.CONTENT_WALLETS,
+                        walletValues("Saved before the refused row"));
+                assertNotNull("the provider refused a wallet that is fine", saved);
+                // foreign keys are on, so this one cannot go in, and the provider says so by
+                // answering nothing. An importer that ignored that answer is what used to let a
+                // refused row disappear while the import reported that it had worked
+                Uri refused = contentResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS,
+                        transactionValuesOnMissingRows());
+                assertNull("the provider took a transaction on a wallet that does not exist, so "
+                        + "this case is no longer testing a refusal", refused);
+                // its own type, and not one the code under test also raises. Catching
+                // IllegalStateException here would swallow the one a provider write throws when
+                // it refuses to run inside a transaction already open, and this case would go
+                // green on a build where no row ever reached the database
+                throw new ImportStopped();
+            });
+            fail("the failure did not leave runInOneTransaction");
+        } catch (ImportStopped expected) {
+            // the importers all end the import here, and the transaction has to go with it
+        }
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 0);
+    }
+
+    @Test
+    public void everyRowOfAnImportThatFinishesIsThere() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        DataContentProvider.runInOneTransaction(mContext, () -> {
+            contentResolver.insert(DataContentProvider.CONTENT_WALLETS, walletValues("First"));
+            contentResolver.insert(DataContentProvider.CONTENT_WALLETS, walletValues("Second"));
+            return null;
+        });
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 2);
+    }
+
+    /**
+     * Watches the wallet list the way an open list screen does, descendants included, so it hears
+     * about a write whichever uri that write announces.
+     */
+    private CountDownLatch watchWallets(ContentResolver contentResolver, ContentObserver[] out) {
+        return watch(contentResolver, DataContentProvider.CONTENT_WALLETS, true, out);
+    }
+
+    private CountDownLatch watch(ContentResolver contentResolver, Uri uri, boolean descendants,
+                                 ContentObserver[] out) {
+        CountDownLatch told = new CountDownLatch(1);
+        ContentObserver observer = new ContentObserver(new Handler(Looper.getMainLooper())) {
+
+            @Override
+            public void onChange(boolean selfChange) {
+                told.countDown();
+            }
+        };
+        contentResolver.registerContentObserver(uri, descendants, observer);
+        out[0] = observer;
+        return told;
+    }
+
+    /**
+     * What an import announces, and what that reaches. Both watchers here take descendants off, so
+     * each one hears about exactly one uri: the list watcher only if the list itself was
+     * announced, and the row watcher only if announcing the list reaches the rows under it.
+     *
+     * The second half is the reason an import is allowed to remember one uri per list instead of
+     * one per row, and it is a claim about the framework, so it is checked here and not argued.
+     */
+    @Test
+    public void anImportAnnouncesTheListAndReachesTheRowsUnderIt() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        long existing = insertWallet("Open on a detail screen", "icon", "EUR", "note", true, 0L, false, "tag");
+        ContentObserver[] listObserver = new ContentObserver[1];
+        ContentObserver[] rowObserver = new ContentObserver[1];
+        CountDownLatch listTold = watch(contentResolver, DataContentProvider.CONTENT_WALLETS, false, listObserver);
+        CountDownLatch rowTold = watch(contentResolver,
+                ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, existing), false, rowObserver);
+        try {
+            DataContentProvider.runInOneTransaction(mContext, () -> contentResolver.insert(
+                    DataContentProvider.CONTENT_WALLETS, walletValues("Imported")));
+            assertTrue("the import announced the row it wrote instead of the list it wrote into",
+                    listTold.await(5, TimeUnit.SECONDS));
+            assertTrue("announcing the list did not reach a screen watching a row under it, so "
+                            + "remembering the list instead of the row loses a watcher",
+                    rowTold.await(5, TimeUnit.SECONDS));
+        } finally {
+            contentResolver.unregisterContentObserver(listObserver[0]);
+            contentResolver.unregisterContentObserver(rowObserver[0]);
+        }
+    }
+
+    @Test
+    public void anImportThatFinishesTellsTheOpenScreens() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        ContentObserver[] observer = new ContentObserver[1];
+        CountDownLatch told = watchWallets(contentResolver, observer);
+        try {
+            DataContentProvider.runInOneTransaction(mContext, () -> {
+                assertNotNull("the provider refused a wallet that is fine, so this case is no "
+                                + "longer testing an import that wrote anything",
+                        contentResolver.insert(DataContentProvider.CONTENT_WALLETS, walletValues("Imported")));
+                return null;
+            });
+            // that an import which finished says something at all. It does not pin WHEN, since a
+            // latch that has already counted down reads the same either way, and an import that
+            // announced every row as it went would satisfy this too. What pins the holding back
+            // is anImportThatFailedAnnouncesNothing, where an announcement must never arrive
+            assertTrue("nothing was announced after the import committed",
+                    told.await(5, TimeUnit.SECONDS));
+        } finally {
+            contentResolver.unregisterContentObserver(observer[0]);
+        }
+    }
+
+    @Test
+    public void anImportThatFailedAnnouncesNothing() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        ContentObserver[] observer = new ContentObserver[1];
+        CountDownLatch told = watchWallets(contentResolver, observer);
+        try {
+            DataContentProvider.runInOneTransaction(mContext, () -> {
+                assertNotNull("the provider refused a wallet that is fine, so there is no row for "
+                                + "this case to roll back",
+                        contentResolver.insert(DataContentProvider.CONTENT_WALLETS, walletValues("Rolled back")));
+                throw new ImportStopped();
+            });
+            fail("the failure did not leave runInOneTransaction");
+        } catch (ImportStopped expected) {
+            // the wallet above went in and came back out, and announcing it would send every open
+            // screen to look for a row that is not there. Checked here and not in the finally,
+            // where a failure of its own would replace the one the case was really reporting and
+            // leave the observer registered on the process wide resolver for the rest of the run
+            assertFalse("a row that was rolled back was announced anyway",
+                    told.await(2, TimeUnit.SECONDS));
+        } finally {
+            contentResolver.unregisterContentObserver(observer[0]);
+        }
+    }
+
+    @Test
+    public void anImportInsideAnImportIsOneImport() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        ContentObserver[] observer = new ContentObserver[1];
+        CountDownLatch told = watchWallets(contentResolver, observer);
+        try {
+            DataContentProvider.runInOneTransaction(mContext, () -> {
+                // the inner has to run the body. Every assertion this case makes afterwards is a
+                // negative one, so an inner branch that returned without calling the body at all
+                // would satisfy every one of them
+                assertNotNull("the nested call wrote nothing",
+                        DataContentProvider.runInOneTransaction(mContext, () -> contentResolver.insert(
+                                DataContentProvider.CONTENT_WALLETS, walletValues("Inner"))));
+                // after the inner call returns, and this is the write that matters. An inner call
+                // that cleared what the outer had left on the thread instead of leaving it alone
+                // would send this one straight to the observers, mid transaction
+                assertNotNull("the provider refused a wallet that is fine",
+                        contentResolver.insert(DataContentProvider.CONTENT_WALLETS, walletValues("After the inner")));
+                throw new ImportStopped();
+            });
+            fail("the failure did not leave runInOneTransaction");
+        } catch (ImportStopped expected) {
+            // the inner call must not commit or announce anything of its own. Nothing nests
+            // today, and this is what keeps the first caller that does from announcing rows the
+            // outer transaction then rolls back
+            assertFalse("the inner import announced rows the outer one rolled back",
+                    told.await(2, TimeUnit.SECONDS));
+        } finally {
+            contentResolver.unregisterContentObserver(observer[0]);
+        }
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 0);
+    }
+
+    /**
+     * The success path of the same nesting, which is where an inner call that kept a set of its
+     * own would show. Its row would go in and the outer commit would announce only what the outer
+     * itself wrote, so an open screen would never hear about the rows the inner call made.
+     */
+    @Test
+    public void anImportInsideAnImportAnnouncesTheInnerRowsToo() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        ContentObserver[] observer = new ContentObserver[1];
+        CountDownLatch told = watch(contentResolver, DataContentProvider.CONTENT_WALLETS, false, observer);
+        try {
+            DataContentProvider.runInOneTransaction(mContext, () -> {
+                assertNotNull("the nested call wrote nothing",
+                        DataContentProvider.runInOneTransaction(mContext, () -> contentResolver.insert(
+                                DataContentProvider.CONTENT_WALLETS, walletValues("Inner"))));
+                return null;
+            });
+            assertTrue("the row the nested call wrote was never announced",
+                    told.await(5, TimeUnit.SECONDS));
+        } finally {
+            contentResolver.unregisterContentObserver(observer[0]);
+        }
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 1);
+    }
+
+    /**
+     * The two importers both throw a checked exception, and the transaction body cannot declare
+     * one, so runInOneTransaction wraps it on the way in and unwraps it on the way out. Every
+     * other case here throws an unchecked one and never reaches that path.
+     */
+    @Test
+    public void aCheckedFailureLeavesTheImportAsItself() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        IOException thrown = new IOException("the backup file ended early");
+        try {
+            DataContentProvider.runInOneTransaction(mContext, () -> {
+                assertNotNull("the provider refused a wallet that is fine, so there is no row for "
+                                + "this case to roll back",
+                        contentResolver.insert(DataContentProvider.CONTENT_WALLETS, walletValues("Rolled back")));
+                throw thrown;
+            });
+            fail("the failure did not leave runInOneTransaction");
+        } catch (IOException expected) {
+            // the same object, not one that merely reads the same. The screen that reports a
+            // failed import branches on what it caught, and a build that rebuilt the failure from
+            // its message would keep the words and lose the type
+            assertSame("the failure was rebuilt on the way out instead of carried out", thrown, expected);
+        }
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 0);
+    }
+
+    @Test
+    public void aNestedInTransactionCommitsWithTheOuterOne() {
+        long nestedId = mDatabase.inTransaction(() -> {
+            insertWallet("Written before the nested call", "icon", "EUR", "note", true, 0L, false, "tag");
+            return mDatabase.inTransaction(() ->
+                    insertWallet("Nested", "icon", "EUR", "note", true, 0L, false, "tag"));
+        });
+        assertTrue("the nested call did not insert a row", nestedId > 0L);
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 2);
     }
 
     @Test
@@ -1453,6 +1739,69 @@ public class SQLDatabaseTest {
         assertFalse("the attachment file outlived a committed delete", file.exists());
         checkCursorSize(mDatabase.getWallets(null, null, null, null), 0);
         assertRowCount(Schema.Attachment.TABLE, null, 0);
+    }
+
+    /**
+     * The attachment names a nested body collects belong to the outer transaction. A nested call
+     * that started a list of its own, or cleared the one already there, would leave this file on
+     * the volume forever with no row naming it, and every count in this case would still be right.
+     */
+    @Test
+    public void aNestedDeleteHandsItsAttachmentFilesToTheOuterCommit() throws Exception {
+        File file = writeAttachmentFile("path1");
+        long walletId = walletWithAnAttachedTransaction("path1");
+        mDatabase.inTransaction(() -> mDatabase.inTransaction(() -> mDatabase.deleteWallet(walletId)));
+        assertFalse("the file removed by the nested body outlived the outer commit", file.exists());
+        assertRowCount(Schema.Attachment.TABLE, null, 0);
+    }
+
+    /**
+     * The rollback half of the case above. A nested body that collected the names into a list of
+     * its own and deleted them itself would pass that one, and would leave this rollback holding
+     * rows that name files already gone from the volume.
+     *
+     * Its own file name, because the attachment folder is not cleaned between cases and another
+     * one deliberately leaves path1 behind, which would make the assertion below pass on its own.
+     */
+    @Test
+    public void aRolledBackNestedDeleteLeavesItsAttachmentFileOnDisk() throws Exception {
+        File file = writeAttachmentFile("pathNestedRollback");
+        long walletId = walletWithAnAttachedTransaction("pathNestedRollback");
+        try {
+            mDatabase.<Integer>inTransaction(() -> {
+                mDatabase.inTransaction(() -> mDatabase.deleteWallet(walletId));
+                throw new ImportStopped();
+            });
+            fail("the body's exception did not leave inTransaction");
+        } catch (ImportStopped expected) {
+            // the delete came back out, so the file the nested body collected has to still be here
+        }
+        assertTrue("the nested body deleted its attachment file before the outer transaction "
+                + "committed, and the rollback has put back rows that name it", file.exists());
+        assertRowCount(Schema.Attachment.TABLE, null, 1);
+    }
+
+    /**
+     * The case the join exists for, and the only one that tells it apart from a real nested pair.
+     * Android rolls the whole transaction back when an inner frame ends unmarked and says nothing,
+     * so under a nested pair the row written after the catch would disappear at the commit while
+     * this method returned as though it had worked.
+     */
+    @Test
+    public void anOuterBodyThatCatchesANestedFailureStillCommits() {
+        mDatabase.inTransaction(() -> {
+            insertWallet("Written before the nested call", "icon", "EUR", "note", true, 0L, false, "tag");
+            try {
+                mDatabase.<Long>inTransaction(() -> {
+                    throw new ImportStopped();
+                });
+                fail("the nested body's exception did not leave inTransaction");
+            } catch (ImportStopped caughtAndCarriedOn) {
+                // exactly what the old refusal made impossible and the join has to survive
+            }
+            return insertWallet("Written after the catch", "icon", "EUR", "note", true, 0L, false, "tag");
+        });
+        checkCursorSize(mDatabase.getWallets(null, null, null, null), 2);
     }
 
     @Test(expected = SQLiteDataException.class)

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -36,7 +36,10 @@ import com.oriondev.moneywallet.BuildConfig;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.widget.WalletWidgetProvider;
 
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
 
 /**
  * Created by andrea on 17/01/18.
@@ -608,11 +611,8 @@ public class DataContentProvider extends ContentProvider {
         Uri objectUri = SQLDatabase.inSharedTransaction(getContext(),
                 database -> insertInTransaction(database, uri, contentValues));
         if (objectUri != null) {
-            PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
-            ContentResolver contentResolver = getContentResolver();
-            if (contentResolver != null) {
-                contentResolver.notifyChange(objectUri, null);
-            }
+            // the list, not the row, for the import path. See notifyObservers
+            notifyObservers(objectUri, uri);
         }
         return objectUri;
     }
@@ -691,7 +691,13 @@ public class DataContentProvider extends ContentProvider {
         // it writes a preference and broadcasts to every open screen and neither of those can be
         // rolled back. Reading the preference after the delete is the same read, nothing in the
         // database is what it answers from. Every wallet delete still passes through this point,
-        // which is the reason it lives in the provider and not in the screen that starts one
+        // which is the reason it lives in the provider and not in the screen that starts one.
+        //
+        // Being out here no longer means the delete has committed. A delete made inside
+        // runInOneTransaction commits only when that import does, so an import that deleted the
+        // wallet in use and then failed leaves the wallet back in the ledger with the preference
+        // already moved off it. Nothing deletes inside one today, and whoever writes the first
+        // importer that does has to answer this
         Context context = getContext();
         if (result > 0 && context != null && mUriMatcher.match(uri) == WALLET_ITEM
                 && ContentUris.parseId(uri) == PreferenceManager.getCurrentWallet()) {
@@ -699,10 +705,8 @@ public class DataContentProvider extends ContentProvider {
             // filter reaches keeps filtering on it, so all of them come back with nothing
             PreferenceManager.setCurrentWallet(context, PreferenceManager.TOTAL_WALLET_ID);
         }
-        ContentResolver contentResolver = getContentResolver();
-        if (contentResolver != null && notifyUri[0] != null) {
-            PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
-            contentResolver.notifyChange(notifyUri[0], null);
+        if (notifyUri[0] != null) {
+            notifyObservers(notifyUri[0], notifyUri[0]);
         }
         return result;
     }
@@ -783,11 +787,7 @@ public class DataContentProvider extends ContentProvider {
         int result = SQLDatabase.inSharedTransaction(getContext(),
                 database -> updateInTransaction(database, uri, values));
         if (result > 0) {
-            PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
-            ContentResolver contentResolver = getContentResolver();
-            if (contentResolver != null) {
-                contentResolver.notifyChange(uri, null);
-            }
+            notifyObservers(uri, uri);
         }
         return result;
     }
@@ -847,6 +847,115 @@ public class DataContentProvider extends ContentProvider {
     private ContentResolver getContentResolver() {
         Context context = getContext();
         return context != null ? context.getContentResolver() : null;
+    }
+
+    /**
+     * The uris a write on this thread would have announced, while an import holds one transaction
+     * open around it. Null when this thread is not inside one, which is every write outside an
+     * import and so the only path that announces anything the moment it is made.
+     */
+    private static final ThreadLocal<Set<Uri>> sDeferredNotifications = new ThreadLocal<>();
+
+    /**
+     * Tells the observers about a write, or remembers it for {@link #runInOneTransaction} to tell
+     * them once the import it is running has committed. Announcing each row as it goes in would
+     * name rows that are not committed yet, and a failed import rolls every one of them back with
+     * nothing to take the announcements back.
+     *
+     * An import remembers whatToRemember and not the row it wrote. Insert passes the list it
+     * inserted into, so a file of a hundred thousand rows holds one uri instead of a hundred
+     * thousand and fires one announcement at the end instead of a hundred thousand. Nothing is
+     * lost by it, an observer registered on a row below that list is told when the list is
+     * announced, checked on an emulator by anImportAnnouncesTheListAndReachesTheRowsUnderIt and
+     * not reasoned about. Delete and update pass their own uri unchanged, and update's is a row
+     * uri, so an importer that updates rows would go back to one entry each. None does today.
+     */
+    private void notifyObservers(Uri uri, Uri whatToRemember) {
+        Set<Uri> deferred = sDeferredNotifications.get();
+        if (deferred != null) {
+            deferred.add(whatToRemember);
+            return;
+        }
+        PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
+        ContentResolver contentResolver = getContentResolver();
+        if (contentResolver != null) {
+            contentResolver.notifyChange(uri, null);
+        }
+    }
+
+    /**
+     * Runs an import inside one transaction, so a row it refuses part way through takes every row
+     * before it back out. Each row still goes in through a provider, and each of those opens a
+     * transaction of its own; SQLDatabase runs those inline once one is already open on the
+     * thread, so there is one transaction and one commit.
+     *
+     * This covers SyncContentProvider's writes as well as this provider's. Both resolve the same
+     * shared helper, so a transaction opened on it here encloses whatever either of them writes on
+     * this thread. Of the two only this provider announces anything, and those announcements are
+     * held back until the commit. The one thing that is not held back is the preference a wallet
+     * delete writes, which is out of the database entirely and is described where it happens.
+     *
+     * Joining is decided from what this method itself left on the thread, so it catches another
+     * call to this method and nothing else. Calling it from inside a provider write, or from
+     * inside a body SQLDatabase is already running, would not join and would announce while that
+     * transaction is still open. It is the entry point an importer starts from, not something to
+     * reach for once a write is already running.
+     *
+     * What it costs, and it is more than it looks. The database is opened without write ahead
+     * logging, so SQLite hands the whole app one connection, and an open transaction holds it.
+     * Every other thread that touches the ledger waits for the import to finish, reads as well as
+     * writes, and some of those writes are made on the main thread, where waiting is a frozen
+     * screen. Keep what runs in here down to the writes themselves and keep the caller somewhere
+     * that can wait, which the import service and the legacy upgrade service both are.
+     *
+     * Public, and here, because SQLDatabase is package local and the importers sit in a sub
+     * package, so they cannot name it.
+     */
+    public static <T> T runInOneTransaction(Context context, Callable<T> body) throws Exception {
+        if (sDeferredNotifications.get() != null) {
+            // already inside one on this thread, so join it the way SQLDatabase.inTransaction
+            // does. Opening a second would replace the outer's remembered uris with its own and
+            // then announce them while the outer transaction is still open and can still roll back
+            return body.call();
+        }
+        Set<Uri> deferred = new LinkedHashSet<>();
+        sDeferredNotifications.set(deferred);
+        T result;
+        try {
+            result = SQLDatabase.inSharedTransaction(context, database -> {
+                try {
+                    return body.call();
+                } catch (RuntimeException e) {
+                    throw e;
+                } catch (Exception e) {
+                    // the transaction body cannot declare a checked exception, and the importers
+                    // all throw one. Carried out and rethrown below so the caller still sees the
+                    // failure it knows how to report, and not a wrapper around it
+                    throw new CheckedFailure(e);
+                }
+            });
+        } catch (CheckedFailure e) {
+            throw (Exception) e.getCause();
+        } finally {
+            sDeferredNotifications.remove();
+        }
+        // reached only when the transaction committed, so every uri here names rows that are
+        // really in the ledger
+        ContentResolver contentResolver = context.getContentResolver();
+        if (!deferred.isEmpty()) {
+            PreferenceManager.setLastTimeDataIsChanged(System.currentTimeMillis());
+            for (Uri uri : deferred) {
+                contentResolver.notifyChange(uri, null);
+            }
+        }
+        return result;
+    }
+
+    private static class CheckedFailure extends RuntimeException {
+
+        private CheckedFailure(Exception cause) {
+            super(cause);
+        }
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/LegacyEditionImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/LegacyEditionImporter.java
@@ -51,8 +51,41 @@ public class LegacyEditionImporter {
         mDatabaseImporter = new LegacyDatabaseImporter(databaseFile);
     }
 
+    /**
+     * The rows go in inside one transaction, so a failure that reaches this method leaves the
+     * ledger as it was instead of half merged. There is no copy of it to fall back on here, since
+     * this one merges into the database in place and never moves it aside.
+     *
+     * What that does not cover, because it is worth knowing before trusting the sentence above.
+     * A row the current schema will not take throws out of the insert, checked on an emulator and
+     * not reasoned about, and every insert in LegacyDatabaseImporter sits in its own catch that
+     * drops it. So that row is skipped, the upgrade carries on and reports success, and only a
+     * failure that gets past those catches reaches the rollback. Moving the attachment files is a
+     * second step that runs after this one has committed, so its failures cannot be undone either;
+     * the attachment rows are in here with everything else.
+     *
+     * The legacy file is closed and deleted after the transaction and not inside it. Deleting it
+     * is the one step here that cannot be undone, and a commit that failed with the delete already
+     * done would take the data the upgrade was reading from with it.
+     */
     public void importDatabase() throws ImportException {
         ContentResolver contentResolver = mContext.getContentResolver();
+        try {
+            DataContentProvider.runInOneTransaction(mContext, () -> {
+                importRows(contentResolver);
+                return null;
+            });
+        } catch (ImportException | RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new ImportException(e.getMessage());
+        }
+        // close the database file in order to delete the file on disk
+        mDatabaseImporter.close();
+        mContext.deleteDatabase(DATABASE_NAME);
+    }
+
+    private void importRows(ContentResolver contentResolver) throws ImportException {
         mDatabaseImporter.importWallets(contentResolver);
         mDatabaseImporter.importCategories(contentResolver);
         mDatabaseImporter.importEvents(contentResolver);
@@ -76,9 +109,6 @@ public class LegacyEditionImporter {
         mDatabaseImporter.importAttachments(contentResolver);
         mDatabaseImporter.importTransactionAttachments(contentResolver);
         mDatabaseImporter.importTransferAttachments(contentResolver);
-        // close the database file in order to delete the file on disk
-        mDatabaseImporter.close();
-        mContext.deleteDatabase(DATABASE_NAME);
     }
 
     public void importAttachments() throws ImportException {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -162,7 +162,8 @@ import java.util.function.Supplier;
             // this thread is inside inSharedTransaction and a read hold cannot be upgraded, so
             // asking for the write lock here would wait on itself forever, holding an open
             // transaction and wedging every later write and every later reset in the process.
-            // inTransaction refuses its own version of this mistake for the same reason
+            // An import holds that read hold for all of its rows, so this is further within reach
+            // than it was when the longest hold was one provider write
             throw new IllegalStateException("resetShared called from inside a transaction");
         }
         sSwapLock.writeLock().lock();
@@ -229,16 +230,28 @@ import java.util.function.Supplier;
      * Attachment files the body removed are deleted only once the transaction has committed. A
      * rollback would otherwise restore rows that point at files already gone from the volume.
      *
-     * Not reentrant, on purpose. SQLite would reference count the nesting, but Android rolls the
-     * whole transaction back when an inner frame ends without being marked successful and it does
-     * that silently, with no exception at the outer endTransaction. An outer body that caught the
-     * inner failure and carried on would leave here believing it had committed, and would delete
-     * the attachment files of rows the rollback had just restored. Nothing nests today. Whoever
-     * writes the first nested caller has to answer that before this throw comes out.
+     * A body already inside one on this thread runs straight through instead of opening a second.
+     * That is what lets an import hold one transaction across every row while each row still goes
+     * in through the provider, which opens one of these per write. Joining and not nesting is the
+     * point. SQLite would reference count a nested pair, but Android rolls the whole transaction
+     * back when an inner frame ends without being marked successful, silently, with no exception
+     * at the outer endTransaction. So an outer body that caught an inner failure and carried on
+     * would leave here believing it had committed. Running inline never opens an inner frame, so
+     * that cannot happen.
+     *
+     * What an outer body still has to answer, since the throw that used to stand here made the
+     * question moot. A provider write is several statements, nine of them in deleteWallet, and
+     * one that fails part way now leaves its earlier statements in the outer transaction. An
+     * outer body that swallows that failure and returns normally commits a half applied write.
+     * Nothing does today, and the first caller that swallows a failure from a DataContentProvider
+     * write has to answer it.
+     *
+     * The attachment names an inline body collects belong to the outer transaction and are
+     * deleted when that one commits, which is the same rule one level up.
      */
     /*package-local*/ <T> T inTransaction(Supplier<T> body) {
         if (mPendingAttachmentFiles.get() != null) {
-            throw new IllegalStateException("inTransaction is not reentrant");
+            return body.get();
         }
         SQLiteDatabase database = getWritableDatabase();
         mPendingAttachmentFiles.set(new ArrayList<>());

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/AbstractDataImporter.java
@@ -87,7 +87,13 @@ public abstract class AbstractDataImporter {
                 .confirmed(true)
                 .countInTotal(true)
                 .build();
-        contentResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
+        Uri result = contentResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
+        if (result == null) {
+            // the provider refused the row and says so by answering nothing. Every other insert
+            // here already checks, and this one used to drop the answer, so a refused transaction
+            // was skipped in silence and the import went on to report that it had worked
+            throw new RuntimeException("Failed to save the transaction");
+        }
     }
 
     private long getOrCreateWallet(ContentResolver contentResolver, String name, CurrencyUnit currencyUnit) {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
@@ -6,6 +6,7 @@ import com.opencsv.CSVReaderHeaderAware;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.database.data.AbstractDataImporter;
 import com.oriondev.moneywallet.storage.database.data.Constants;
 import com.oriondev.moneywallet.utils.CurrencyManager;
@@ -127,14 +128,27 @@ public class CSVDataImporter extends AbstractDataImporter {
         try (CSVReaderHeaderAware check = openReader()) {
             readRows(check, false);
         }
-        readRows(mReader, true);
+        // only the saving pass. The transaction holds the one database connection the whole app
+        // has, so reading the file inside it would hold that connection across a full parse for
+        // nothing, twice over on a file that is fine
+        try {
+            DataContentProvider.runInOneTransaction(getContext(), () -> {
+                readRows(mReader, true);
+                return null;
+            });
+        } catch (IOException | RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException(e);
+        }
     }
 
     /**
      * Reads every row and throws on the first bad one. Saves a row only when write is true.
-     * {@link #importData} calls this twice, with write off and then on, so that a bad file is
-     * caught before anything is saved. Saving itself can still fail part way through, and whatever
-     * {@link #insertTransaction} already saved stays.
+     * {@link #importData} calls this twice, with write off and then on. The first pass is what
+     * names the line a bad row is on, and it keeps a file that was never going to work from
+     * opening a write transaction at all. A row the database itself refuses reaches only the
+     * second pass, and the transaction that pass runs in takes the rows before it back out.
      */
     private void readRows(CSVReaderHeaderAware reader, boolean write) throws IOException {
         Map<String, String> lineMap = reader.readMap();

--- a/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserver.java
@@ -48,9 +48,10 @@ import com.oriondev.moneywallet.storage.database.DataContentProvider;
 public class WalletWidgetObserver extends ContentObserver {
 
     /**
-     * Long enough to fold an import into one redraw and short enough that a save the user just
-     * made looks immediate. A CSV import writes one row at a time and the provider notifies on
-     * each, so without this a file of five thousand rows would ask for five thousand redraws.
+     * Long enough to fold a run of writes into one redraw and short enough that a save the user
+     * just made looks immediate. An import is no longer the case that needs it, since those now
+     * announce once per list after their transaction commits. Anything that writes a row at a
+     * time still is, a wallet delete taking its transactions with it being the one to picture.
      */
     private static final long COALESCE_DELAY_MILLIS = 250L;
 


### PR DESCRIPTION
Importing a file used to save it one row at a time, each row on its own. If
the app refused a row half way down, everything above it stayed in your ledger
while the screen told you the import had failed. You could not tell how much
had landed, and running it again would double whatever did.

An import now saves as one piece. If any row fails, your ledger is exactly
what it was before you started.

The other half of it is that when the app refused a row, it said so by
answering nothing, and the import was throwing that answer away. A row the
database would not take vanished without a word and the import carried on and
reported success. That answer is now read, and a refused row is what ends the
import.

This covers the two places that read a whole file in: bringing a spreadsheet
of transactions in, and the one time upgrade that pulls a ledger over from the
old edition of the app. The upgrade is the one that had nothing at all before,
since it merges straight into your live ledger with no copy set aside.

What it costs. The app has one connection to its database, and saving a file
as one piece holds that connection for as long as the import runs, so anything
else the app wants to do with your ledger waits for it to finish. On a few
thousand rows that is a couple of seconds. Both imports run in the background
with a progress dialog up.

Two limitations worth naming. The upgrade from the old edition skips rows it
cannot convert and always has, so the all or nothing part covers a failure it
cannot skip, not every failure. And moving the attachment files over is a
separate step that runs after the ledger is saved, so a failure there cannot
be put back.

Tested on an emulator, including a real file imported through the app's own
import screen and read back out of the database.
