### PR TITLE
Build a restore in a staging file and swap it in

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -43,6 +43,7 @@ import com.oriondev.moneywallet.model.Attachment;
 import com.oriondev.moneywallet.model.ColorIcon;
 import com.oriondev.moneywallet.model.Money;
 import com.oriondev.moneywallet.utils.DateUtils;
+import org.apache.commons.io.FileUtils;
 
 import org.junit.After;
 import org.junit.Before;
@@ -158,7 +159,7 @@ public class SQLDatabaseTest {
         // case makes cannot land on the real database when the wrapper is the thing that is broken
         targetContext.deleteDatabase(TestStorageContext.PREFIX + SQLDatabase.DATABASE_NAME);
         // create a new database for testing purposes
-        mDatabase = new SQLDatabase(mContext);
+        mDatabase = new SQLDatabase(mContext, SQLDatabase.DATABASE_NAME);
         // and ask SQLDatabase which file it actually opened, whichever way it got there
         assertEquals(testDatabase.getPath(), mDatabase.getWritableDatabase().getPath());
         // point the process wide shared helper at the same test file. These cases run inside the
@@ -169,7 +170,7 @@ public class SQLDatabaseTest {
         // real one back afterwards
         SQLDatabase.resetShared(mContext);
         assertEquals(testDatabase.getPath(),
-                SQLDatabase.getShared(mContext).getWritableDatabase().getPath());
+                sharedPath());
     }
 
     /**
@@ -180,6 +181,10 @@ public class SQLDatabaseTest {
      */
     @After
     public void releaseSharedHelper() {
+        // the staged import goes first. A case that opened one and failed before closing it would
+        // otherwise leave this thread writing into the staged file for every later case in the
+        // run, since the redirect lives on the thread and the runner reuses it
+        SQLDatabase.closeStaging();
         SQLDatabase.resetShared(InstrumentationRegistry.getInstrumentation().getTargetContext());
     }
 
