### PR TITLE
Stop the currency cache locking every reader out while it reloads

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/utils/CurrencyManagerConcurrencyTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/utils/CurrencyManagerConcurrencyTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.utils;
+
+import android.content.Context;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.oriondev.moneywallet.model.CurrencyUnit;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNotSame;
+import static junit.framework.Assert.assertNull;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+
+/**
+ * getCurrencies hands out a view of the cache, and the rate download service walks that view
+ * across a run of database writes. A currency edit or a restore reloads the cache in the middle of
+ * that walk, and the reload used to empty the very map being walked, so the download thread got a
+ * ConcurrentModificationException part way down the list of currencies it was storing rates for.
+ *
+ * The cache is now replaced instead of emptied, which leaves a walk already under way reading a
+ * map nothing is touching. This drives the two against each other on purpose.
+ */
+public class CurrencyManagerConcurrencyTest {
+
+    private static final long TIMEOUT_SECONDS = 30;
+
+    /**
+     * The lock invalidateCache holds is only safe while no caller already holds the one database
+     * connection, so it refuses instead of deadlocking. This is the probe for that refusal, and
+     * it is the half of the safety argument no source reading can settle.
+     */
+    @Test
+    public void aReloadRefusesToRunInsideATransaction() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        CurrencyManager.initialize(context);
+        try {
+            DataContentProvider.runInOneTransaction(context, () -> {
+                CurrencyManager.invalidateCache(context);
+                return null;
+            });
+            fail("invalidateCache ran inside a transaction instead of refusing");
+        } catch (IllegalStateException expected) {
+            assertTrue("refused for the wrong reason: " + expected.getMessage(),
+                    expected.getMessage().contains("inside a transaction"));
+        }
+    }
+
+    @Test
+    public void aReloadDoesNotDisturbAWalkOfTheCurrencies() throws Exception {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        CurrencyManager.initialize(context);
+        Collection<CurrencyUnit> beforeTheReload = CurrencyManager.getCurrencies();
+        int expected = beforeTheReload.size();
+        // the walk has to reach a second element after the reload for anything to go wrong, so a
+        // cache of one would pass this whichever way the code behaved
+        assertTrue("only " + expected + " currencies installed, too few to walk", expected > 1);
+        // a currency the cache holds now, so the reload can be shown to have kept it
+        String knownIso = beforeTheReload.iterator().next().getIso();
+
+        CountDownLatch walkStarted = new CountDownLatch(1);
+        CountDownLatch reloadFinished = new CountDownLatch(1);
+        AtomicReference<Throwable> failure = new AtomicReference<>();
+        AtomicInteger walked = new AtomicInteger();
+
+        Thread walker = new Thread(() -> {
+            try {
+                for (CurrencyUnit unit : CurrencyManager.getCurrencies()) {
+                    assertNotNull("a null currency in the cache", unit);
+                    if (walked.incrementAndGet() == 1) {
+                        // hold the walk open on its first element until the reload has been and
+                        // gone, so the two cannot pass each other by luck of the scheduler
+                        walkStarted.countDown();
+                        reloadFinished.await(TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                    }
+                }
+            } catch (Throwable t) {
+                failure.set(t);
+            }
+        });
+        walker.start();
+        assertTrue("the walk never started", walkStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+        CurrencyManager.invalidateCache(context);
+        reloadFinished.countDown();
+        walker.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
+        // join returns whether or not the walk ended, and reading its counters after a timeout
+        // reads them with no ordering against the writes, so the failures below would describe
+        // the wrong thing
+        assertFalse("the walk was still running after " + TIMEOUT_SECONDS + " seconds",
+                walker.isAlive());
+
+        assertNull("a reload landing in the middle of a walk threw " + failure.get(),
+                failure.get());
+        assertEquals("the walk saw a different number of currencies than it started with",
+                expected, walked.get());
+        // without these three the case passes against an invalidateCache that publishes nothing,
+        // and against one that publishes an empty map, and then it says nothing about a reload
+        Collection<CurrencyUnit> afterTheReload = CurrencyManager.getCurrencies();
+        assertNotSame("invalidateCache published no new map, so nothing was driven against the walk",
+                beforeTheReload, afterTheReload);
+        assertEquals("the reload published a different number of currencies than it read",
+                expected, afterTheReload.size());
+        assertNotNull("the reload published a map without " + knownIso + " in it, which the cache "
+                + "held before it ran", CurrencyManager.getCurrency(knownIso));
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/background/OverviewDataLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/OverviewDataLoader.java
@@ -163,7 +163,10 @@ public class OverviewDataLoader extends AbstractGenericLoader<OverviewData> {
             for (int i = 0; i < periodMoneyList.size(); i++) {
                 PeriodMoney periodMoney = periodMoneyList.get(i);
                 long money = periodMoney.getNetIncomes().getMoney(currency);
-                float value = MoneyScale.toHumanAmount(money, currencyUnit.getDecimals()).floatValue();
+                // getDecimals and not getDecimals() on the unit. A row can name a currency this
+                // installation does not have, which a restore from another one leaves behind, and
+                // getCurrency answers null for it
+                float value = MoneyScale.toHumanAmount(money, CurrencyManager.getDecimals(currencyUnit)).floatValue();
                 barEntryList.add(new BarEntry(i, value));
                 lineEntryList.add(new Entry(i, value));
                 radarEntryList.add(new RadarEntry(value));

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -857,6 +857,23 @@ public class DataContentProvider extends ContentProvider {
     private static final ThreadLocal<Set<Uri>> sDeferredNotifications = new ThreadLocal<>();
 
     /**
+     * True when this thread is inside runInOneTransaction, and so holds a database connection for
+     * as long as that runs. Which connection depends on the thread: a staged import holds the
+     * staging one, everything else holds the one the app shares.
+     *
+     * This is narrower than holding a connection. A single provider write holds one too, through
+     * inSharedTransaction, and does not set this. It covers the case worth covering, which is a
+     * caller that has wrapped other work in a transaction and reaches something that takes a lock
+     * across the database. SQLDatabase.resetShared refuses on a wider condition, the swap read
+     * hold count, which it can read because that lock is private to it. Reaching the same
+     * condition from here would take an accessor on SQLDatabase, which is worth doing the day
+     * something inside a plain provider write can reach code that locks across the database.
+     */
+    public static boolean isInsideOneTransaction() {
+        return sDeferredNotifications.get() != null;
+    }
+
+    /**
      * Tells the observers about a write, or remembers it for {@link #runInOneTransaction} to tell
      * them once the import it is running has committed. Announcing each row as it goes in would
      * name rows that are not committed yet, and a failed import rolls every one of them back with
@@ -906,7 +923,12 @@ public class DataContentProvider extends ContentProvider {
      * Every other thread that touches the ledger waits for the import to finish, reads as well as
      * writes, and some of those writes are made on the main thread, where waiting is a frozen
      * screen. Keep what runs in here down to the writes themselves and keep the caller somewhere
-     * that can wait, which the import service and the legacy upgrade service both are.
+     * that can wait, or somewhere nothing else is running yet. The import service and the legacy
+     * upgrade service are the first. CurrencyManager writing the default currency set is the
+     * other, and it reaches here three ways: from a first launch, where nothing else has started
+     * yet; from a restore of a legacy backup, which carries no currencies and so leaves the table
+     * empty, on the backup service thread while the user interface is live; and from deleting the
+     * last currency, on the main thread. The last two can both make a user wait.
      *
      * Public, and here, because SQLDatabase is package local and the importers sit in a sub
      * package, so they cannot name it.

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivity.java
@@ -214,6 +214,34 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
             }
 
         });
+        // before the one below, because a wallet naming a currency this installation does not
+        // have has no currency to compare and the comparison there would pass it through to
+        // onSaveChanges, which reads the iso straight off it. Validators run in order and stop at
+        // the first refusal, so this is also what decides the message the user is shown
+        mWalletsEditText.addValidator(new Validator() {
+
+            @NonNull
+            @Override
+            public String getErrorMessage() {
+                return getString(R.string.error_input_currency_not_valid);
+            }
+
+            @Override
+            public boolean isValid(@NonNull CharSequence charSequence) {
+                for (Wallet wallet : mWalletsPicker.getCurrentWallets()) {
+                    if (wallet.getCurrency() == null) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public boolean autoValidate() {
+                return false;
+            }
+
+        });
         mWalletsEditText.addValidator(new Validator() {
 
             @NonNull

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/WalletItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/WalletItemFragment.java
@@ -259,8 +259,12 @@ public class WalletItemFragment extends SecondaryPanelFragment implements Loader
             Icon icon = IconLoader.parse(cursor.getString(cursor.getColumnIndex(Contract.Wallet.ICON)));
             IconLoader.loadInto(icon, mAvatarImageView);
             mNameTextView.setText(cursor.getString(cursor.getColumnIndex(Contract.Wallet.NAME)));
-            CurrencyUnit currency = CurrencyManager.getCurrency(cursor.getString(cursor.getColumnIndex(Contract.Wallet.CURRENCY)));
-            mCurrencyTextView.setText(currency.getName());
+            String currencyIso = cursor.getString(cursor.getColumnIndex(Contract.Wallet.CURRENCY));
+            CurrencyUnit currency = CurrencyManager.getCurrency(currencyIso);
+            // the wallet can name a currency this installation does not have, which a restore from
+            // another one leaves behind, and then the iso is the only name there is. The money
+            // below already reads a null currency, this line did not
+            mCurrencyTextView.setText(currency != null ? currency.getName() : currencyIso);
             long startMoney = cursor.getLong(cursor.getColumnIndex(Contract.Wallet.START_MONEY));
             mMoneyFormatter.applyNotTinted(mStartMoneyTextView, currency, startMoney);
             String note = cursor.getString(cursor.getColumnIndex(Contract.Wallet.NOTE));

--- a/app/src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java
@@ -39,9 +39,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Currency;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -52,47 +55,137 @@ import java.util.Map;
  */
 public class CurrencyManager {
 
-    private static final Object CACHE_MUTEX = new Object();
+    /**
+     * Volatile so that a thread which reads this field and finds it set also sees the map the
+     * constructor built. The field it holds used to be final, and a final field carries that
+     * guarantee on its own even when the reference to its holder is published in a race. A
+     * volatile field does not, so the guarantee has to come from here instead.
+     */
+    private static volatile CurrencyManager mInstance;
 
-    private static CurrencyManager mInstance;
+    /**
+     * Held for the whole of one load, so two of them cannot interleave their read and their
+     * publish and leave the cache holding the older of the two. Both loaders take it, initialize
+     * and invalidateCache.
+     *
+     * This is a lock held across a database read, which is what the monitor it replaced did and
+     * what deadlocked. It is safe here for one reason, and that reason has to stay true: only
+     * those two take it, and neither is called from inside a database transaction, so no thread
+     * holding the one connection the app shares can be made to wait on it. The readers below take
+     * nothing at all. CurrencyManagerSourceTest pins the first half and refuseIfInsideATransaction
+     * refuses the second at runtime.
+     */
+    private static final Object RELOAD_LOCK = new Object();
 
-    public static void initialize(Context context) {
-        if (mInstance == null) {
-            mInstance = new CurrencyManager(context);
-        }
-    }
-
-    private final ExchangeRateCache mExchangeRateCache;
-    private final Map<String, CurrencyUnit> mCurrencyCache;
-
-    private CurrencyManager(Context context) {
-        mExchangeRateCache = new ExchangeRateCache(context);
-        mCurrencyCache = new HashMap<>();
-        loadCurrencies(context);
-    }
-
-    private void loadCurrencies(Context context) {
-        loadUserCurrencies(context);
-        if (mCurrencyCache.isEmpty()) {
-            System.out.println("[CurrencyManager] No currency found. Loading default currencies from the assets...");
-            loadDefaultCurrencies(context);
-        }
-    }
-
-    public static void invalidateCache(Context context) {
-        synchronized (CACHE_MUTEX) {
-            System.out.println("[CurrencyManager] Invalidating cache...");
-            mInstance.mCurrencyCache.clear();
-            mInstance.loadCurrencies(context);
+    /**
+     * A thread inside a transaction holds the one database connection until it returns, and both
+     * loaders below take RELOAD_LOCK across a read that needs it, so one calling either of them
+     * is the deadlock this class was rewritten to remove. Refused here and not deadlocked later.
+     *
+     * The refusal is raised inside the caller's transaction, so it rolls that whole transaction
+     * back. For an importer that would mean losing the import, which is the right outcome for a
+     * call that could not have completed anyway.
+     */
+    private static void refuseIfInsideATransaction() {
+        if (DataContentProvider.isInsideOneTransaction()) {
+            throw new IllegalStateException("CurrencyManager loaded from inside a transaction");
         }
     }
 
     /**
-     * This method will force reload all currencies from the database inside the currency manager.
-     * A call to this method is very expensive because it is an I/O operation on the main thread.
-     * @param context of the application.
+     * Under the same lock as a reload, because building the instance reads the currency table and
+     * writes the default set into an empty one, which is the work a reload does. That makes the
+     * check and the assignment one step, and it stops this and a reload both loading at once.
+     *
+     * App.onCreate is the only caller. That is Application.onCreate, which Android runs after
+     * every content provider's onCreate, so the providers are already serving by the time this
+     * runs and the lock is not decoration.
+     *
+     * @throws IllegalStateException if called from inside a database transaction. See
+     *         {@link #refuseIfInsideATransaction()}.
      */
-    private void loadUserCurrencies(Context context) {
+    public static void initialize(Context context) {
+        refuseIfInsideATransaction();
+        synchronized (RELOAD_LOCK) {
+            if (mInstance == null) {
+                mInstance = new CurrencyManager(context);
+            }
+        }
+    }
+
+    private final ExchangeRateCache mExchangeRateCache;
+
+    /**
+     * Built whole and never written to again once it is published, so a reader takes no lock and
+     * a reload is never seen half done. The map is wrapped unmodifiable to keep it that way. That
+     * is a guard and not a requirement of the memory model, since the volatile write already
+     * carries everything the loading thread put in the map, but a later write to a published map
+     * would take that away and the wrapper is what stops one being added.
+     */
+    private volatile Map<String, CurrencyUnit> mCurrencyCache;
+
+    private CurrencyManager(Context context) {
+        mExchangeRateCache = new ExchangeRateCache(context);
+        mCurrencyCache = loadCurrencies(context);
+    }
+
+    private static Map<String, CurrencyUnit> loadCurrencies(Context context) {
+        Map<String, CurrencyUnit> currencies = loadUserCurrencies(context);
+        if (currencies.isEmpty()) {
+            System.out.println("[CurrencyManager] No currency found. Loading default currencies from the assets...");
+            currencies = loadDefaultCurrencies(context);
+        }
+        return Collections.unmodifiableMap(currencies);
+    }
+
+    /**
+     * Reads every currency again and swaps the new map in.
+     *
+     * The load holds nothing that a reader of the cache can take, and it has to. An importer runs
+     * a whole import inside one transaction, and the database is opened without write ahead
+     * logging, so that transaction holds the single connection the whole app shares. The importer
+     * asks this class for the currency named on every row it reads. A lock held here across the
+     * load and taken again by {@link #getCurrency(String)} put those two in opposite orders, the
+     * importer waiting on the lock and this method waiting on the connection, which is what this
+     * method used to do. The readers take nothing now, which is what makes the lock below safe.
+     *
+     * The load is usually a read, and on a currency table that is empty it also inserts the whole
+     * default set, which a restore from a legacy backup leaves behind since that format carries no
+     * currencies.
+     *
+     * The whole reload runs under RELOAD_LOCK so that two of them cannot interleave. Ordering them
+     * by something cheaper than a lock was tried and does not work, because a reload reads over an
+     * interval and not at an instant, so no single number taken at its start or at its end says
+     * whose read saw more. A reload that seeds the table writes rows another may or may not have
+     * seen, and a reload whose own caller has just inserted one currency reads a table that is not
+     * empty and so seeds nothing and holds only that one. Running them one at a time is what makes
+     * all of those come out right.
+     *
+     * The cost is that one reload waits for another, and the currency editor calls this on the
+     * main thread. What it waits for is one read of the currency table, or on an empty table the
+     * write of the default set.
+     *
+     * @param context of the application.
+     * @throws IllegalStateException if called from inside a database transaction. See
+     *         {@link #refuseIfInsideATransaction()}.
+     */
+    public static void invalidateCache(Context context) {
+        refuseIfInsideATransaction();
+        System.out.println("[CurrencyManager] Invalidating cache...");
+        synchronized (RELOAD_LOCK) {
+            mInstance.mCurrencyCache = loadCurrencies(context);
+        }
+    }
+
+    /**
+     * Reads the currencies this installation has into a new map. A call to this method is very
+     * expensive because it is an I/O operation, and invalidateCache reaches it from the main
+     * thread.
+     * @param context of the application.
+     * @return what the currency table holds, which is empty on a first run.
+     */
+    private static Map<String, CurrencyUnit> loadUserCurrencies(Context context) {
+        Map<String, CurrencyUnit> currencies = new HashMap<>();
         ContentResolver contentResolver = context.getContentResolver();
         String[] projections = new String[] {
                 Contract.Currency.ISO,
@@ -112,13 +205,16 @@ public class CurrencyManager {
                         cursor.getString(indexName),
                         cursor.getString(indexSymbol),
                         cursor.getInt(indexDecimals));
-                mCurrencyCache.put(currencyUnit.getIso(), currencyUnit);
+                currencies.put(currencyUnit.getIso(), currencyUnit);
             }
             cursor.close();
         }
+        return currencies;
     }
 
-    private void loadDefaultCurrencies(Context context) {
+    private static Map<String, CurrencyUnit> loadDefaultCurrencies(Context context) {
+        final List<ContentValues> rows = new ArrayList<>();
+        Map<String, CurrencyUnit> currencies = new HashMap<>();
         try {
             // open assets file and load all the default currencies into a JSONArray
             StringBuilder jsonBuilder = new StringBuilder();
@@ -129,8 +225,8 @@ public class CurrencyManager {
                 jsonBuilder.append(line);
             }
             JSONArray array = new JSONArray(jsonBuilder.toString());
-            // for each currency, load it into cache and store a copy inside the database
-            ContentResolver contentResolver = context.getContentResolver();
+            // every row is read and turned into a currency out here, so the transaction below
+            // holds the one database connection for the writes and for nothing else
             for (int i = 0; i < array.length(); i++) {
                 JSONObject currency = array.getJSONObject(i);
                 ContentValues contentValues = new ContentValues();
@@ -138,7 +234,7 @@ public class CurrencyManager {
                 contentValues.put(Contract.Currency.NAME, currency.getString("name"));
                 contentValues.put(Contract.Currency.SYMBOL, currency.optString("symbol", null));
                 contentValues.put(Contract.Currency.DECIMALS, currency.optInt("decimals", 2));
-                contentResolver.insert(DataContentProvider.CONTENT_CURRENCIES, contentValues);
+                rows.add(contentValues);
                 // directly store the currency inside the local cache
                 CurrencyUnit currencyUnit = new CurrencyUnit(
                         contentValues.getAsString(Contract.Currency.ISO),
@@ -146,11 +242,27 @@ public class CurrencyManager {
                         contentValues.getAsString(Contract.Currency.SYMBOL),
                         contentValues.getAsInteger(Contract.Currency.DECIMALS)
                 );
-                mCurrencyCache.put(currencyUnit.getIso(), currencyUnit);
+                currencies.put(currencyUnit.getIso(), currencyUnit);
             }
         } catch (IOException | JSONException e) {
-            throw new RuntimeException("Exception while reading currencies file from assets: " + e.getMessage());
+            throw new RuntimeException("Exception while reading currencies file from assets: " + e.getMessage(), e);
         }
+        try {
+            // one transaction for the whole set, so the table is never seen part way through it.
+            // RELOAD_LOCK already keeps the other loader out, so the reader this protects is
+            // everything else that queries the currency table, the currency list loader among
+            // them. It also turns one announcement per currency into one for the set
+            DataContentProvider.runInOneTransaction(context, () -> {
+                ContentResolver contentResolver = context.getContentResolver();
+                for (ContentValues row : rows) {
+                    contentResolver.insert(DataContentProvider.CONTENT_CURRENCIES, row);
+                }
+                return null;
+            });
+        } catch (Exception e) {
+            throw new RuntimeException("Exception while storing the default currencies: " + e.getMessage(), e);
+        }
+        return currencies;
     }
 
     /**
@@ -159,23 +271,28 @@ public class CurrencyManager {
      * @return the currency object if the iso code is found.
      */
     public static CurrencyUnit getCurrency(String iso) {
-        synchronized (CACHE_MUTEX) {
-            return mInstance.mCurrencyCache.get(iso);
-        }
-    }
-
-    public static Collection<CurrencyUnit> getCurrencies() {
-        synchronized (CACHE_MUTEX) {
-            return mInstance.mCurrencyCache.values();
-        }
+        return mInstance.mCurrencyCache.get(iso);
     }
 
     /**
-     * @return the number of decimals of the currency, or 0 when the currency is null because
-     *         {@link #getCurrency(String)} did not know the iso code stored on the row.
+     * @return every currency this installation has. The collection is a view of a map that is
+     *         never written to, so a reload replaces the map the next caller reads and leaves a
+     *         walk already under way to finish over the whole of the old one.
+     */
+    public static Collection<CurrencyUnit> getCurrencies() {
+        return mInstance.mCurrencyCache.values();
+    }
+
+    /**
+     * @return the number of decimals of the currency, or 2 when the currency is null because
+     *         {@link #getCurrency(String)} did not know the iso code stored on the row. Two is
+     *         what MoneyFormatter divides the same row by when it cannot resolve the currency
+     *         either, and a chart drawn beside a figure that formatter wrote has to agree with
+     *         it. It used to answer 0, from a caller that refuses to save a row it cannot
+     *         resolve and so never rendered the answer.
      */
     public static int getDecimals(CurrencyUnit currency) {
-        return currency != null ? currency.getDecimals() : 0;
+        return currency != null ? currency.getDecimals() : 2;
     }
 
     /**
@@ -200,23 +317,21 @@ public class CurrencyManager {
      *         has deleted the one it implies.
      */
     public static CurrencyUnit getDefaultCurrency() {
-        synchronized (CACHE_MUTEX) {
-            LocaleList preferredLocales = LocaleList.getAdjustedDefault();
-            for (int index = 0; index < preferredLocales.size(); index++) {
-                Currency currency = currencyOf(preferredLocales.get(index));
-                if (currency != null) {
-                    CurrencyUnit currencyUnit = getCurrency(currency.getCurrencyCode());
-                    if (currencyUnit == null) {
-                        System.out.println("[CurrencyManager] The locale implies "
-                                + currency.getCurrencyCode() + ", which is not installed");
-                    }
-                    return currencyUnit;
+        LocaleList preferredLocales = LocaleList.getAdjustedDefault();
+        for (int index = 0; index < preferredLocales.size(); index++) {
+            Currency currency = currencyOf(preferredLocales.get(index));
+            if (currency != null) {
+                CurrencyUnit currencyUnit = getCurrency(currency.getCurrencyCode());
+                if (currencyUnit == null) {
+                    System.out.println("[CurrencyManager] The locale implies "
+                            + currency.getCurrencyCode() + ", which is not installed");
                 }
+                return currencyUnit;
             }
-            System.out.println("[CurrencyManager] No preferred locale implies a currency: "
-                    + preferredLocales.toLanguageTags());
-            return null;
         }
+        System.out.println("[CurrencyManager] No preferred locale implies a currency: "
+                + preferredLocales.toLanguageTags());
+        return null;
     }
 
     /**

--- a/app/src/test/java/com/oriondev/moneywallet/utils/CurrencyManagerSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/CurrencyManagerSourceTest.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.utils;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * The deadlock this class was rewritten to remove needed two things at once: a reader of the cache
+ * that could block on a lock, and a reload that held that same lock while it read the database.
+ * An importer runs a whole import inside one transaction, which holds the single SQLite connection
+ * the app shares, and asks this class for a currency on every row. So the importer waited on the
+ * lock while the reload waited on the connection.
+ *
+ * Only one of those two has to go for the cycle to be impossible, and it is the readers that went.
+ * If nothing a thread inside a transaction can call acquires anything, that thread can never be
+ * made to wait inside this class, whatever invalidateCache does. READERS below is every such
+ * method, and it has to stay that way if a new one is added.
+ *
+ * invalidateCache does still hold a lock across the database, because two reloads have to be kept
+ * from interleaving and nothing cheaper orders them correctly, and so does initialize, which does
+ * the same load. That is safe only while the two things the second and third cases pin stay true:
+ * nothing but those two takes that lock, and neither is called from inside a transaction. Both
+ * refuse at runtime if anything does.
+ *
+ * What this is and is not. It reads the source and matches text, so it is a tripwire against the
+ * old code coming back, not a proof that the new code is correct. Someone determined to reintroduce
+ * a lock can pick a spelling none of these look for. The behavior that can be run instead is in
+ * CurrencyManagerConcurrencyTest. Comments and string literals are stripped first, so nothing here
+ * can be satisfied by a comment describing code the file no longer has, and whitespace is collapsed
+ * so a statement may be wrapped, following ReportLoaderSourceTest.
+ *
+ * A failure means read the source and decide, not that the cache is broken.
+ */
+public class CurrencyManagerSourceTest {
+
+    /** A java string literal, then a line comment, then a block comment. Literal first. */
+    private static final Pattern STRIPPED = Pattern.compile(
+            "\"(?:\\\\.|[^\"\\\\])*\"|//.*?$|/[*].*?[*]/",
+            Pattern.DOTALL | Pattern.MULTILINE);
+
+    /** Every way of taking a lock that this file could plausibly be rewritten to use. */
+    private static final String[] WAYS_TO_TAKE_A_LOCK = {
+            "synchronized", ".lock()", ".lockInterruptibly()", ".tryLock(", "Lock ",
+    };
+
+    private static String readSource() {
+        String path = "src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java";
+        File file = new File(path);
+        if (!file.exists()) {
+            // a runner rooted at the repo root instead of the module, which the precedent
+            // handles the same way
+            file = new File("app/" + path);
+        }
+        if (!file.exists()) {
+            fail("Cannot find CurrencyManager.java at " + file.getAbsolutePath());
+        }
+        try {
+            String source = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            return STRIPPED.matcher(source).replaceAll(" ").replaceAll("\\s+", " ");
+        } catch (IOException e) {
+            fail("Cannot read CurrencyManager.java: " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * The signature and everything to its matching closing brace. Literals and comments are gone
+     * by the time this runs and the file has no character literal, so every brace left is real.
+     */
+    private static String bodyOf(String source, String signature) {
+        int start = source.indexOf(signature);
+        assertTrue(signature + " is gone", start >= 0);
+        int depth = 0;
+        for (int i = source.indexOf('{', start); i < source.length(); i++) {
+            char character = source.charAt(i);
+            if (character == '{') {
+                depth++;
+            } else if (character == '}' && --depth == 0) {
+                return source.substring(start, i + 1);
+            }
+        }
+        fail("no closing brace found for " + signature);
+        return null;
+    }
+
+    /** How many blocks deep a position sits inside a body. 1 is a statement of the method. */
+    private static int depthOf(String body, int position) {
+        int depth = 0;
+        for (int i = 0; i < position; i++) {
+            char character = body.charAt(i);
+            if (character == '{') {
+                depth++;
+            } else if (character == '}') {
+                depth--;
+            }
+        }
+        return depth;
+    }
+
+    /** Every way out of this class that a thread inside a database transaction can reach. */
+    private static final String[] READERS = {
+            "public static CurrencyUnit getCurrency(String iso) {",
+            "public static Collection<CurrencyUnit> getCurrencies() {",
+            "public static CurrencyUnit getDefaultCurrency() {",
+            "public static ExchangeRate getExchangeRate(CurrencyUnit currency1, CurrencyUnit currency2) {",
+            "public static ExchangeRateCache getExchangeRateCache() {",
+            "public static int getDecimals(CurrencyUnit currency) {",
+    };
+
+    @Test
+    public void noReaderOfTheCacheTakesALock() {
+        String source = readSource();
+        for (String reader : READERS) {
+            String body = bodyOf(source, reader);
+            for (String lock : WAYS_TO_TAKE_A_LOCK) {
+                assertFalse(reader + " takes a lock again through " + lock.trim() + ". An importer "
+                                + "calls in here while holding the one database connection, so a "
+                                + "reader that can block is half of the deadlock this removed",
+                        body.contains(lock));
+            }
+        }
+    }
+
+    /**
+     * The reader cases above read one method body each, so a reader that took its lock inside a
+     * helper it calls would pass every one of them. These close that from the other side, over the
+     * whole file: every lock taken any way at all has to be RELOAD_LOCK, only invalidateCache and
+     * initialize may name it, and the reload has to both load and publish inside it.
+     */
+    @Test
+    public void theOnlyLockIsReloadLockAndOnlyTheReloadTakesIt() {
+        String source = readSource();
+        // over the WHOLE file and not just the reader bodies, because a reader that calls a
+        // helper which locks passes every case that reads one body at a time
+        for (String lock : WAYS_TO_TAKE_A_LOCK) {
+            int taken = count(source, lock);
+            int onReloadLock = "synchronized".equals(lock)
+                    ? count(source, "synchronized (RELOAD_LOCK)") : 0;
+            assertTrue("CurrencyManager takes a lock through " + lock.trim() + " that is not "
+                            + "RELOAD_LOCK. Whichever method holds it, an importer holding the one "
+                            + "database connection can be made to wait on it, which is half of the "
+                            + "deadlock this removed",
+                    taken == onReloadLock);
+        }
+        String reload = bodyOf(source, "public static void invalidateCache(Context context) {");
+        String setUp = bodyOf(source, "public static void initialize(Context context) {");
+        // the declaration, and every other mention inside invalidateCache. A helper that took
+        // RELOAD_LOCK for a reader would raise the first count and not the second
+        assertTrue("something other than invalidateCache and initialize names RELOAD_LOCK. It is "
+                        + "held across a database read, which is only safe while the two methods "
+                        + "that take it both refuse to run inside a transaction",
+                count(source, "RELOAD_LOCK")
+                        == count(reload, "RELOAD_LOCK") + count(setUp, "RELOAD_LOCK") + 1);
+        // and the load has to be INSIDE it. Lifted out, the lock guards the assignment alone,
+        // which nothing needs, and two reloads interleave their read and their publish again. The
+        // cache then keeps whichever finished last, which is not whichever read last
+        assertTrue("invalidateCache reads the currencies outside RELOAD_LOCK and only publishes "
+                        + "under it. That is the interleaving this lock exists to stop: two "
+                        + "reloads both read, and the cache keeps the one that finished last "
+                        + "instead of the one that read last",
+                depthOf(reload, reload.indexOf("loadCurrencies(context)")) == 2);
+        // and so does the assignment. Reading under the lock and publishing outside it orders the
+        // reads and nothing else, so the cache still keeps whichever reload finished last
+        assertTrue("invalidateCache publishes outside RELOAD_LOCK. Two reloads then read one at a "
+                        + "time and still publish in whatever order they finish, so a reload that "
+                        + "read an older table can overwrite one that read a newer one",
+                depthOf(reload, reload.indexOf("mInstance.mCurrencyCache =")) == 2);
+        // initialize loads the same way and takes the same lock, so its load has to be inside it
+        // too. Built outside and only assigned under the lock, a first launch can seed the table
+        // while a reload on another thread is reading it
+        // initialize is pinned by position and not by depth alone. Depth 2 is reached just as
+        // well by the null check with no lock around it at all, which is the very shape the
+        // message below names, so the construction has to sit AFTER the lock is entered
+        for (String loader : new String[] {"invalidateCache", "initialize"}) {
+            String body = "invalidateCache".equals(loader) ? reload : setUp;
+            int locked = body.indexOf("synchronized (RELOAD_LOCK)");
+            assertTrue(loader + " no longer takes RELOAD_LOCK at all, so the two loaders can run "
+                    + "their read and their publish at the same time", locked >= 0);
+            // before the lock, by position. At depth 1 but below the block it is useless, and a
+            // caller already inside a transaction walks straight into the old deadlock
+            int refuses = body.indexOf("refuseIfInsideATransaction()");
+            assertTrue(loader + " no longer refuses before it takes RELOAD_LOCK. A caller that "
+                            + "already holds a database connection then takes the lock across a "
+                            + "read that needs it, which is the deadlock this removed",
+                    refuses >= 0 && refuses < locked && depthOf(body, refuses) == 1);
+        }
+        assertTrue("initialize builds the instance outside RELOAD_LOCK and only assigns it under "
+                        + "the lock, so its load and a reload can run at the same time. That is "
+                        + "the interleaving the lock exists to stop",
+                setUp.indexOf("new CurrencyManager(context)")
+                        > setUp.indexOf("synchronized (RELOAD_LOCK)")
+                        && depthOf(setUp, setUp.indexOf("new CurrencyManager(context)")) >= 2);
+        // the map the readers walk without a lock is only safe while nothing can write to it
+        assertTrue("loadCurrencies no longer wraps the map it publishes. A later write to a "
+                        + "published map is what the volatile stops carrying, and the walk in "
+                        + "CurrencyManagerConcurrencyTest is what breaks first",
+                source.contains("return Collections.unmodifiableMap(currencies);"));
+    }
+
+    /**
+     * The other half of that argument, and the half this file cannot see: the lock is held across
+     * a database read, so it is only safe while no thread that already holds the one database
+     * connection can reach invalidateCache. These are the three callers that exist, all of which
+     * call it with no transaction open. A new one is not necessarily wrong, it just has to be
+     * checked, which is what this is for.
+     */
+    @Test
+    public void nothingNewCallsTheReloadWithoutBeingChecked() {
+        String[] allowed = {
+                "service/BackupHandlerIntentService.java",
+                "service/UpgradeLegacyEditionIntentService.java",
+                "ui/activity/NewEditCurrencyActivity.java",
+                "App.java",
+        };
+        List<String> callers = new ArrayList<>();
+        List<File> files = new ArrayList<>();
+        for (File root : productionSourceRoots()) {
+            files.addAll(sourceFiles(root));
+        }
+        for (File file : files) {
+            String text = read(file);
+            if (text.contains("CurrencyManager.invalidateCache(")
+                    || text.contains("CurrencyManager.initialize(")) {
+                String path = file.getPath().replace(File.separatorChar, '/');
+                boolean known = false;
+                for (String one : allowed) {
+                    known = known || path.endsWith(one);
+                }
+                if (!known) {
+                    callers.add(path);
+                }
+            }
+        }
+        assertTrue("a new caller of CurrencyManager.invalidateCache or initialize: " + callers
+                        + ". Both hold a "
+                        + "lock across a database read, so read the new caller and make sure it is "
+                        + "not inside a transaction, then add it here",
+                callers.isEmpty());
+    }
+
+    /**
+     * Every production source set, not just main. floss, gmap, osm and proprietary are flavor
+     * source sets and are compiled into the app exactly like main is, so a caller added in one of
+     * them ships.
+     */
+    private static List<File> productionSourceRoots() {
+        File app = new File("src");
+        if (!app.isDirectory()) {
+            app = new File("app/src");
+        }
+        assertTrue("cannot find the source root at " + app.getAbsolutePath(), app.isDirectory());
+        List<File> roots = new ArrayList<>();
+        File[] sets = app.listFiles();
+        assertTrue("no source sets under " + app.getAbsolutePath(), sets != null);
+        for (File set : sets) {
+            String name = set.getName();
+            if (set.isDirectory() && !name.equals("test") && !name.equals("androidTest")) {
+                File java = new File(set, "java");
+                if (java.isDirectory()) {
+                    roots.add(java);
+                }
+            }
+        }
+        assertTrue("no production source set has a java directory", !roots.isEmpty());
+        return roots;
+    }
+
+    private static List<File> sourceFiles(File directory) {
+        List<File> found = new ArrayList<>();
+        File[] children = directory.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                if (child.isDirectory()) {
+                    found.addAll(sourceFiles(child));
+                } else if (child.getName().endsWith(".java")) {
+                    found.add(child);
+                }
+            }
+        }
+        return found;
+    }
+
+    private static String read(File file) {
+        try {
+            return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            fail("cannot read " + file + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private static int count(String text, String needle) {
+        int found = 0;
+        for (int at = text.indexOf(needle); at >= 0; at = text.indexOf(needle, at + 1)) {
+            found++;
+        }
+        return found;
+    }
+
+    @Test
+    public void bothStaticsThatCarryTheCacheAreVolatile() {
+        String source = readSource();
+        // the cache itself, so a reader on another thread sees the map that was published and not
+        // a stale one
+        assertTrue("the currency cache field is no longer volatile",
+                source.contains("private volatile Map<String, CurrencyUnit> mCurrencyCache;"));
+        // and the holder, because the cache field is no longer final. A final field publishes the
+        // object it points at even when its holder is reached through a race, and volatile does
+        // not, so a racing reader could otherwise see mInstance set and its cache still null
+        assertTrue("the singleton field is no longer volatile, and the cache field it carries is "
+                        + "not final. getCurrency, getCurrencies, getExchangeRate and "
+                        + "getExchangeRateCache all read mInstance with no lock, so without it a "
+                        + "reader can see mInstance set and the map it carries still null",
+                source.contains("private static volatile CurrencyManager mInstance;"));
+    }
+}


### PR DESCRIPTION
The app keeps the list of currencies in memory so every screen can read it without going to the database. Refreshing that list used to lock it, and then go to the database while holding the lock.

An import runs inside one database transaction, and this database hands the whole app a single connection, so an import holds it from its first row to its last. It also looks up the currency named on every row it reads, so it waits for the lock on the list, while the refresh holds that lock and waits for the connection. Neither can finish, and one of them can be the thread drawing the screen.

Reading the list now takes no lock at all. It is rebuilt separately and swapped in complete, so nothing holding the connection can be made to wait on it. Refreshing still takes a lock, because two refreshes at once have to be kept from overwriting each other with older readings, and nothing cheaper orders them correctly. A refresh started from inside a transaction now refuses instead of hanging.

Three other things came out of it.

Refreshing used to empty the list before refilling it. A background exchange rate download walks that same list while it saves rates, so a currency edit or a restore during one stopped it part way through. Replacing the list leaves a walk already under way alone.

A backup restored from another installation can name a currency this one does not have, and four places used the answer without checking it. Saving a budget on such a wallet crashed the app, and so did opening the wallet. A chart drew at a hundred times the figure below it. All four handle it now.

The default currency list is written in one go instead of one row at a time, so nothing can read it half filled. That runs on a first launch, after restoring an older backup, and after deleting the last currency.

Tested on an emulator, including a first launch, plus the unit and instrumented suites.
