### PR TITLE
Hold the exchange rate cache in a map built for two threads

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/cache/ExchangeRateCache.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/cache/ExchangeRateCache.java
@@ -26,19 +26,32 @@ import android.text.TextUtils;
 
 import com.oriondev.moneywallet.model.ExchangeRate;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by andre on 25/03/2018.
  */
 public class ExchangeRateCache {
 
+    /**
+     * Written by the rate download service on its own thread and read from the main thread on
+     * every keystroke in the currency converter, so it cannot be a plain map. It used to be one:
+     * a get landing during a resize can answer null for a rate the cache holds, and a get that
+     * reaches a CacheObj the writer has only just allocated can read the three fields at their
+     * defaults, divide by a rate of zero, and hand the converter an infinite rate it cannot parse.
+     *
+     * A reader takes no lock here, and that is a requirement rather than a preference.
+     * CurrencyManagerSourceTest lists CurrencyManager.getExchangeRate among the methods a thread
+     * inside a database transaction can reach and asserts none of them takes a lock; that method
+     * hands straight to this class. ConcurrentHashMap.get blocks on nothing, and its put is what
+     * carries a CacheObj's fields to the thread that reads them.
+     */
     private final Map<String, CacheObj> mCacheMemory;
     private final SQLCache mCacheStorage;
 
     public ExchangeRateCache(Context context) {
-        mCacheMemory = new HashMap<>();
+        mCacheMemory = new ConcurrentHashMap<>();
         mCacheStorage = new SQLCache(context);
         loadCacheInMemory();
     }
@@ -52,8 +65,15 @@ public class ExchangeRateCache {
         Cursor cursor = mCacheStorage.getExchangeRates(projection, null, null, null);
         if (cursor != null) {
             while (cursor.moveToNext()){
+                String iso = cursor.getString(cursor.getColumnIndex(SQLCache.ExchangeRateT.CURRENCY_ISO));
+                // exchange_currency_iso is a TEXT PRIMARY KEY with no NOT NULL, so a row can carry
+                // no iso at all. It names nothing any reader can ask for, and putting it would
+                // throw here and take the app down on the next launch instead of on that row.
+                if (iso == null) {
+                    continue;
+                }
                 CacheObj cacheObj = new CacheObj();
-                cacheObj.mCurrency = cursor.getString(cursor.getColumnIndex(SQLCache.ExchangeRateT.CURRENCY_ISO));
+                cacheObj.mCurrency = iso;
                 cacheObj.mRate = cursor.getDouble(cursor.getColumnIndex(SQLCache.ExchangeRateT.RATE));
                 cacheObj.mTimestamp = cursor.getLong(cursor.getColumnIndex(SQLCache.ExchangeRateT.TIMESTAMP));
                 mCacheMemory.put(cacheObj.mCurrency, cacheObj);
@@ -63,6 +83,14 @@ public class ExchangeRateCache {
     }
 
     public void setExchangeRate(String currency, double rate, long timestamp) {
+        // The same null key getExchangeRate refuses, refused on the way in as well. A rate filed
+        // under no iso is one nothing can look up. The only caller today cannot reach this, since
+        // it asks the rates it downloaded whether they name this currency and a null names
+        // nothing, but the guard belongs with the map that needs it and not in a service in
+        // another package.
+        if (currency == null) {
+            return;
+        }
         CacheObj cacheObj = new CacheObj();
         cacheObj.mCurrency = currency;
         cacheObj.mRate = rate;
@@ -78,6 +106,14 @@ public class ExchangeRateCache {
     public ExchangeRate getExchangeRate(String currency1, String currency2) {
         if (TextUtils.equals(currency1, currency2)) {
             return new ExchangeRate(currency1, currency2, 1, System.currentTimeMillis());
+        }
+        // A currency row can carry a null iso, since Schema declares it TEXT PRIMARY KEY with no
+        // NOT NULL and SQLite allows a null there, and CurrencyManager.getExchangeRate checks the
+        // two currencies for null without checking their isos. A map that refuses a null key
+        // throws on one, where the map this replaced answered null and the pair below returned
+        // null. This keeps that answer. Two null isos are equal and never reach here.
+        if (currency1 == null || currency2 == null) {
+            return null;
         }
         CacheObj rate1 = mCacheMemory.get(currency1);
         CacheObj rate2 = mCacheMemory.get(currency2);

--- a/app/src/test/java/com/oriondev/moneywallet/utils/CurrencyManagerSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/CurrencyManagerSourceTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -73,7 +74,10 @@ public class CurrencyManagerSourceTest {
     };
 
     private static String readSource() {
-        String path = "src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java";
+        return readSource("src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java");
+    }
+
+    private static String readSource(String path) {
         File file = new File(path);
         if (!file.exists()) {
             // a runner rooted at the repo root instead of the module, which the precedent
@@ -81,13 +85,13 @@ public class CurrencyManagerSourceTest {
             file = new File("app/" + path);
         }
         if (!file.exists()) {
-            fail("Cannot find CurrencyManager.java at " + file.getAbsolutePath());
+            fail("Cannot find " + path + " at " + file.getAbsolutePath());
         }
         try {
             String source = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
             return STRIPPED.matcher(source).replaceAll(" ").replaceAll("\\s+", " ");
         } catch (IOException e) {
-            fail("Cannot read CurrencyManager.java: " + e.getMessage());
+            fail("Cannot read " + path + ": " + e.getMessage());
             return null;
         }
     }
@@ -135,6 +139,102 @@ public class CurrencyManagerSourceTest {
             "public static ExchangeRateCache getExchangeRateCache() {",
             "public static int getDecimals(CurrencyUnit currency) {",
     };
+
+    /**
+     * CurrencyManager.getExchangeRate is one of the READERS below and hands straight to
+     * ExchangeRateCache, so the rule that a reader takes no lock has to hold one file down too.
+     * These two cases are what holds it, since every case here reads CurrencyManager.java alone.
+     */
+    @Test
+    public void theExchangeRateCacheIsAConcurrentMapAndNotAPlainOne() {
+        String source = readSource(
+                "src/main/java/com/oriondev/moneywallet/storage/cache/ExchangeRateCache.java");
+        assertTrue("the exchange rate cache is no longer a ConcurrentHashMap. It is written by "
+                        + "the rate download thread and read from the main thread on every "
+                        + "keystroke, so a plain map can answer null for a rate it holds and can "
+                        + "hand back a CacheObj whose fields are still at their defaults",
+                source.contains("mCacheMemory = new ConcurrentHashMap<>();"));
+        assertFalse("something in ExchangeRateCache builds a plain HashMap again",
+                source.contains("new HashMap"));
+        // the price of a map that refuses a null key, paid at all three places a key touches it.
+        // A currency row can carry a null iso and CurrencyManager.getExchangeRate does not check
+        // for one, so without these the throw replaces the null the plain map used to answer, and
+        // on the load path it would take the app down at startup instead of on that row
+        String reader = bodyOf(source,
+                "public ExchangeRate getExchangeRate(String currency1, String currency2) {");
+        assertTrue("getExchangeRate no longer refuses a null iso before the lookup. A "
+                        + "ConcurrentHashMap throws on a null key where the map it replaced "
+                        + "answered null and this method returned null",
+                reader.contains("if (currency1 == null || currency2 == null) { return null; }"));
+        // Boxed in from both sides. Above the equal check, two null isos stop taking that branch
+        // and a currency converted to itself answers nothing instead of a rate of one. Below the
+        // lookup it is simply too late, and the string reads the same wherever it sits, so
+        // presence alone pins nothing
+        assertTrue("the null iso guard moved above the equality check, so getExchangeRate answers "
+                        + "nothing for two null isos where it used to answer a rate of one",
+                reader.indexOf("TextUtils.equals") < reader.indexOf("currency1 == null"));
+        assertTrue("the null iso guard sits below the lookup it exists to come before, so a null "
+                        + "iso reaches ConcurrentHashMap.get and throws",
+                reader.indexOf("currency1 == null") < reader.indexOf("mCacheMemory.get"));
+        // and on the method's own path, not tucked inside the equality branch above it. Nested
+        // there it reads as being in the right place and between the right two lines, and a
+        // single null iso never reaches it at all. Depth 1 is a statement of the method
+        assertEquals("the null iso guard is nested inside a block, so the case it exists for takes "
+                        + "the branch around it and throws on the lookup",
+                1, depthOf(reader, reader.indexOf("currency1 == null")));
+        String writer = bodyOf(source,
+                "public void setExchangeRate(String currency, double rate, long timestamp) {");
+        assertTrue("setExchangeRate no longer refuses a null iso, so a rate filed under none "
+                        + "throws on the put instead of being dropped",
+                writer.contains("if (currency == null) { return; }"));
+        assertTrue("setExchangeRate refuses a null iso only after storing it, which is the throw "
+                        + "the guard exists to avoid",
+                writer.indexOf("currency == null") < writer.indexOf("mCacheMemory.put"));
+        assertEquals("setExchangeRate's null iso guard is nested inside a block instead of "
+                        + "standing on the method's own path", 1,
+                depthOf(writer, writer.indexOf("currency == null")));
+        String load = bodyOf(source, "private void loadCacheInMemory() {");
+        assertTrue("loadCacheInMemory no longer skips a row with no iso, so one in cache.db throws "
+                        + "while the cache is being built and takes the app down at startup",
+                load.contains("if (iso == null) { continue; }"));
+        assertTrue("loadCacheInMemory skips a row with no iso only after putting it, so the row it "
+                        + "means to drop still throws during startup",
+                load.indexOf("iso == null") < load.indexOf("mCacheMemory.put"));
+        // depth 3 is inside the cursor check and inside the row loop, which is where a per row
+        // skip has to sit. Anywhere shallower it runs once or not at all
+        assertEquals("loadCacheInMemory's skip is not inside the row loop, so it does not run per "
+                        + "row", 3, depthOf(load, load.indexOf("iso == null")));
+        // and the reader must not reach the storage at all. Every mCacheStorage call enters
+        // SQLiteOpenHelper.getReadableDatabase, which is synchronized, so a fallback read here
+        // would put a monitor AND a disk read on the keystroke path that takes nothing. The token
+        // scan below cannot see that lock, because it is spelled in another file
+        assertFalse("getExchangeRate reaches mCacheStorage. Every call on it enters a "
+                        + "synchronized SQLiteOpenHelper method, so the reader this file pins as "
+                        + "lock free would take one, and wait on a disk read on the main thread",
+                reader.contains("mCacheStorage"));
+    }
+
+    /**
+     * Over the whole file and not one method body, for the reason the reload case below gives: a
+     * reader that took its lock inside a helper it calls would pass a per body check. Four of the
+     * five spellings open no block either, so counting is the only way to see them.
+     *
+     * A lock here would not deadlock an importer, since cache.db is its own helper and shares no
+     * connection with database.db. It would stall a main thread keystroke behind a disk write,
+     * and it would put a monitor under a method this file pins as taking nothing.
+     */
+    @Test
+    public void nothingInTheExchangeRateCacheTakesALock() {
+        String source = readSource(
+                "src/main/java/com/oriondev/moneywallet/storage/cache/ExchangeRateCache.java");
+        for (String lock : WAYS_TO_TAKE_A_LOCK) {
+            assertEquals("ExchangeRateCache takes a lock through " + lock.trim() + ". "
+                            + "CurrencyManager.getExchangeRate is listed below as a reader that "
+                            + "takes nothing and it hands straight to this class, so a lock "
+                            + "anywhere in the file can end up on the read path",
+                    0, count(source, lock));
+        }
+    }
 
     @Test
     public void noReaderOfTheCacheTakesALock() {


### PR DESCRIPTION
The app keeps a small table of exchange rates in memory so the currency converter can answer instantly as you type. It is filled in the background when rates are downloaded, and read on the main thread every time you press a key, and it was not built to be used from two places at once.

Two things could go wrong, both silent. A read landing while the background download is growing the table can come back empty for a rate the app is holding, so the converter shows nothing for a pair it knows. Worse, a read can catch a rate the download has only part way stored and see it as zero, which makes the conversion infinite, and the converter then stops updating with nothing shown and nothing logged.

It now uses a table built for exactly this, one that can be read while it is being written without either side waiting on the other. Making the reader wait would have been the shorter change and it is the one thing this part of the app may not do, because a reader that can wait is half of a deadlock removed here recently. The check guarding that rule only looks at one file, so a wait added one file deeper would have gone straight past it.

The new table refuses an entry with no name, where the old one quietly accepted one. A currency can be stored with no code at all, so three places had to start turning those away: reading, writing, and loading at startup. Reading and writing answer exactly what they used to. The one at startup drops the bad row instead of failing, which would otherwise have stopped the app before it opened.

Two checks read the source and refuse the wait, the wrong kind of table, and any of the three refusals being deleted or moved somewhere it would not run. Ten deliberate breakages were tried against them and every one turned a check red.

Tested on an emulator running Android 15, unit and instrumented tests green, no new lint issues.