@@ -191,6 +196,8 @@ public class SQLDatabaseTest {
         mDatabase.close();
         Context targetContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
         targetContext.deleteDatabase(TestStorageContext.PREFIX + SQLDatabase.DATABASE_NAME);
+        targetContext.deleteDatabase(
+                TestStorageContext.PREFIX + SQLDatabaseImporter.STAGING_DATABASE_NAME);
         // the database the build under test owns was not unlinked, and was not replaced by a
         // smaller one. Against the size setUp saw and not against zero, so a device without that
         // database reads nothing against nothing and passes instead of failing every case
@@ -1239,22 +1246,22 @@ public class SQLDatabaseTest {
         // the assertion that everything below rests on. If the wrapper were bypassed here the
         // shared helper would be the real ledger, and these cases would be writing into it
         assertEquals(mContext.getDatabasePath(SQLDatabase.DATABASE_NAME).getPath(),
-                SQLDatabase.getShared(mContext).getWritableDatabase().getPath());
+                sharedPath());
     }
 
     @Test
     public void resetSharedReplacesTheInstanceAndGetSharedKeepsIt() {
-        SQLDatabase first = SQLDatabase.getShared(mContext);
+        SQLDatabase first = shared();
         assertTrue("getShared handed back two helpers for one process",
-                first == SQLDatabase.getShared(mContext));
+                first == shared());
         SQLDatabase.resetShared(mContext);
         assertFalse("resetShared left the old helper installed",
-                first == SQLDatabase.getShared(mContext));
+                first == shared());
     }
 
     @Test
     public void inSharedTransactionRunsOnTheSharedHelperAndRollsBack() {
-        SQLDatabase shared = SQLDatabase.getShared(mContext);
+        SQLDatabase shared = shared();
         try {
             SQLDatabase.<Long>inSharedTransaction(mContext, database -> {
                 assertTrue("the body was handed a different helper than the transaction was "
@@ -1376,7 +1383,7 @@ public class SQLDatabaseTest {
      */
     @Test
     public void resetSharedRunsTheWorkWithTheFileClosedAndReplacesTheHelperAfterIt() {
-        SQLDatabase first = SQLDatabase.getShared(mContext);
+        SQLDatabase first = shared();
         SQLiteDatabase open = first.getWritableDatabase();
         assertTrue("the helper was not open before the swap", open.isOpen());
         final boolean[] ran = new boolean[1];
@@ -1385,16 +1392,16 @@ public class SQLDatabaseTest {
             assertFalse("the work ran with the database still open", open.isOpen());
             // and before the replacement, which is what leaves the path free for the rename
             assertTrue("the helper was replaced before the work ran",
-                    SQLDatabase.getShared(mContext) == first);
+                    shared() == first);
         });
         assertTrue("the work never ran", ran[0]);
         assertFalse("resetShared left the old helper installed",
-                SQLDatabase.getShared(mContext) == first);
+                shared() == first);
     }
 
     @Test
     public void resetSharedInstallsAWorkingHelperEvenWhenTheWorkThrows() {
-        SQLDatabase first = SQLDatabase.getShared(mContext);
+        SQLDatabase first = shared();
         try {
             SQLDatabase.resetShared(mContext, () -> {
                 throw new IllegalStateException("forced from the work");
@@ -1404,12 +1411,257 @@ public class SQLDatabaseTest {
             // it has to leave, since the caller is the one that knows what a failed file swap
             // means. What must not happen is the helper being left closed behind it
         }
-        SQLDatabase replacement = SQLDatabase.getShared(mContext);
+        SQLDatabase replacement = shared();
         assertFalse("the closed helper was left installed after the work threw",
                 replacement == first);
         assertTrue("the helper installed after the work threw cannot open the database",
                 replacement.getWritableDatabase().isOpen());
     }
+
+    private ContentValues wallet(String name) {
+        ContentValues values = new ContentValues();
+        values.put(Contract.Wallet.NAME, name);
+        values.put(Contract.Wallet.ICON, "icon");
+        values.put(Contract.Wallet.CURRENCY, "EUR");
+        values.put(Contract.Wallet.NOTE, "note");
+        values.put(Contract.Wallet.COUNT_IN_TOTAL, true);
+        values.put(Contract.Wallet.START_MONEY, 0L);
+        values.put(Contract.Wallet.ARCHIVED, false);
+        values.put(Contract.Wallet.TAG, "tag");
+        return values;
+    }
+
+    /**
+     * A wallet row as a restore writes one. SyncContentProvider inserts raw with no defaults of
+     * its own, so the columns SQLDatabase.insertWallet would have generated have to be here.
+     */
+    private ContentValues syncWallet(String name) {
+        ContentValues values = new ContentValues();
+        values.put(Schema.Wallet.NAME, name);
+        values.put(Schema.Wallet.ICON, "icon");
+        values.put(Schema.Wallet.CURRENCY, "EUR");
+        values.put(Schema.Wallet.START_MONEY, 0L);
+        values.put(Schema.Wallet.COUNT_IN_TOTAL, true);
+        values.put(Schema.Wallet.ARCHIVED, false);
+        values.put(Schema.Wallet.INDEX, 0);
+        values.put(Schema.Wallet.NOTE, "note");
+        values.put(Schema.Wallet.TAG, "tag");
+        values.put(Schema.Wallet.UUID, java.util.UUID.randomUUID().toString());
+        values.put(Schema.Wallet.LAST_EDIT, System.currentTimeMillis());
+        values.put(Schema.Wallet.DELETED, false);
+        return values;
+    }
+
+    /** Counts through whichever file this thread is currently resolving. */
+    private long sharedWalletsNamed(String name) {
+        Cursor cursor = SQLDatabase.getShared(mContext).getReadableDatabase().rawQuery(
+                "SELECT COUNT(*) FROM " + Schema.Wallet.TABLE
+                        + " WHERE " + Schema.Wallet.NAME + " = ?", new String[]{name});
+        try {
+            cursor.moveToFirst();
+            return cursor.getLong(0);
+        } finally {
+            cursor.close();
+        }
+    }
+
+    /** The helper this thread resolves, which is the staged one while a staged import is open. */
+    private SQLDatabase shared() {
+        return SQLDatabase.getShared(mContext);
+    }
+
+    /** The file this thread is open on. */
+    private String sharedPath() {
+        return SQLDatabase.getShared(mContext).getWritableDatabase().getPath();
+    }
+
+    /**
+     * The claim the whole redesign rests on, and the reason the redirect is per thread. The
+     * importing thread has to write into the staged file, and every other thread has to go on
+     * writing into the live ledger, because that is what keeps the live file name still and lets
+     * every read in the app run with no lock at all.
+     *
+     * The first assertion is the one that matters. A staged name resolving to the live file
+     * would make everything below pass without testing anything.
+     */
+    @Test
+    public void aStagedImportRedirectsItsOwnThreadAndNoOther() throws InterruptedException {
+        final String onImporter = "Written on the importing thread";
+        final String onOther = "Written on another thread";
+        File live = mContext.getDatabasePath(SQLDatabase.DATABASE_NAME);
+        File staged = mContext.getDatabasePath(SQLDatabaseImporter.STAGING_DATABASE_NAME);
+        assertFalse("the staged name resolves to the live file, so nothing below can fail",
+                live.getPath().equals(staged.getPath()));
+        assertEquals(live.getPath(), sharedPath());
+
+        final String[] otherPath = new String[1];
+        final Throwable[] otherFailure = new Throwable[1];
+        SQLDatabase.openStaging(mContext, SQLDatabaseImporter.STAGING_DATABASE_NAME);
+        try {
+            assertEquals("the importing thread did not follow the staged name",
+                    staged.getPath(), sharedPath());
+            SQLDatabase.inSharedTransaction(mContext,
+                    database -> database.insertWallet(wallet(onImporter)));
+
+            Thread other = new Thread(() -> {
+                try {
+                    otherPath[0] = sharedPath();
+                    SQLDatabase.inSharedTransaction(mContext,
+                            database -> database.insertWallet(wallet(onOther)));
+                } catch (Throwable t) {
+                    otherFailure[0] = t;
+                }
+            });
+            other.start();
+            other.join();
+        } finally {
+            SQLDatabase.closeStaging();
+        }
+        assertNull("the other thread failed: " + otherFailure[0], otherFailure[0]);
+        assertEquals("another thread was redirected to the staged file too",
+                live.getPath(), otherPath[0]);
+        assertEquals("the importing thread did not come back to the live database",
+                live.getPath(), sharedPath());
+
+        assertEquals("the other thread row is not in the live ledger",
+                1, sharedWalletsNamed(onOther));
+        assertEquals("the staged row reached the live ledger",
+                0, sharedWalletsNamed(onImporter));
+
+        // and the staged row really is in the staged file. Without this the assertion above
+        // passes just as well when the insert wrote nowhere at all
+        SQLDatabase.openStaging(mContext, SQLDatabaseImporter.STAGING_DATABASE_NAME);
+        try {
+            assertEquals("the staged row never reached the staged database",
+                    1, sharedWalletsNamed(onImporter));
+            assertEquals("the other thread row reached the staged database",
+                    0, sharedWalletsNamed(onOther));
+        } finally {
+            SQLDatabase.closeStaging();
+        }
+    }
+
+    /**
+     * The path a restore actually writes on. Every row an import puts in goes ContentResolver to
+     * SyncContentProvider, which resolves the helper on each call and takes no transaction, so a
+     * redirect that only reached inSharedTransaction would leave every restored row in the live
+     * ledger. inSharedTransaction is DataContentProvider entry point and no restore uses it.
+     *
+     * The provider is used against the live ledger first on purpose, and that is what gives this
+     * case its teeth. SyncContentProvider.db resolves the helper on every use instead of holding
+     * it in a field, and its own javadoc says so; hold it in a field instead and the read below
+     * fills that field with the live helper, so the staged insert goes into the ledger and this
+     * case fails. Without the read first, a field would be filled by the staged insert itself and
+     * the same broken provider would pass.
+     */
+    @Test
+    public void aRowWrittenThroughTheSyncProviderFollowsTheStagedRedirect() {
+        final String viaProvider = "Written through the sync provider";
+        ContentResolver resolver = mContext.getContentResolver();
+
+        Cursor warmUp = resolver.query(SyncContentProvider.CONTENT_WALLETS, null, null, null, null);
+        assertNotNull("the sync provider answered nothing on the live ledger", warmUp);
+        warmUp.close();
+
+        SQLDatabase.openStaging(mContext, SQLDatabaseImporter.STAGING_DATABASE_NAME);
+        try {
+            resolver.insert(SyncContentProvider.CONTENT_WALLETS, syncWallet(viaProvider));
+            assertEquals("the row did not reach the staged database",
+                    1, sharedWalletsNamed(viaProvider));
+        } finally {
+            SQLDatabase.closeStaging();
+        }
+        assertEquals("the row written through the sync provider landed in the live ledger",
+                0, sharedWalletsNamed(viaProvider));
+    }
+
+    /**
+     * closeStaging is called from a finally on a path where the open may never have happened, so
+     * calling it with nothing staged, and calling it twice, both have to be no ops. If either
+     * moved this thread off the live database the whole suite after it would read the wrong file.
+     *
+     * The second close here runs against a helper with a connection really open on it, since
+     * openStaging opens the staged file instead of leaving it to the first row.
+     */
+    @Test
+    public void closingAStagedImportIsSafeWithoutOneAndTwiceOver() {
+        File live = mContext.getDatabasePath(SQLDatabase.DATABASE_NAME);
+        SQLDatabase.closeStaging();
+        assertEquals("closing with nothing staged moved this thread", live.getPath(), sharedPath());
+
+        SQLDatabase.openStaging(mContext, SQLDatabaseImporter.STAGING_DATABASE_NAME);
+        SQLDatabase.closeStaging();
+        SQLDatabase.closeStaging();
+        assertEquals("a second close moved this thread off the live database",
+                live.getPath(), sharedPath());
+    }
+
+    /**
+     * An import that writes no rows still has to leave a file behind for the promote to rename.
+     * SQLiteOpenHelper creates the file on first use, so openStaging opens the staged database
+     * itself; without that, a backup whose arrays are all empty writes nothing, the rename finds
+     * no source and the restore reports a failure for a backup with nothing wrong with it. A
+     * legacy backup of an empty install is the reachable one, since that importer reads no
+     * currencies and so has no table that is always written.
+     */
+    @Test
+    public void openingAStagedImportCreatesTheFileBeforeAnyRowIsWritten() {
+        File staged = mContext.getDatabasePath(SQLDatabaseImporter.STAGING_DATABASE_NAME);
+        staged.delete();
+        assertFalse("the precondition failed, a staged file was already on disk", staged.exists());
+
+        SQLDatabase.openStaging(mContext, SQLDatabaseImporter.STAGING_DATABASE_NAME);
+        try {
+            assertTrue("openStaging left no file for the promote to rename", staged.exists());
+        } finally {
+            SQLDatabase.closeStaging();
+        }
+        assertTrue("the staged file went away when the helper closed", staged.exists());
+    }
+
+    /**
+     * Two staged imports on one thread would leak the first helper, leaving a connection open on
+     * a file the promote is about to rename, so the second is refused instead. Nothing does this
+     * today and the refusal is what keeps it that way.
+     */
+    @Test
+    public void aSecondStagedImportOnOneThreadIsRefused() {
+        SQLDatabase.openStaging(mContext, SQLDatabaseImporter.STAGING_DATABASE_NAME);
+        try {
+            SQLDatabase.openStaging(mContext, SQLDatabaseImporter.STAGING_DATABASE_NAME);
+            fail("a second staged import was allowed on one thread");
+        } catch (IllegalStateException expected) {
+            assertTrue("refused for the wrong reason: " + expected.getMessage(),
+                    expected.getMessage().contains("already open"));
+        } finally {
+            SQLDatabase.closeStaging();
+        }
+    }
+
+    /**
+     * What promoteStagedDatabase rests on. It renames the staged file straight over the live one
+     * and deletes nothing ahead of it, so that a rename which fails leaves the user's ledger
+     * where it was. That is only safe if a rename replaces an existing target instead of
+     * refusing it, which is a platform promise and not one this code can make.
+     */
+    @Test
+    public void aRenameOverAnExistingFileReplacesItInOneStep() throws IOException {
+        File live = new File(mContext.getCacheDir(), "rename-live.db");
+        File staged = new File(mContext.getCacheDir(), "rename-staged.db");
+        try {
+            FileUtils.write(live, "the ledger", "UTF-8");
+            FileUtils.write(staged, "the import", "UTF-8");
+            assertTrue("the rename refused an existing target, so a promote would have to delete "
+                            + "the live database first and a failure there would destroy both",
+                    staged.renameTo(live));
+            assertEquals("the import", FileUtils.readFileToString(live, "UTF-8"));
+            assertFalse("the staged file outlived its own rename", staged.exists());
+        } finally {
+            FileUtils.deleteQuietly(live);
+            FileUtils.deleteQuietly(staged);
+        }
+    }
+
 
     @Test
     public void aNestedInTransactionRollsBackWithTheOuterOne() {

--- a/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/BackupHandlerIntentService.java
@@ -219,9 +219,7 @@ public class BackupHandlerIntentService extends IntentService {
                     restoreLocalBackupFile(backup, password);
                 }
                 notifyTaskProgress(ACTION_RESTORE, STATUS_BACKUP_RESTORING, 100);
-                DataContentProvider.notifyDatabaseIsChanged(this);
                 PreferenceManager.setLastTimeDataIsChanged(0L);
-                CurrencyManager.invalidateCache(this);
                 RecurrenceBroadcastReceiver.scheduleRecurrenceTask(this);
                 AutoBackupBroadcastReceiver.scheduleAutoBackupTask(this);
                 notifyTaskFinished(ACTION_RESTORE);
@@ -246,6 +244,20 @@ public class BackupHandlerIntentService extends IntentService {
         try {
             File databaseFile = getDatabasePath(SQLDatabaseImporter.DATABASE_NAME);
             importer.importDatabase(temporaryFolder, databaseFile.getParentFile());
+            // Announced here, between the two, and nowhere else. The ledger is live from the
+            // rename inside importDatabase, so waiting until after the attachments would leave
+            // the current wallet and every widget binding naming rows out of the database that
+            // has just been replaced whenever the attachment pass fails. Announcing in both
+            // places instead is worse. This call writes user state, the current wallet preference
+            // and every widget wallet binding, the app stays interactive for the whole attachment
+            // extraction, and a second announcement would silently undo whatever the user set
+            // during it.
+            //
+            // The currency cache goes with it. It is held in memory and only this reloads it, so
+            // announcing without it makes every screen redraw the restored rows through the
+            // replaced database currencies.
+            DataContentProvider.notifyDatabaseIsChanged(this);
+            CurrencyManager.invalidateCache(this);
             importer.importAttachments(BackupOperation.getAttachmentFolder(this));
         } finally {
             FileUtils.cleanDirectory(temporaryFolder);

--- a/app/src/main/java/com/oriondev/moneywallet/service/BackupOperation.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/BackupOperation.java
@@ -69,9 +69,15 @@ class BackupOperation {
 
     /**
      * Held for the length of a backup or a restore, so the two do not run at once. A restore
-     * renames the live database away and empties the attachment folder, and the auto backup no
-     * longer shares the serial service queue that used to keep them apart. It guards these two
-     * against each other only: attachment writes elsewhere in the app are outside it.
+     * renames its staged file over the live database and empties the attachment folder, and the
+     * auto backup no longer shares the serial service queue that used to keep them apart. It
+     * guards these two against each other only: attachment writes elsewhere in the app are
+     * outside it.
+     *
+     * Both halves still need it. The export is twenty four separate queries, not one snapshot, so
+     * a rename landing in the middle of it would put the old wallets and the new transactions in
+     * one file, and a cursor being read across the swap meets a closed database. The attachment
+     * folder is worse still, importAttachments empties it before it extracts anything.
      */
     static final Object LOCK = new Object();
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -972,13 +972,32 @@ public class DataContentProvider extends ContentProvider {
 
     /**
      * Runs a replacement of the database file with the shared helper closed and no write of this
-     * provider's in flight. The runnable does the file work and nothing else.
+     * provider in flight. The runnable does the file work and nothing else.
      *
      * Public, and here, because SQLDatabase is package local and the importers that replace the
      * database file sit in a sub package, so they cannot name it.
      */
     public static void replaceDatabaseFile(Context context, Runnable swap) {
         SQLDatabase.resetShared(context, swap);
+    }
+
+    /**
+     * Sends the calling thread database work to a file of its own until the matching close. A
+     * restore uses it to build its import somewhere other than the live ledger.
+     *
+     * No other thread is affected and no lock is taken, which is the whole reason the restore
+     * redirect is per thread. Public for the same reason as the method above.
+     */
+    public static void openStagingDatabase(Context context, String name) {
+        SQLDatabase.openStaging(context, name);
+    }
+
+    /**
+     * Closes the calling thread staging database and sends its work back to the live ledger.
+     * Does nothing when there is no staging database, so it is safe in a finally.
+     */
+    public static void closeStagingDatabase() {
+        SQLDatabase.closeStaging();
     }
 
     @SuppressLint("Recycle")

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -79,6 +79,24 @@ import java.util.function.Supplier;
     /*package-local*/ static final String DATABASE_NAME = "database.db";
     private static final int DATABASE_VERSION = 5;
 
+    /**
+     * The helper a restore builds its import in, set only on the thread running that import.
+     *
+     * It is per thread and not per process so that the live database keeps its name for everyone
+     * else while a restore runs, which is what makes the swap safe without any lock on readers.
+     * The name a thread outside the restore resolves is always DATABASE_NAME, that file always
+     * exists, and a caller still holding an older helper after the promote reopens it and gets
+     * the file the restore just put there. Pointing the whole app at the staging file instead
+     * would make the live name movable, and a caller holding a helper across the promote would
+     * then reopen a name that had been renamed away, which SQLiteOpenHelper creates empty.
+     *
+     * What it costs is that a write from another thread during a restore goes into the live
+     * database and is replaced with it, so that write is lost. That is what this app already
+     * did. The alternative was not keeping the write, it was landing it in a half imported
+     * database whose ids name different rows, with foreign keys on.
+     */
+    private static final ThreadLocal<SQLDatabase> sStaging = new ThreadLocal<>();
+
     private static final String ENABLE_FOREIGN_KEYS = "PRAGMA foreign_keys=ON";
 
     private final Context mContext;
@@ -110,24 +128,34 @@ import java.util.function.Supplier;
      * that override being dropped before a case reaches the real ledger.
      */
     /*package-local*/ static synchronized SQLDatabase getShared(Context context) {
+        SQLDatabase staging = sStaging.get();
+        if (staging != null) {
+            // a restore is running on this thread and its rows belong in the file it is building,
+            // not in the ledger it is about to replace. Every other thread falls through to the
+            // shared helper and keeps reading and writing the live database while that happens
+            return staging;
+        }
         if (sShared == null) {
-            sShared = new SQLDatabase(context.getApplicationContext());
+            sShared = new SQLDatabase(context.getApplicationContext(), DATABASE_NAME);
         }
         return sShared;
     }
 
     /**
      * Closes the shared helper and opens a new one, for after a restore has replaced the file on
-     * disk. Both providers reach this through their own notifyDatabaseIsChanged, and calling it
-     * twice in a row is what AbstractBackupImporter does, so it has to be safe to repeat. It is:
-     * the first call leaves a helper that has opened nothing, since SQLiteOpenHelper opens on
-     * first use, and the second discards it at no cost.
+     * disk. It has to be safe to call twice in a row, and one restore does exactly that. The
+     * promote comes through here, and the announcement BackupHandlerIntentService makes once
+     * importDatabase returns comes through here again. A file delete and a preference write run
+     * in between, so the helper the first call installed has normally opened nothing by the time
+     * the second discards it, SQLiteOpenHelper opening on first use. A thread that did reach it
+     * in that window has its connection closed under it, which is the same thing every query on
+     * this database already risks, since queries take no lock.
      *
-     * Why the close has to happen. A restore renames the database aside and writes a new one at
-     * the old path. A write that STARTS after that rename is refused, checked on the emulator and
-     * not reasoned about. It fails with "attempt to write a readonly database", the row does not
-     * land, and the journal is left behind at the path the new database is about to take over.
-     * Closing releases that connection and truncates the journal it left.
+     * Why the close has to happen. A restore renames its staged file over the live one. A write
+     * that STARTS after that rename, on a connection opened before it, is refused; checked on the
+     * emulator and not reasoned about. It fails with "attempt to write a readonly database", the
+     * row does not land, and the journal is left behind at the path the new database has taken
+     * over. Closing releases that connection and truncates the journal it left.
      *
      * Why no write may be in flight while it happens. A transaction belongs to the SQLiteDatabase,
      * and every write method here asks the helper for it again per statement, nine times in
@@ -138,7 +166,8 @@ import java.util.function.Supplier;
      *
      * What it does NOT cover, stated because it is easy to read the lock as wider than it is.
      * SyncContentProvider's own writes do not come through inSharedTransaction, so they are
-     * outside the lock, and the restore's own row inserts are exactly those writes.
+     * outside the lock. A restore's rows travel that path too, and they are not what this leaves
+     * open, since they go into its own staging file and it closes that before any rename here.
      */
     /*package-local*/ static void resetShared(Context context) {
         resetShared(context, null);
@@ -181,11 +210,54 @@ import java.util.function.Supplier;
                     // Either of them throwing would otherwise leave sShared naming a helper that
                     // is closed or half closed, and every later getShared would hand that out for
                     // the rest of the process
-                    sShared = new SQLDatabase(context.getApplicationContext());
+                    sShared = new SQLDatabase(context.getApplicationContext(), DATABASE_NAME);
                 }
             }
         } finally {
             sSwapLock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Sends this thread database work to a file of its own, from here until closeStaging. A
+     * restore calls this before its first row, and every row it then writes through either
+     * provider goes into that file instead of into the ledger.
+     *
+     * No lock is taken and none is needed. Nothing outside this thread can reach this helper,
+     * and opening it does not touch the live database, so the rest of the app carries on
+     * against the ledger as if no restore were running.
+     */
+    /*package-local*/ static void openStaging(Context context, String name) {
+        if (sStaging.get() != null) {
+            throw new IllegalStateException("a staging database is already open on this thread");
+        }
+        SQLDatabase staging = new SQLDatabase(context.getApplicationContext(), name);
+        // opened here instead of being left to the first row. SQLiteOpenHelper creates the file on
+        // first use, so an import that writes no rows at all would leave nothing on disk to put in
+        // place, and the promote would report a failure for a backup with nothing wrong with it. A
+        // legacy backup of an empty install is the reachable one, since that importer reads no
+        // currencies and so has no table that is always written
+        staging.getWritableDatabase();
+        // set last. A helper that failed to open must not be left on this thread
+        sStaging.set(staging);
+    }
+
+    /**
+     * Closes this thread staging helper and sends its work back to the live database. Safe to
+     * call when there is none, so it belongs in a finally.
+     *
+     * A restore calls it before putting the staged file in place, and again on the way out of a
+     * failure. Neither call affects any other thread. The rename would succeed with the file
+     * still open, since it only replaces a directory entry; what has to be avoided is a
+     * connection that survives INTO the new file, which resetShared describes.
+     */
+    /*package-local*/ static void closeStaging() {
+        SQLDatabase staging = sStaging.get();
+        if (staging != null) {
+            // cleared before the close. A close that threw would otherwise leave this thread
+            // pointed at a helper it can no longer use, for as long as the thread lives
+            sStaging.remove();
+            staging.close();
         }
     }
 
@@ -219,8 +291,8 @@ import java.util.function.Supplier;
      */
     private final ThreadLocal<List<String>> mPendingAttachmentFiles = new ThreadLocal<>();
 
-    /*package-local*/ SQLDatabase(Context context) {
-        super(context, DATABASE_NAME, null, DATABASE_VERSION);
+    /*package-local*/ SQLDatabase(Context context, String name) {
+        super(context, name, null, DATABASE_VERSION);
         mContext = context;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabaseImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabaseImporter.java
@@ -34,6 +34,12 @@ public class SQLDatabaseImporter {
 
     public static final String DATABASE_NAME = SQLDatabase.DATABASE_NAME;
 
+    /**
+     * The file a restore builds its import in, beside the live database so that putting it in
+     * place is a rename within one folder and not a copy across volumes.
+     */
+    public static final String STAGING_DATABASE_NAME = "database.staging";
+
     public static long insert(ContentResolver contentResolver, Currency currency) {
         ContentValues contentValues = new ContentValues();
         contentValues.put(Schema.Currency.ISO, currency.mIso);

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SyncContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SyncContentProvider.java
@@ -129,6 +129,10 @@ public class SyncContentProvider extends ContentProvider {
      * One helper means one connection on one file, so the two providers cannot end up with a
      * transaction on one and a write on the other. A field would be a closed handle after a
      * restore, since resetShared closes what it replaces.
+     *
+     * A restore resolves its own staging helper through here. Its rows travel through this
+     * provider on the one thread the import runs on, and getShared answers that thread with the
+     * file the import is building instead of with the live ledger.
      */
     private SQLDatabase db() {
         return SQLDatabase.getShared(getContext());

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/AbstractBackupImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/AbstractBackupImporter.java
@@ -26,7 +26,6 @@ import androidx.annotation.NonNull;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.database.ImportException;
 import com.oriondev.moneywallet.storage.database.SQLDatabaseImporter;
-import com.oriondev.moneywallet.storage.database.SyncContentProvider;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 
 import org.apache.commons.io.FileUtils;
@@ -40,7 +39,16 @@ import java.util.Collections;
  */
 public abstract class AbstractBackupImporter {
 
-    private static final String TEMP_BACKUP_FILE = "database.bk";
+    /**
+     * The aside copy the design before this one made, kept only long enough to roll a failed
+     * restore back. Nothing writes it any more.
+     *
+     * It is still deleted here because deleting it was the job of the method that made it, which
+     * this design removed along with the rollback. A user whose process died part way through a
+     * restore on an older build has one of these sitting in the databases folder, the size of
+     * their whole ledger, and after that removal nothing in the app would ever collect it.
+     */
+    private static final String ABANDONED_BACKUP_COPY = "database.bk";
 
     private final Context mContext;
     private final File mBackupFile;
@@ -52,57 +60,65 @@ public abstract class AbstractBackupImporter {
 
     /**
      * This method imports all the data included in the backup file inside the main database.
-     * The current database is backed-up before starting the import procedure and restored if
-     * something goes wrong. The old data is then permanently removed if success.
+     *
+     * The import is built in a staging file beside the live database and put in place only once
+     * every row is in, so a failure leaves the live database untouched. Nothing has to be rolled
+     * back and no copy of the ledger is kept aside while this runs, which is what the design
+     * before this one needed and this one does not.
+     *
      * @param temporaryFolder folder where temporary data can be stored.
      * @param databaseFolder folder where the database is located.
      * @throws ImportException if an error occur while importing the backup file.
      *
-     * What this does NOT do, because a reader will ask and part of the answer took a device run.
-     * Nothing serializes another thread's DataContentProvider writes against this import. The
-     * recurrence job is the one that needs no user present, it runs off an alarm, and the lock in
-     * BackupHandlerIntentService that serializes backup against restore is not taken anywhere in
-     * that job.
+     * Only this thread is sent to the staging file. The rest of the app keeps reading and
+     * writing the live ledger while the import runs, so a screen open during a restore shows
+     * the old data until the swap and then redraws, instead of watching rows appear.
      *
-     * Such a write is not refused and not held, so it lands wherever the path points at the time.
-     * Between the rename below and the import's first insert that is a database this class has
-     * just emptied. After it, it is the half imported database itself, carrying ids that named
-     * different rows before the restore, and foreign keys are on.
+     * A write made from another thread while this runs therefore goes into the ledger that is
+     * about to be replaced, and is lost. That is what this app already did and it is deliberate.
+     * Sending every thread to the staging file instead would keep such a write, by putting it in
+     * a half imported database whose ids name different rows with foreign keys on, and it would
+     * make the live file name movable, which costs a lock on every read in the app. Refusing
+     * those writes was also built and reverted. The refusal reaches the caller as an exception,
+     * no caller on any of these write paths catches it, and injecting that throw into the
+     * recurrence job on an emulator ended the run with FATAL EXCEPTION on the AsyncTask that
+     * JobIntentService dispatches on, with the process gone. Every component here shares that
+     * one process, so the restore died with it.
      *
-     * Refusing them was built and reverted. The refusal reaches the caller as an exception, no
-     * caller on any of these write paths catches it, and injecting that throw into the recurrence
-     * job on an emulator ended the run with FATAL EXCEPTION on the AsyncTask that JobIntentService
-     * dispatches on, with the process gone; the same trigger without it left the process running.
-     * Every component here shares that one process, so the restore dies with it, half written.
-     * Holding the writes instead blocks whichever thread they arrived on, for as long as the
-     * backup is large.
-     *
-     * Closing this properly means never pointing the live path at a database an import is still
-     * filling, which is an import that builds its database elsewhere and swaps it in at the end.
+     * What this does NOT cover is the attachments. BackupHandlerIntentService runs importDatabase
+     * and then importAttachments, and importAttachments empties the attachment folder before it
+     * extracts anything, so a failure there leaves the new ledger live and the files gone. True
+     * before this change and not made worse by it. No sentence anywhere may call the restore
+     * atomic without naming it.
      */
     public void importDatabase(@NonNull File temporaryFolder, @NonNull File databaseFolder) throws ImportException {
-        File temporary = createBackupCopyOfCurrentDatabase(databaseFolder);
+        File staged = new File(databaseFolder, SQLDatabaseImporter.STAGING_DATABASE_NAME);
         try {
             importDatabase(temporaryFolder);
-            // The categories the user had hidden are remembered by id, and the database that
-            // knew those ids has just been replaced. The rows that went into the new one were
-            // given fresh ids in the order they were read, so the remembered ones now name other
-            // categories. Forgetting them leaves every category showing, where the list starts.
-            PreferenceManager.setCollapsedCategories(Collections.<String>emptySet());
+            promoteStagedDatabase(databaseFolder, staged);
         } catch (ImportException | RuntimeException e) {
             // RuntimeException as well. JSONDatabaseImporter converts IOException and
             // JSONException and catches nothing else, so anything unchecked the provider raises
-            // comes straight through, a full disk being the one to expect. Every one of those
-            // used to skip the rollback and leave the half written import live
-            restoreBackupCopyOfDatabase(databaseFolder, temporary);
+            // comes straight through, a full disk being the one to expect
+            discardStagedDatabase(staged);
             throw e;
+        } finally {
+            // both paths above close it already. This is here for the third one, an Error, which
+            // neither catch takes. Without it a thread that had been sent to the staging file
+            // would keep writing there for as long as it lived, with the real ledger sitting
+            // untouched beside it and nothing to say so
+            DataContentProvider.closeStagingDatabase();
         }
-        // deliberately not in a finally. The rollback above deletes the half imported database
-        // before it renames the backup back, so a rollback that throws has already destroyed one
-        // copy, and a finally here would then delete the only one left. Reached only when the
-        // import succeeded, where the copy is the replaced database and is not wanted, or when
-        // the rollback succeeded, where the rename has already consumed it
-        FileUtils.deleteQuietly(temporary);
+        // out of the try on purpose, so that nothing which can throw runs between the promote and
+        // the end of it. A throw after the ledger has been replaced would reach a catch whose only
+        // job is to discard a staged file that no longer exists, and the caller would be told the
+        // restore failed when it had in fact succeeded.
+        //
+        // The categories the user had hidden are remembered by id, and the database that knew
+        // those ids has just been replaced. The rows that went into the new one were given fresh
+        // ids in the order they were read, so the remembered ones now name other categories.
+        // Forgetting them leaves every category showing, where the list starts.
+        PreferenceManager.setCollapsedCategories(Collections.<String>emptySet());
     }
 
     protected abstract void importDatabase(@NonNull File temporaryFolder) throws ImportException;
@@ -130,47 +146,82 @@ public abstract class AbstractBackupImporter {
         return mContext.getContentResolver();
     }
 
-    /*package-local*/ void notifyImportStarted() {
-        // Before starting to write the database file, it is necessary to notify both the providers
-        // to ensure that they point to the new file (and not the old reference)
-        DataContentProvider.notifyDatabaseIsChanged(mContext);
-        SyncContentProvider.notifyDatabaseIsChanged(mContext);
+    /**
+     * Sends this thread to the staging file, from here to the end of the import. Each importer
+     * calls it once it has opened its backup file and read enough of it to be worth trusting,
+     * and before the first row goes in.
+     *
+     * A staging file already on disk belongs to a restore that died, so it is deleted before the
+     * helper opens, instead of being left for this import to fill on top of.
+     *
+     * Nothing is announced here, and the design before this one had to announce twice at this
+     * point because it had already renamed the live database away. Nothing has changed for
+     * anyone yet, the ledger every other thread reads is the one it was reading a moment ago.
+     * The announcement belongs after the swap, and BackupHandlerIntentService makes it there,
+     * between this import and the attachments.
+     */
+    /*package-local*/ void beginStagedImport() {
+        deleteDatabaseAndJournal(mContext.getDatabasePath(SQLDatabaseImporter.STAGING_DATABASE_NAME));
+        DataContentProvider.openStagingDatabase(mContext, SQLDatabaseImporter.STAGING_DATABASE_NAME);
     }
 
     /**
-     * Both renames happen with the shared helper closed and no DataContentProvider write in
-     * flight. Moving the database while a connection is open on it strands that connection's
-     * journal at the old path and refuses its next write, and moving it while a transaction is
-     * open is worse, the transaction commits into the file this method is putting aside.
+     * Puts the staged import in place. The staging helper closes first, and the rename then runs
+     * in the slot where the live helper is closed too and no DataContentProvider write is in
+     * flight. That is the whole of what the swap lock excludes; SyncContentProvider writes and
+     * every query take no lock at all and can be running while the file moves, which resetShared
+     * says in full. Today the only writers on that provider are the importers themselves, on this
+     * thread. An open connection does not stop the rename itself, rename replaces a directory
+     * entry and does not care what has the file open; it is the connection carried ACROSS the
+     * rename that breaks, which resetShared also describes.
+     *
+     * The rename goes straight over the live database and nothing is deleted ahead of it, so a
+     * rename that fails leaves the ledger where it was and the staged file is the only thing
+     * thrown away. Deleting first would mean a failure here destroyed both.
+     *
+     * The journal beside the live name belongs to the database this just replaced and would be
+     * read as the new one if it stayed, so it goes once the rename has happened. Neither file is
+     * in write ahead logging and both were closed above, so a journal beside either of them is a
+     * leftover and never state the database still needs.
      */
-    private File createBackupCopyOfCurrentDatabase(@NonNull File databaseFolder) throws ImportException {
-        File temporary = new File(databaseFolder, TEMP_BACKUP_FILE);
-        if (temporary.exists()) {
-            FileUtils.deleteQuietly(temporary);
-        }
+    private void promoteStagedDatabase(@NonNull File databaseFolder, @NonNull File staged) throws ImportException {
         File database = new File(databaseFolder, SQLDatabaseImporter.DATABASE_NAME);
-        if (!database.exists()) {
-            return temporary;
+        DataContentProvider.closeStagingDatabase();
+        boolean[] promoted = new boolean[1];
+        DataContentProvider.replaceDatabaseFile(mContext, () -> {
+            promoted[0] = staged.renameTo(database);
+            if (promoted[0]) {
+                FileUtils.deleteQuietly(journalOf(database));
+                FileUtils.deleteQuietly(journalOf(staged));
+            }
+        });
+        if (!promoted[0]) {
+            throw new ImportException("Cannot put the imported database in place");
         }
-        boolean[] renamed = new boolean[1];
-        DataContentProvider.replaceDatabaseFile(mContext, () -> renamed[0] = database.renameTo(temporary));
-        if (!renamed[0]) {
-            throw new ImportException("Cannot backup the old database file");
-        }
-        return temporary;
+        // swept here and not at the start of the import, because until this rename it may be the
+        // only whole ledger the user has. The design before this one renamed the live database
+        // onto that name, so deleting a stale one cost nothing; here there is no replacement, and
+        // an import that fails after the delete would leave the user with neither
+        deleteDatabaseAndJournal(new File(databaseFolder, ABANDONED_BACKUP_COPY));
     }
 
-    private void restoreBackupCopyOfDatabase(@NonNull File databaseFolder, @NonNull File backup) throws ImportException {
-        File database = new File(databaseFolder, SQLDatabaseImporter.DATABASE_NAME);
-        boolean[] restored = new boolean[1];
-        DataContentProvider.replaceDatabaseFile(mContext, () -> {
-            if (database.exists()) {
-                FileUtils.deleteQuietly(database);
-            }
-            restored[0] = !backup.exists() || backup.renameTo(database);
-        });
-        if (!restored[0]) {
-            throw new ImportException("Rollback failed, all data is lost");
-        }
+    /**
+     * Sends this thread back to the live database and throws the staged import away.
+     *
+     * No lock and no swap. A restore that failed part way never touched the live file, so there
+     * is nothing to put back and nothing for another thread to be told about.
+     */
+    private void discardStagedDatabase(@NonNull File staged) {
+        DataContentProvider.closeStagingDatabase();
+        deleteDatabaseAndJournal(staged);
+    }
+
+    private static void deleteDatabaseAndJournal(@NonNull File database) {
+        FileUtils.deleteQuietly(database);
+        FileUtils.deleteQuietly(journalOf(database));
+    }
+
+    private static File journalOf(@NonNull File database) {
+        return new File(database.getPath() + "-journal");
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/DefaultBackupImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/DefaultBackupImporter.java
@@ -67,7 +67,7 @@ public class DefaultBackupImporter extends AbstractBackupImporter {
                     throw new ImportException("Decryption filed: missing user password");
                 }
             }
-            notifyImportStarted();
+            beginStagedImport();
             ZipInputStream inputStream = zipFile.getInputStream(header);
             importer = new JSONDatabaseImporter(inputStream);
             ContentResolver contentResolver = getContentResolver();

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/LegacyBackupImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/backup/LegacyBackupImporter.java
@@ -97,7 +97,7 @@ public class LegacyBackupImporter extends AbstractBackupImporter {
             if (header.isEncrypted()) {
                 header.setPassword(LEGACY_BACKUP_PASSWORD);
             }
-            notifyImportStarted();
+            beginStagedImport();
             // extract the database file inside the temporary folder
             zipFile.extractFile(header, temporaryFolder.getPath(), null, TEMPORARY_DATABASE_FILE);
             // import everything from the legacy database


### PR DESCRIPTION
Restoring a backup used to move the current ledger aside, write the incoming one in its place, and move the old one back if anything went wrong. A failure during that recovery left people with their data in a file the app no longer opens.

The restore now builds the incoming ledger in a separate file beside the live one and puts it in place with a single rename, only once every row has landed. A restore that fails never touches the live file, so there is nothing to undo and no second copy of the data sitting around while it runs. The aside copy and the recovery path it existed for are both gone.

Only the thread doing the import is sent to the new file. Everything else in the app keeps reading the real ledger for the whole restore, which is what lets the swap happen without locking every read.

One thing this gives up: a change saved elsewhere in the app while a restore runs goes into the ledger that is about to be replaced, so it is lost. That was already true before this change.

The app also tells its screens about the new data once now, between the database and the attachments. Doing it afterwards meant a failed attachment step left the selected wallet and every home screen widget naming rows out of the ledger that had just been replaced.

I tested both directions on an emulator through the app's own screens, against a six month ledger of about 450 transactions. On a good backup I watched the new file fill beside an untouched live one and the switch happen in one step. On a deliberately damaged backup the app reported the failure and the live ledger came out byte for byte identical, including a marker row I added first.

One limitation: attachments are extracted after the database, and that step empties the attachment folder first. A failure there still leaves the new ledger in place with the files gone. That was true before this change, but it means a restore is not all or nothing across attachments.
