### PR TITLE
Read and write the amount keypad at two decimals when the currency is unknown

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
@@ -76,8 +76,10 @@ public class EquationSolver {
     }
 
     public void setValue(CurrencyUnit currency, long money) {
-        if (currency != null && money != 0L && currency.hasDecimals()) {
-            mFirstNumber = MoneyScale.toHumanAmount(money, currency.getDecimals()).toPlainString();
+        // Scale taken through CurrencyManager for the reason getResult gives.
+        int decimals = CurrencyManager.getDecimals(currency);
+        if (money != 0L && decimals > 0) {
+            mFirstNumber = MoneyScale.toHumanAmount(money, decimals).toPlainString();
         } else {
             mFirstNumber = String.valueOf(money);
         }
@@ -225,17 +227,19 @@ public class EquationSolver {
             return 0L;
         }
         BigDecimal parsedNumber = parseNumber(mFirstNumber);
-        if (mCurrency != null) {
-            if (mComputed) {
-                // An answer is rounded to the currency scale, so 20.00 / 3 stores 667, which is
-                // what master stored for it when it rounded the quotient at the dividend's scale.
-                // A typed number falls through to toMinorUnits, which truncates what will not fit:
-                // 64.9 on a zero decimal currency stays 64, as the entry tests pin.
-                parsedNumber = parsedNumber.setScale(mCurrency.getDecimals(), RoundingMode.HALF_EVEN);
-            }
-            return MoneyScale.toMinorUnits(parsedNumber, mCurrency.getDecimals());
+        // A currency this installation cannot resolve is worth two decimals here, which is what
+        // CurrencyManager.getDecimals answers for a null one and what MoneyFormatter divides the
+        // same row by when it cannot resolve it either. This used to return the typed number as
+        // if it were already minor units, so a wallet naming a missing currency stored a typed
+        // 12.50 as 12, which MoneyFormatter then renders as 0.12.
+        int decimals = CurrencyManager.getDecimals(mCurrency);
+        if (mComputed) {
+            // An answer is rounded to the currency scale, so 20.00 / 3 stores 667. A typed
+            // number falls through to toMinorUnits, which truncates what will not fit: 64.9 on a
+            // zero decimal currency stays 64, as the entry tests pin.
+            parsedNumber = parsedNumber.setScale(decimals, RoundingMode.HALF_EVEN);
         }
-        return parsedNumber.longValue();
+        return MoneyScale.toMinorUnits(parsedNumber, decimals);
     }
 
     /**

--- a/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
@@ -771,4 +771,125 @@ public class EquationSolverTest {
 
         assertEquals(250L, result);
     }
+
+    // Unresolvable currency. mCurrency is null when the wallet on the screen names a currency
+    // this installation does not have, which CurrencyManager.getCurrency answers null for. The
+    // keypad reads and writes those rows at two decimals, the same scale MoneyFormatter renders
+    // them at, instead of treating the typed number as minor units already.
+
+    @Test
+    public void testGetResult_unresolvableCurrencyAndTypedValue() {
+        equationSolver.mFirstNumber = "12.50";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(1250L, result);
+    }
+
+    @Test
+    public void testGetResult_unresolvableCurrencyAndNegativeValue() {
+        equationSolver.mFirstNumber = "-12.50";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(-1250L, result);
+    }
+
+    @Test
+    public void testGetResult_unresolvableCurrencyAndWholeValue() {
+        equationSolver.mFirstNumber = "12";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(1200L, result);
+    }
+
+    @Test
+    public void testGetResult_unresolvableCurrencyTruncatesATypedThirdDecimal() {
+        equationSolver.mFirstNumber = "12.509";
+
+        long result = equationSolver.getResult();
+
+        assertEquals(1250L, result);
+    }
+
+    @Test
+    public void testGetResult_unresolvableCurrencyRoundsAComputedAnswer() {
+        enter("20.00", EquationSolver.Operation.DIVISION, "3");
+
+        long result = equationSolver.getResult();
+
+        assertEquals(667L, result);
+    }
+
+    @Test
+    public void testSetValue_unresolvableCurrencyReadsAStoredAmountBackWhole() {
+        equationSolver.setValue(null, 1250L);
+
+        assertEquals("12.50", equationSolver.mFirstNumber);
+        assertEquals(1250L, equationSolver.getResult());
+    }
+
+    // setValue with a currency that does resolve. Without these, the scale it reads a stored
+    // amount back at is pinned only where the currency is null, so replacing the lookup with a
+    // literal 2 passes every other test in this class.
+
+    @Test
+    public void testSetValue_zeroDecimalCurrencyReadsAStoredAmountBackWhole() {
+        equationSolver.setValue(new CurrencyUnit("", "", "", 0), 1250L);
+
+        assertEquals("1250", equationSolver.mFirstNumber);
+        assertEquals(1250L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testSetValue_twoDecimalCurrencyReadsAStoredAmountBackWhole() {
+        equationSolver.setValue(new CurrencyUnit("", "", "", 2), 1250L);
+
+        assertEquals("12.50", equationSolver.mFirstNumber);
+        assertEquals(1250L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testSetValue_threeDecimalCurrencyReadsAStoredAmountBackWhole() {
+        equationSolver.setValue(new CurrencyUnit("", "", "", 3), 1250L);
+
+        assertEquals("1.250", equationSolver.mFirstNumber);
+        assertEquals(1250L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testSetValue_oneDecimalCurrencyReadsAStoredAmountBackWhole() {
+        equationSolver.setValue(new CurrencyUnit("", "", "", 1), 1250L);
+
+        assertEquals("125.0", equationSolver.mFirstNumber);
+        assertEquals(1250L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testSetValue_aNegativeStoredAmountReadsBackWhole() {
+        // A wallet may open on a negative balance, and NewEditWalletActivity is the one screen
+        // that hands the keypad a real currency with negatives allowed. Were this to fall to the
+        // bare number, confirming without pressing a key would multiply the balance by a hundred.
+        equationSolver.setValue(new CurrencyUnit("", "", "", 2), -1250L);
+
+        assertEquals("-12.50", equationSolver.mFirstNumber);
+        assertEquals(-1250L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testSetValue_anEmptyAmountStartsOnABareZero() {
+        // CalculatorActivity passes 0 every time the keypad opens on an empty field, and
+        // appendNumber only replaces the display when it reads exactly "0". Were this to arrive
+        // as "0.00", the first digit typed would append to it, so a 5 would read "0.005" and
+        // reach the ledger as nothing.
+        equationSolver.setValue(new CurrencyUnit("", "", "", 2), 0L);
+
+        assertEquals("0", equationSolver.mFirstNumber);
+
+        equationSolver.appendNumber("5");
+
+        assertEquals("5", equationSolver.mFirstNumber);
+        assertEquals(500L, equationSolver.getResult());
+    }
 }


### PR DESCRIPTION
To store an amount you type, this app has to know how many decimal places the currency uses, and it gets that from the wallet you picked.

A wallet remembers its currency by code, and restoring an old backup brings the wallet back without the currency, so one you made yourself comes back as a code this copy of the app no longer has. The keypad then had no decimal places to work with, and treated what you typed as if it were already the smallest unit. Typing 12.50 stored twelve of those units and the app showed it back to you as 0.12. Opening that saved row again put the bare stored number on the keypad instead of the amount.

Both directions now fall back to two decimal places, which is already what the rest of the app uses to draw a row whose currency it cannot find, and what Unicode's currency data gives for one it has no entry for. What you type and what you see are the same number again.

Two decimal places is a house rule, not something read off the row, because a currency that has gone took its decimal places with it. Of the 157 currencies this app ships, 43 use none and 6 use three, so if one of those comes back later its amounts will read a hundred times high or ten times low.

That same state, no currency yet, also happens on a new budget before any wallets are chosen. Typing an amount there and choosing a wallet afterwards now stores a different number than it used to, right for most currencies and wrong for the ones using no decimal places. That is not what this change is for, and an amount staying put while the currency under it changes is an older problem left alone here.

Tested on an emulator running Android 15 against a wallet naming a currency that is not installed, driven through the real screens, and a build of master the same way on the same data. Unit and instrumented tests green, no new lint issues.
