### PR TITLE
Tell every open screen about a write instead of listing what each one reads

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -33,6 +33,7 @@ import android.database.sqlite.SQLiteException;
 import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.text.TextUtils;
 
 import androidx.test.filters.LargeTest;
@@ -51,11 +52,15 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static junit.framework.Assert.assertEquals;
@@ -1712,16 +1717,7 @@ public class SQLDatabaseTest {
      * fails on them and not on something left out.
      */
     private ContentValues transactionValuesOnMissingRows() {
-        ContentValues contentValues = new ContentValues();
-        contentValues.put(Contract.Transaction.WALLET_ID, 987654321L);
-        contentValues.put(Contract.Transaction.CATEGORY_ID, 987654321L);
-        contentValues.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(new Date()));
-        contentValues.put(Contract.Transaction.MONEY, 1000L);
-        contentValues.put(Contract.Transaction.DIRECTION, Contract.Direction.EXPENSE);
-        contentValues.put(Contract.Transaction.TYPE, Contract.TransactionType.STANDARD);
-        contentValues.put(Contract.Transaction.CONFIRMED, true);
-        contentValues.put(Contract.Transaction.COUNT_IN_TOTAL, true);
-        return contentValues;
+        return transactionValues(987654321L, 987654321L);
     }
 
     /**
@@ -1925,6 +1921,322 @@ public class SQLDatabaseTest {
             contentResolver.unregisterContentObserver(observer[0]);
         }
         checkCursorSize(mDatabase.getWallets(null, null, null, null), 1);
+    }
+
+    /**
+     * The sixteen top level lists, which is every one of them and not a sample of them. The other
+     * thirty branches of the switch are fourteen lists that hang off a row and sixteen single row
+     * uris, and two of those are the case after this one.
+     */
+    private static final Uri[] LIST_URIS = new Uri[] {
+            DataContentProvider.CONTENT_CURRENCIES,
+            DataContentProvider.CONTENT_WALLETS,
+            DataContentProvider.CONTENT_TRANSACTIONS,
+            DataContentProvider.CONTENT_TRANSFERS,
+            DataContentProvider.CONTENT_CATEGORIES,
+            DataContentProvider.CONTENT_DEBTS,
+            DataContentProvider.CONTENT_BUDGETS,
+            DataContentProvider.CONTENT_SAVINGS,
+            DataContentProvider.CONTENT_EVENTS,
+            DataContentProvider.CONTENT_RECURRENT_TRANSACTIONS,
+            DataContentProvider.CONTENT_RECURRENT_TRANSFERS,
+            DataContentProvider.CONTENT_TRANSACTION_MODELS,
+            DataContentProvider.CONTENT_TRANSFER_MODELS,
+            DataContentProvider.CONTENT_PLACES,
+            DataContentProvider.CONTENT_PEOPLE,
+            DataContentProvider.CONTENT_ATTACHMENTS
+    };
+
+    /**
+     * Every column the table insists on, so a row built from two ids that are really there cannot
+     * be refused at all.
+     */
+    private ContentValues transactionValues(long walletId, long categoryId) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(Contract.Transaction.WALLET_ID, walletId);
+        contentValues.put(Contract.Transaction.CATEGORY_ID, categoryId);
+        contentValues.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(new Date()));
+        contentValues.put(Contract.Transaction.MONEY, 1000L);
+        contentValues.put(Contract.Transaction.DIRECTION, Contract.Direction.EXPENSE);
+        contentValues.put(Contract.Transaction.TYPE, Contract.TransactionType.STANDARD);
+        contentValues.put(Contract.Transaction.CONFIRMED, true);
+        contentValues.put(Contract.Transaction.COUNT_IN_TOTAL, true);
+        return contentValues;
+    }
+
+    private ContentValues categoryValues(String name) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(Contract.Category.NAME, name);
+        contentValues.put(Contract.Category.ICON, "encoded-icon");
+        contentValues.put(Contract.Category.TYPE, Contract.CategoryType.EXPENSE.getValue());
+        contentValues.put(Contract.Category.SHOW_REPORT, true);
+        return contentValues;
+    }
+
+    private ContentValues currencyValues(String iso) {
+        ContentValues contentValues = new ContentValues();
+        contentValues.put(Contract.Currency.ISO, iso);
+        contentValues.put(Contract.Currency.NAME, "Currency " + iso);
+        contentValues.put(Contract.Currency.SYMBOL, "T");
+        // the column is NOT NULL with no default, so a currency without it is refused
+        contentValues.put(Contract.Currency.DECIMALS, 2);
+        return contentValues;
+    }
+
+    /**
+     * Watches a cursor the way a CursorLoader does, by registering on the cursor itself. An
+     * observer put on the resolver by hand instead would prove that the framework delivers a
+     * notification and say nothing about the uri the provider registered the cursor on, which is
+     * the whole of what these cases are about.
+     *
+     * It keeps the uris it is told about instead of counting. A case that only counts cannot tell
+     * its own write from any other write in the process, and these run in the live app, where the
+     * recurrence alarm can fire and a widget observer is already registered. That was harmless
+     * while a cursor only heard about the entities it named and is not now.
+     */
+    private BlockingQueue<Uri> watchCursor(Cursor cursor) {
+        final BlockingQueue<Uri> heard = new LinkedBlockingQueue<>();
+        cursor.registerContentObserver(new ContentObserver(new Handler(Looper.getMainLooper())) {
+
+            @Override
+            public void onChange(boolean selfChange, Uri uri) {
+                heard.add(uri != null ? uri : Uri.EMPTY);
+            }
+
+        });
+        return heard;
+    }
+
+    /**
+     * The same, for an observer put on the resolver instead of on a cursor.
+     */
+    private BlockingQueue<Uri> watchUris(ContentResolver contentResolver, Uri uri,
+                                         boolean descendants, ContentObserver[] out) {
+        final BlockingQueue<Uri> heard = new LinkedBlockingQueue<>();
+        ContentObserver observer = new ContentObserver(new Handler(Looper.getMainLooper())) {
+
+            @Override
+            public void onChange(boolean selfChange, Uri changed) {
+                heard.add(changed != null ? changed : Uri.EMPTY);
+            }
+
+        };
+        contentResolver.registerContentObserver(uri, descendants, observer);
+        out[0] = observer;
+        return heard;
+    }
+
+    /**
+     * Two seconds of nothing at all, and not two seconds of anything but one named uri. A write
+     * that announced the bare authority would reach this observer as that uri and not as the row
+     * it wrote, so a case that only refused the row uri would let it through. Call it after
+     * something else has been shown to have heard the write, or it is two seconds of waiting for
+     * a notification that has not been sent yet and it passes whatever the truth is.
+     */
+    private void assertHeardNothing(BlockingQueue<Uri> heard, String message)
+            throws InterruptedException {
+        Uri uri = heard.poll(2000L, TimeUnit.MILLISECONDS);
+        assertNull(message + ", it was told about " + uri, uri);
+    }
+
+    /**
+     * Waits for one named uri and ignores anything else that arrives. Five seconds in total and
+     * not five seconds per uri, so a run of unrelated announcements cannot stretch it.
+     */
+    private void assertHeard(BlockingQueue<Uri> heard, Uri expected, String message)
+            throws InterruptedException {
+        long deadline = SystemClock.uptimeMillis() + 5000L;
+        for (long left = 5000L; left > 0L; left = deadline - SystemClock.uptimeMillis()) {
+            Uri uri = heard.poll(left, TimeUnit.MILLISECONDS);
+            if (uri == null) {
+                break;
+            }
+            if (expected.equals(uri)) {
+                return;
+            }
+        }
+        fail(message);
+    }
+
+    /**
+     * Two writes of two entities, and the second one is what makes this a check. A single write
+     * cannot tell a cursor registered on the whole provider apart from one registered on whatever
+     * that write happens to announce, so a provider that put every cursor on the currency list
+     * would pass a currency only version of this on its own.
+     *
+     * A currency is the first, because it is the entity the fewest queries read. A provider that
+     * registered each cursor on the entities its own query names would leave every cursor here
+     * except the currency one hearing nothing about it.
+     */
+    @Test
+    public void everyListCursorIsToldAboutAWriteToAnyEntity() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        assertEveryListCursorIsToldAbout(contentResolver, DataContentProvider.CONTENT_CURRENCIES,
+                currencyValues("TSA"));
+        assertEveryListCursorIsToldAbout(contentResolver, DataContentProvider.CONTENT_WALLETS,
+                walletValues("Written while every list is open"));
+    }
+
+    /**
+     * Opens its own cursors each time it is called. Watching one cursor twice would not work,
+     * since the wrapper replays what it has already been told to an observer that registers after
+     * it, so the second round would start with its latch already down.
+     */
+    private void assertEveryListCursorIsToldAbout(ContentResolver contentResolver, Uri listUri,
+                                                  ContentValues values) throws Exception {
+        Cursor[] cursors = new Cursor[LIST_URIS.length];
+        List<BlockingQueue<Uri>> heard = new ArrayList<>();
+        try {
+            for (int i = 0; i < LIST_URIS.length; i++) {
+                cursors[i] = contentResolver.query(LIST_URIS[i], null, null, null, null);
+                assertNotNull("the provider answered nothing for " + LIST_URIS[i], cursors[i]);
+                heard.add(watchCursor(cursors[i]));
+            }
+            Uri written = contentResolver.insert(listUri, values);
+            assertNotNull("the provider refused a row that is fine, so nothing was written for "
+                    + "these cursors to hear about", written);
+            for (int i = 0; i < LIST_URIS.length; i++) {
+                assertHeard(heard.get(i), written, "the cursor on " + LIST_URIS[i] + " was not "
+                        + "told about " + written + ", so a screen holding it goes on showing "
+                        + "what was true before that write");
+            }
+        } finally {
+            for (Cursor cursor : cursors) {
+                if (cursor != null) {
+                    cursor.close();
+                }
+            }
+        }
+    }
+
+    /**
+     * The two kinds of branch the case above does not open, a list that hangs off a row and a
+     * single row.
+     *
+     * Two writes on the first, and for the same reason as above. A transaction because that is the
+     * relation this cursor was given a uri for by hand, saving a debt's master transaction writes
+     * the debt's people. A category because nothing about a debt's people reads one, so a provider
+     * registering this cursor on what its own query names would fail there and pass the
+     * transaction on its own. The single row uri takes a currency for the same job, since the debt
+     * row reads a wallet, a category, a transaction, a person and a place and never a currency.
+     */
+    @Test
+    public void aSubListAndASingleRowCursorAreToldAboutAWriteToAnotherEntity() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        long walletId = insertWallet("Wallet the debt is against", "encoded-icon", "EUR", null,
+                true, 0L, false, null);
+        long debtId = insertDebt(Contract.DebtType.DEBT.getValue(), "encoded-icon", "desc",
+                new Date(), null, walletId, null, null, 2000L, false, null, null, false);
+        long categoryId = insertCategory("Category the transaction is in", "encoded-icon",
+                Contract.CategoryType.EXPENSE.getValue(), null, true, null);
+        Uri people = Uri.withAppendedPath(
+                ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, debtId), "people");
+        assertCursorIsToldAbout(contentResolver, people,
+                DataContentProvider.CONTENT_TRANSACTIONS, transactionValues(walletId, categoryId));
+        assertCursorIsToldAbout(contentResolver, people,
+                DataContentProvider.CONTENT_CATEGORIES, categoryValues("Written somewhere else"));
+        assertCursorIsToldAbout(contentResolver,
+                ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, debtId),
+                DataContentProvider.CONTENT_CURRENCIES, currencyValues("TSD"));
+    }
+
+    /**
+     * Its own cursor each time, for the reason the list helper opens its own.
+     */
+    private void assertCursorIsToldAbout(ContentResolver contentResolver, Uri cursorUri,
+                                         Uri listUri, ContentValues values)
+            throws Exception {
+        Cursor cursor = contentResolver.query(cursorUri, null, null, null, null);
+        try {
+            assertNotNull("the provider answered nothing for " + cursorUri, cursor);
+            BlockingQueue<Uri> heard = watchCursor(cursor);
+            Uri written = contentResolver.insert(listUri, values);
+            assertNotNull("the provider refused a row that is fine, so nothing was written for "
+                    + "this cursor to hear about", written);
+            assertHeard(heard, written, "the cursor on " + cursorUri + " was not told about "
+                    + written + ", so the detail screen holding it goes on showing what was true "
+                    + "before that write");
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+
+    /**
+     * The replay, which is the one thing MultiUriCursorWrapper still does that the platform cursor
+     * does not, and the reason it is still wrapped now that there is one uri to register. A loader
+     * registers on its cursor after the query it is loading has returned, and on a real screen the
+     * time between the two is the first window filling. AbstractCursor drops a change that lands
+     * in there.
+     *
+     * Writing and then registering proves nothing on its own, since the announcement is delivered
+     * asynchronously and would reach the second watcher through the ordinary path if it had not
+     * arrived yet. What rules that out is the lock: registerContentObserver takes the one onChange
+     * holds across both its dispatch and its add, so the second registration cannot run until the
+     * change has been stored. Waiting for the first watcher only says the dispatch happened, and
+     * that dispatch is a post the main thread can drain before the add has run.
+     */
+    @Test
+    public void aCursorHandsAChangeItWasAlreadyToldAboutToALateObserver() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        Cursor cursor = contentResolver.query(DataContentProvider.CONTENT_WALLETS, null, null,
+                null, null);
+        try {
+            assertNotNull("the provider answered nothing for the wallet list", cursor);
+            BlockingQueue<Uri> early = watchCursor(cursor);
+            Uri written = contentResolver.insert(DataContentProvider.CONTENT_WALLETS,
+                    walletValues("Written before the late observer"));
+            assertNotNull("the provider refused a wallet that is fine, so nothing was written for "
+                    + "this cursor to be told about", written);
+            assertHeard(early, written, "the cursor was never told about " + written
+                    + ", so this case cannot say anything about what a later observer gets");
+            assertHeard(watchCursor(cursor), written, "a change the cursor had already been told "
+                    + "about was not handed to an observer that registered after it, so a loader "
+                    + "registering after its query would hold what was true before that write");
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+
+    /**
+     * The registration the widget makes, made here rather than by calling the widget, since
+     * nothing can read back what the framework was asked to watch. So this pins the mechanism and
+     * not WalletWidgetObserver's own two lines, which no case reaches.
+     *
+     * The second half is the part worth having. Nothing ever announces CONTENT_ALL itself, so an
+     * observer that did not ask for the uris below it hears none of these writes, and that is what
+     * carries the whole registration.
+     */
+    @Test
+    public void anObserverOnTheWholeProviderIsToldWhicheverUriTheWriteAnnounces() throws Exception {
+        ContentResolver contentResolver = mContext.getContentResolver();
+        Uri[] lists = {DataContentProvider.CONTENT_CURRENCIES, DataContentProvider.CONTENT_WALLETS};
+        ContentValues[] values = {currencyValues("TSB"), walletValues("Watched by the widget")};
+        for (int i = 0; i < lists.length; i++) {
+            ContentObserver[] wide = new ContentObserver[1];
+            ContentObserver[] narrow = new ContentObserver[1];
+            BlockingQueue<Uri> wideHeard =
+                    watchUris(contentResolver, DataContentProvider.CONTENT_ALL, true, wide);
+            BlockingQueue<Uri> narrowHeard =
+                    watchUris(contentResolver, DataContentProvider.CONTENT_ALL, false, narrow);
+            try {
+                Uri written = contentResolver.insert(lists[i], values[i]);
+                assertNotNull("the provider refused a row that is fine, so nothing was written "
+                        + "for this observer to hear about", written);
+                assertHeard(wideHeard, written, "an observer on the whole provider was not told "
+                        + "about " + written + ", which is how the widget would go stale after a "
+                        + "write");
+                assertHeardNothing(narrowHeard, "an observer that did not ask for the uris below "
+                        + "CONTENT_ALL was told about a write. Either the descendants flag is not "
+                        + "what carries this, or something now announces the bare authority");
+            } finally {
+                contentResolver.unregisterContentObserver(wide[0]);
+                contentResolver.unregisterContentObserver(narrow[0]);
+            }
+        }
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/DataContentProvider.java
@@ -65,6 +65,16 @@ public class DataContentProvider extends ContentProvider {
     public static final Uri CONTENT_PEOPLE = Uri.parse("content://" + AUTHORITY + "/people");
     public static final Uri CONTENT_ATTACHMENTS = Uri.parse("content://" + AUTHORITY + "/attachments");
 
+    /**
+     * Every uri above sits under this one. An observer registered here with descendants included
+     * is told about every change this provider announces, whichever of those uris the write named,
+     * because the framework collects an observer sitting above a uri for a notification on
+     * anything below it.
+     *
+     * It is what a cursor this provider hands out is registered on, and what the widget watches.
+     */
+    public static final Uri CONTENT_ALL = Uri.parse("content://" + AUTHORITY);
+
     private static final int CURRENCY_LIST = 1;
     private static final int WALLET_LIST = 2;
     private static final int TRANSACTION_LIST = 3;
@@ -182,6 +192,27 @@ public class DataContentProvider extends ContentProvider {
         return true;
     }
 
+    /**
+     * Every cursor is registered on the whole provider and not on the entities its own query
+     * reads. A cursor that names its own is a list that has to be kept in step with the joins
+     * under it and with what each write announces, and getting that list wrong shows up as a
+     * screen holding a figure that is no longer true. One of those lists already needed a uri
+     * added by hand when saving a debt's master transaction started writing the debt's people.
+     *
+     * What it costs is reloads. Twenty five of the forty six cases named two entities or fewer,
+     * ten of them exactly one, and every case now wakes for writes it did not name. The ten are
+     * cheap single table queries; the transaction list is not, and it wakes for a currency or a
+     * budget now where it named nine other things and not those. An import announces once per
+     * list when it commits and not once a row, but a run of single row writes reaches further
+     * than it used to. Attaching several files to one transaction, or the recurrence job posting
+     * a backlog, are the two to picture. A reload is the query run again and then the whole list
+     * rebound on the main thread, since nothing here sets an update throttle on a loader and the
+     * adapters swap a cursor with notifyDataSetChanged.
+     *
+     * The cursor stays wrapped for one uri because the wrapper replays a change that arrives
+     * between this method returning and a loader registering on the cursor. AbstractCursor drops
+     * that one.
+     */
     @Nullable
     @Override
     public Cursor query(@NonNull Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
@@ -189,312 +220,145 @@ public class DataContentProvider extends ContentProvider {
         switch (mUriMatcher.match(uri)) {
             case CURRENCY_LIST:
                 cursor = new MultiUriCursorWrapper(db().getCurrencies(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CURRENCIES);
                 break;
             case CURRENCY_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getCurrency(uri.getLastPathSegment(), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
                 break;
             case WALLET_LIST:
                 cursor = new MultiUriCursorWrapper(db().getWallets(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
                 break;
             case WALLET_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getWallet(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
                 break;
             case TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getTransactions(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSACTION_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getTransaction(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSACTION_ATTACHMENTS:
                 cursor = new MultiUriCursorWrapper(db().getTransactionAttachments(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSACTION_PEOPLE:
                 cursor = new MultiUriCursorWrapper(db().getTransactionPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
                 break;
             case TRANSFER_LIST:
                 cursor = new MultiUriCursorWrapper(db().getTransfers(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSFER_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getTransfer(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSFER_ATTACHMENTS:
                 cursor = new MultiUriCursorWrapper(db().getTransferAttachments(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case TRANSFER_PEOPLE:
                 cursor = new MultiUriCursorWrapper(db().getTransferPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFERS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
                 break;
             case CATEGORY_LIST:
                 cursor = new MultiUriCursorWrapper(db().getCategories(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 break;
             case CATEGORY_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getCategory(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
                 break;
             case CATEGORY_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getCategoryTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 break;
             case DEBT_LIST:
                 cursor = new MultiUriCursorWrapper(db().getDebts(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case DEBT_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getDebt(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case DEBT_PEOPLE:
                 cursor = new MultiUriCursorWrapper(db().getDebtPeople(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
-                // Saving a debt's master transaction now writes the debt's people, so a write
-                // to a transaction can change what this cursor holds.
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case DEBT_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getDebtTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case BUDGET_LIST:
                 cursor = new MultiUriCursorWrapper(db().getBudgets(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
                 break;
             case BUDGET_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getBudget(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case BUDGET_WALLETS:
                 cursor = new MultiUriCursorWrapper(db().getBudgetWallets(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
                 break;
             case BUDGET_CATEGORIES:
                 cursor = new MultiUriCursorWrapper(db().getBudgetCategories(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
                 break;
             case BUDGET_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getBudgetTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_BUDGETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case SAVING_LIST:
                 cursor = new MultiUriCursorWrapper(db().getSavings(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_SAVINGS);
                 break;
             case SAVING_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getSaving(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case SAVING_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getSavingTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_SAVINGS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case EVENT_LIST:
                 cursor = new MultiUriCursorWrapper(db().getEvents(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
                 break;
             case EVENT_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getEvent(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case EVENT_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getEventTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case RECURRENT_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getRecurrentTransactions(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTION_MODELS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_RECURRENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case RECURRENT_TRANSACTION_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getRecurrentTransaction(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTION_MODELS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_RECURRENT_TRANSACTIONS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case RECURRENT_TRANSFER_LIST:
                 cursor = new MultiUriCursorWrapper(db().getRecurrentTransfers(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFER_MODELS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_RECURRENT_TRANSFERS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case RECURRENT_TRANSFER_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getRecurrentTransfer(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFER_MODELS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_RECURRENT_TRANSFERS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case TRANSACTION_MODEL_LIST:
                 cursor = new MultiUriCursorWrapper(db().getTransactionModels(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTION_MODELS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case TRANSACTION_MODEL_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getTransactionModel(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case TRANSFER_MODEL_LIST:
                 cursor = new MultiUriCursorWrapper(db().getTransferModels(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSFER_MODELS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case TRANSFER_MODEL_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getTransferModel(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_WALLETS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_CATEGORIES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_DEBTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_EVENTS);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case PLACE_LIST:
                 cursor = new MultiUriCursorWrapper(db().getPlaces(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
                 break;
             case PLACE_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getPlace(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
                 break;
             case PLACE_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getPlaceTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PLACES);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case PERSON_LIST:
                 cursor = new MultiUriCursorWrapper(db().getPeople(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
                 break;
             case PERSON_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getPerson(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
                 break;
             case PERSON_TRANSACTION_LIST:
                 cursor = new MultiUriCursorWrapper(db().getPeopleTransactions(parseIdAtIndex(uri, 1), projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_PEOPLE);
-                cursor.setNotificationUri(getContentResolver(), CONTENT_TRANSACTIONS);
                 break;
             case ATTACHMENT_LIST:
                 cursor = new MultiUriCursorWrapper(db().getAttachments(projection, selection, selectionArgs, sortOrder));
-                cursor.setNotificationUri(getContentResolver(), CONTENT_ATTACHMENTS);
                 break;
             case ATTACHMENT_ITEM:
                 cursor = new MultiUriCursorWrapper(db().getAttachment(ContentUris.parseId(uri), projection));
-                cursor.setNotificationUri(getContentResolver(), uri);
                 break;
+        }
+        if (cursor != null) {
+            cursor.setNotificationUri(getContentResolver(), CONTENT_ALL);
         }
         return cursor;
     }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/MultiUriCursorWrapper.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/MultiUriCursorWrapper.java
@@ -25,7 +25,6 @@ import android.database.ContentObserver;
 import android.database.Cursor;
 import android.database.CursorWrapper;
 import android.net.Uri;
-import android.os.Build;
 
 import java.lang.ref.WeakReference;
 import java.util.Iterator;
@@ -34,6 +33,11 @@ import java.util.LinkedHashSet;
 /**
  * This class works as wrapper on top of {@link Cursor}.
  * This allow to register multiple notification uri instead of a single one.
+ *
+ * Nothing registers more than one on it now. What it is still here for is the replay in
+ * registerContentObserver, which hands a newly registered observer the changes this cursor was
+ * already told about. AbstractCursor drops those, and a loader registers after the query it is
+ * loading has returned, so that window is a real one.
  *
  * Credits to: https://gist.github.com/chalup/4201307da02b9cfe4f40
  */
@@ -98,17 +102,18 @@ public class MultiUriCursorWrapper extends CursorWrapper {
         onDeactivateOrClose();
     }
 
-    @SuppressWarnings("deprecation")
+    /**
+     * Under the same lock onChange takes, because this walks the set that method adds to and it
+     * adds from whichever binder thread the notification arrived on. Without the lock a loader
+     * registering here can walk the set while it is being written, and a change that lands
+     * between onChange's dispatch and its add reaches neither the dispatch nor this replay.
+     */
     @Override
     public void registerContentObserver(ContentObserver observer) {
-        mContentObservable.registerObserver(observer);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+        synchronized (mSelfObserverLock) {
+            mContentObservable.registerObserver(observer);
             for (Uri changedByUri : mChangedByUris) {
                 observer.dispatchChange(false, changedByUri);
-            }
-        } else {
-            if (!mChangedByUris.isEmpty()) {
-                observer.dispatchChange(false);
             }
         }
     }
@@ -121,20 +126,9 @@ public class MultiUriCursorWrapper extends CursorWrapper {
         }
     }
 
-    @SuppressWarnings("deprecation")
     private void onChange(boolean selfChange, Uri uri) {
         synchronized (mSelfObserverLock) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
-                mContentObservable.dispatchChange(selfChange, uri);
-            } else {
-                mContentObservable.dispatchChange(selfChange);
-            }
-
-            if (selfChange) {
-                for (Uri notifyUri : mNotifyUris) {
-                    mContentResolver.notifyChange(notifyUri, mSelfObserver);
-                }
-            }
+            mContentObservable.dispatchChange(selfChange, uri);
 
             if (!selfChange) {
                 mChangedByUris.add(uri);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserver.java
@@ -21,15 +21,13 @@ package com.oriondev.moneywallet.ui.widget;
 
 import android.content.Context;
 import android.database.ContentObserver;
-import android.net.Uri;
 import android.os.Handler;
 import android.os.HandlerThread;
 
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 
 /**
- * Pushes a redraw to the placed widgets whenever anything that can move a wallet balance is
- * written.
+ * Pushes a redraw to the placed widgets whenever DataContentProvider announces a write.
  *
  * A balance does not only move when a transaction row is written, and the provider notifies the
  * URI a write came through. A transfer notifies transfers, a debt with a master transaction
@@ -38,9 +36,8 @@ import com.oriondev.moneywallet.storage.database.DataContentProvider;
  * from. Listening to transactions alone would leave a widget showing the figure from before a
  * transfer until something unrelated was saved.
  *
- * The first four are what the wallet list cursor is registered on in DataContentProvider. Savings
- * is the one this needs and that cursor does not, since a goal is deleted from a screen that
- * rebuilds the wallet list on its way back anyway.
+ * Naming those uris here is a list that has to be kept in step with what every write announces,
+ * so this watches the whole provider instead and is told about all of them.
  *
  * This is what keeps the widget level with the app. The slow period in widget_wallet_info covers
  * the other half, a transaction dated ahead coming due, which no write announces.
@@ -51,17 +48,9 @@ public class WalletWidgetObserver extends ContentObserver {
      * Long enough to fold a run of writes into one redraw and short enough that a save the user
      * just made looks immediate. An import is no longer the case that needs it, since those now
      * announce once per list after their transaction commits. Anything that writes a row at a
-     * time still is, a wallet delete taking its transactions with it being the one to picture.
+     * time still is, the recurrence job posting a backlog being the one to picture.
      */
     private static final long COALESCE_DELAY_MILLIS = 250L;
-
-    private static final Uri[] OBSERVED_URIS = new Uri[] {
-            DataContentProvider.CONTENT_WALLETS,
-            DataContentProvider.CONTENT_TRANSACTIONS,
-            DataContentProvider.CONTENT_TRANSFERS,
-            DataContentProvider.CONTENT_DEBTS,
-            DataContentProvider.CONTENT_SAVINGS
-    };
 
     private static volatile Handler sHandler;
     private static volatile Runnable sUpdate;
@@ -94,10 +83,11 @@ public class WalletWidgetObserver extends ContentObserver {
         thread.start();
         sHandler = new Handler(thread.getLooper());
         WalletWidgetObserver observer = new WalletWidgetObserver(sHandler);
-        for (Uri uri : OBSERVED_URIS) {
-            // Descendants too, because the provider notifies the row it wrote and not the list.
-            applicationContext.getContentResolver().registerContentObserver(uri, true, observer);
-        }
+        // Descendants, because no write names CONTENT_ALL itself and an observer that did not
+        // ask for what sits below it would be told about nothing at all. The whole registration
+        // rests on that flag.
+        applicationContext.getContentResolver()
+                .registerContentObserver(DataContentProvider.CONTENT_ALL, true, observer);
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetProvider.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetProvider.java
@@ -55,8 +55,14 @@ import com.oriondev.moneywallet.utils.MoneyFormatter;
 public class WalletWidgetProvider extends AppWidgetProvider {
 
     /**
-     * Redraw every placed widget. Called from WalletWidgetObserver when something that can move a
-     * balance is written, and from PreferenceManager when a setting the figure depends on changes.
+     * Redraw every placed widget. Reached from WalletWidgetObserver for every write
+     * DataContentProvider announces, which is more than can move a balance, from PreferenceManager
+     * when a setting the figure depends on changes, and from onUpdate below when the system asks.
+     * A restore is none of those and asks for a redraw in forgetConfiguredWallets.
+     *
+     * The observer folds a run of writes into one redraw only while they keep landing inside its
+     * delay. Writes further apart than that get one redraw each, which is what attaching several
+     * files one at a time does.
      *
      * Not from the main thread. Asking for the ids is a call into another process and drawing one
      * reads an aggregate over the transaction table.

--- a/app/src/test/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserverSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserverSourceTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.widget;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * One registration that nothing which runs can check, pinned as text the way
+ * DataContentProviderTransactionSourceTest pins what the provider's write methods must be reached
+ * by. There is no way to ask the framework what it was asked to watch, and the instrumented case
+ * that registers the same way pins what the framework does with those arguments and not that this
+ * file passes them.
+ *
+ * Both arguments are all or nothing. Nothing announces CONTENT_ALL itself, so without the
+ * descendants flag the widget is told about no write at all, and a narrower uri is the list this
+ * change deleted coming back one entity at a time. Neither failure says anything at run time, the
+ * widget just holds the figure it was drawn with.
+ *
+ * The lock in MultiUriCursorWrapper.registerContentObserver is NOT pinned here, and a case for it
+ * was written and taken out again. The property is mutual exclusion between two methods, and a
+ * check that reads the file can only see a token: three separate ways were found to leave that
+ * token in place with the exclusion gone, and each pattern written to close one of them let
+ * another through or failed on code that was right. A check that says a property holds when it
+ * does not is worse than not having one, so what guards that lock is the comment on it.
+ *
+ * Comments and literals are stripped before matching, for the reason the precedent gives: an
+ * assertion here must not be satisfied by a comment describing code the file no longer has. What
+ * is matched allows any spacing, so rewrapping a line is not a failure. What it cannot see is a
+ * call that is there and never reached.
+ *
+ * A failure means read the source and decide, not that the app is broken.
+ */
+public class WalletWidgetObserverSourceTest {
+
+    /**
+     * A java string literal, a char literal, a line comment, then a block comment. The literals go
+     * first so that a comment marker inside one cannot cut the line short, and the char literal is
+     * in the list so that a lone quote written as a character cannot invert the quote parity of
+     * everything below it and stop comments being stripped at all.
+     */
+    private static final Pattern STRIPPED = Pattern.compile(
+            "\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*'|//.*?$|/[*].*?[*]/",
+            Pattern.DOTALL | Pattern.MULTILINE);
+
+    private static final Pattern WATCHES_THE_WHOLE_PROVIDER = Pattern.compile(
+            "registerContentObserver\\(\\s*DataContentProvider\\.CONTENT_ALL\\s*,\\s*true\\s*,");
+
+    /** The leading dot keeps unregisterContentObserver out, which contains the rest of this. */
+    private static final Pattern ANY_REGISTRATION = Pattern.compile(
+            "\\.\\s*registerContentObserver\\s*\\(");
+
+    private String source() {
+        String path = "src/main/java/com/oriondev/moneywallet/ui/widget/WalletWidgetObserver.java";
+        File file = new File(path);
+        if (!file.exists()) {
+            // a runner rooted at the repo root instead of the module, which the precedent
+            // handles the same way
+            file = new File("app/" + path);
+        }
+        if (!file.exists()) {
+            fail("Cannot find " + path + " at " + file.getAbsolutePath());
+        }
+        try {
+            String read = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            return STRIPPED.matcher(read).replaceAll(" ");
+        } catch (IOException e) {
+            fail("Cannot read " + path + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    @Test
+    public void theWidgetWatchesTheWholeProviderAndAsksForWhatIsUnderIt() {
+        assertTrue("the widget no longer registers on the whole provider with descendants "
+                        + "included. Nothing announces CONTENT_ALL itself, so without the flag it "
+                        + "is told about nothing at all, and with a narrower uri it is told about "
+                        + "nothing outside that one",
+                WATCHES_THE_WHOLE_PROVIDER.matcher(source()).find());
+    }
+
+    @Test
+    public void theWidgetRegistersOnce() {
+        Matcher matcher = ANY_REGISTRATION.matcher(source());
+        int registrations = 0;
+        while (matcher.find()) {
+            registrations++;
+        }
+        assertTrue("the widget registers on nothing at all", registrations > 0);
+        // a second registration is how the deleted list would grow back, and it would also mean
+        // two redraws asked for per write
+        assertEquals("the widget registers on something as well as the whole provider",
+                1, registrations);
+    }
+}


### PR DESCRIPTION
When a screen in this app shows a list, it asks to be told when the data behind it changes. Until now each screen named the kinds of data it wanted to hear about, 168 entries across 46 screens, and the home screen widget kept a list of five of its own.

Those lists have to be kept in step with two moving things, what a screen actually reads, which changes the moment a query starts joining something new, and what a save actually announces. One of them already needed an entry added by hand when saving a debt from its own transaction started writing the people on that debt. A wrong list breaks nothing loudly, the screen just goes on showing a figure that is no longer true.

Every screen now asks to hear about everything this app saves, and so does the widget. That is one line, it cannot fall behind, and it is what Android's own contacts and calendar do.

What it costs is refreshes. Twenty five of the forty six screens named two kinds of data or fewer and ten named exactly one, so those now refresh on any save instead of only their own. An import still announces once when it finishes and not once per row, but a run of one at a time saves reaches further than it used to. Attaching several files to one transaction is the clearest example.

One more thing went in with it. A lock was missing where a screen starts listening while a save is arriving on another thread, which can drop that notification or crash the load. It was there before this change, and what is new is that any save can reach it.

Tested on an emulator running Android 15, unit and instrumented tests green, no new lint issues. Five new checks cover it, four running on the device and one reading the source, and the two that matter most both fail against a build of master, which is what says they are checking anything.

Not tested: a widget actually placed on a home screen.
