### PR TITLE
Let the default currencies be written back over rows that are there and not served

### DIFF
--- a/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
+++ b/app/src/androidTest/java/com/oriondev/moneywallet/storage/database/SQLDatabaseTest.java
@@ -1973,6 +1973,205 @@ public class SQLDatabaseTest {
         return contentValues;
     }
 
+    /**
+     * Every query of the currency table filters DELETED = 0, so a row carrying a 1 is one the app
+     * does not serve while its iso still holds the primary key. A backup restored through
+     * SyncContentProvider writes that column straight through, so an installation can hold every
+     * currency and offer none, and the default set written to repair that collided with those rows
+     * and landed nothing.
+     */
+    @Test
+    public void insertCurrencyBringsBackARowThatIsThereAndNotServed() {
+        assertEquals("TST", mDatabase.insertCurrency(currencyValues("TST")));
+        markDeleted("TST");
+        assertEquals("marking the row deleted did not stop it being served, so what follows is "
+                + "not being asked anything", 0, servedCount("TST"));
+
+        assertEquals("TST", mDatabase.insertCurrency(seedValues("TST")));
+
+        assertEquals("the row is still not served, so the default set cannot be written back over "
+                + "a table that holds it and offers nothing", 1, servedCount("TST"));
+    }
+
+    /**
+     * The editor creates a currency through the same method and must not be given the revive. A
+     * row that came from a backup as deleted holds that backup's name, symbol and decimals, so
+     * answering the editor with it would discard everything the user typed and report success.
+     */
+    @Test
+    public void insertCurrencyDoesNotBringBackARowForACallerThatDidNotAsk() {
+        assertEquals("TST", mDatabase.insertCurrency(currencyValues("TST")));
+        markDeleted("TST");
+
+        assertNull("an insert that did not ask for the revive was answered with an existing row",
+                mDatabase.insertCurrency(currencyValues("TST")));
+
+        assertEquals("a caller that did not ask for the revive brought the row back anyway",
+                0, servedCount("TST"));
+    }
+
+    /** The revive is for the iso it was asked about, not for every row that is not served. */
+    @Test
+    public void insertCurrencyBringsBackOnlyTheIsoItWasAskedAbout() {
+        assertEquals("TST", mDatabase.insertCurrency(currencyValues("TST")));
+        assertEquals("TSU", mDatabase.insertCurrency(currencyValues("TSU")));
+        markDeleted("TST");
+        markDeleted("TSU");
+
+        assertEquals("TST", mDatabase.insertCurrency(seedValues("TST")));
+
+        assertEquals(1, servedCount("TST"));
+        assertEquals("reviving one currency brought back another the caller said nothing about",
+                0, servedCount("TSU"));
+    }
+
+    /**
+     * The scale is the reason this writes as little as it does. Money is stored as a long scaled
+     * by the currency's decimals, which is why updateCurrency reads the old value first and sends
+     * every amount held in that currency through fixCurrencyAmounts before it changes them.
+     */
+    @Test
+    public void insertCurrencyLeavesTheScaleOfTheRowItBringsBack() {
+        ContentValues owned = currencyValues("TST");
+        owned.put(Contract.Currency.DECIMALS, 2);
+        assertEquals("TST", mDatabase.insertCurrency(owned));
+        markDeleted("TST");
+        // the default set's own idea of this currency, at a different scale from the owner's
+        ContentValues fromTheAssetFile = seedValues("TST");
+        fromTheAssetFile.put(Contract.Currency.DECIMALS, 0);
+
+        fromTheAssetFile.put(Contract.Currency.NAME, "From the asset file");
+        fromTheAssetFile.put(Contract.Currency.SYMBOL, "A");
+
+        assertEquals("TST", mDatabase.insertCurrency(fromTheAssetFile));
+
+        assertEquals("bringing the row back moved its decimals, so every amount already stored in "
+                        + "that currency now means something else, with nothing rescaled and "
+                        + "nothing said", 2, servedDecimals("TST"));
+        // the same rule one size down. These are the owner's, and the asset file is not entitled
+        // to them either
+        assertEquals("bringing the row back renamed the owner's currency from the asset file",
+                "Currency TST", servedString("TST", Contract.Currency.NAME));
+        assertEquals("bringing the row back took the owner's symbol from the asset file",
+                "T", servedString("TST", Contract.Currency.SYMBOL));
+        // the uuid is the row's identity in the backup it came from, and the column is NOT NULL
+        // UNIQUE, so writing a computed one over it can also collide and raise out of update,
+        // where the insert above would have answered a quiet -1
+        assertEquals("bringing the row back rewrote the uuid it arrived with",
+                "from-the-backup-TST", storedValue("TST", Schema.Currency.UUID));
+        assertEquals("bringing the row back cleared the owner's favourite flag",
+                "1", storedValue("TST", Schema.Currency.FAVOURITE));
+        // and it is a write, so it says when it happened
+        assertFalse("bringing the row back left the timestamp of the backup it came from, so an "
+                        + "export carries the wrong last edit for it",
+                "1".equals(storedValue("TST", Schema.Currency.LAST_EDIT)));
+    }
+
+    /**
+     * The revive is for a row that is not served. Asking for it against one that is has to be
+     * refused, or a caller that meant to insert is told it did and a row nobody edited has its
+     * timestamp moved. The case below covers a caller that did not ask, and returns at the gate
+     * before this clause is reached, so it cannot stand in for this one.
+     */
+    @Test
+    public void insertCurrencyDoesNotBringBackARowThatIsAlreadyServed() {
+        assertEquals("TST", mDatabase.insertCurrency(currencyValues("TST")));
+        String beforeTheSecondInsert = storedValue("TST", Schema.Currency.LAST_EDIT);
+
+        assertNull("an insert that asked for the revive was answered with a row that is already "
+                        + "served, so a collision reads as a success",
+                mDatabase.insertCurrency(seedValues("TST")));
+
+        assertEquals("the refused insert moved the timestamp of a row it did not change",
+                beforeTheSecondInsert, storedValue("TST", Schema.Currency.LAST_EDIT));
+    }
+
+    @Test
+    public void insertCurrencyStillRefusesOneThatIsAlreadyServed() {
+        assertEquals("TST", mDatabase.insertCurrency(currencyValues("TST")));
+
+        assertNull("a second insert of a currency that is already there was accepted, so the "
+                        + "currency editor can take over one that exists",
+                mDatabase.insertCurrency(currencyValues("TST")));
+    }
+
+    /** What the default set sends, which is the only caller that asks for a revive. */
+    private ContentValues seedValues(String iso) {
+        ContentValues contentValues = currencyValues(iso);
+        contentValues.put(Contract.Currency.REVIVE_IF_DELETED, true);
+        return contentValues;
+    }
+
+    private String servedString(String iso, String column) {
+        Cursor cursor = mDatabase.getCurrencies(new String[] {column},
+                Contract.Currency.ISO + " = ?", new String[] {iso}, null);
+        assertNotNull(cursor);
+        try {
+            assertTrue("no served row for " + iso, cursor.moveToFirst());
+            return cursor.getString(cursor.getColumnIndex(column));
+        } finally {
+            cursor.close();
+        }
+    }
+
+    /**
+     * The state a restore leaves, and not merely a deleted row. A row that arrived from a backup
+     * carries that backup's uuid, which is nothing this build would compute, and whatever the
+     * owner had set on it. A ghost built by deleting one of our own inserts holds exactly the
+     * values a fresh insert would write, so it cannot tell a revive that keeps them from one that
+     * writes them again.
+     */
+    private void markDeleted(String iso) {
+        ContentValues values = new ContentValues();
+        values.put(Schema.Currency.DELETED, true);
+        values.put(Schema.Currency.UUID, "from-the-backup-" + iso);
+        values.put(Schema.Currency.FAVOURITE, true);
+        // a timestamp from the backup and not one this run produced. Left as the insert wrote it,
+        // the case below compares two readings of the clock taken a few statements apart and can
+        // fail on a fast run for a defect that is not there
+        values.put(Schema.Currency.LAST_EDIT, 1L);
+        mDatabase.getWritableDatabase().update(Schema.Currency.TABLE, values,
+                Schema.Currency.ISO + " = ?", new String[] {iso});
+    }
+
+    /** Straight off the table, for the columns the served view does not carry. */
+    private String storedValue(String iso, String column) {
+        Cursor cursor = mDatabase.getWritableDatabase().query(Schema.Currency.TABLE,
+                new String[] {column}, Schema.Currency.ISO + " = ?", new String[] {iso},
+                null, null, null);
+        assertNotNull(cursor);
+        try {
+            assertTrue("no row at all for " + iso, cursor.moveToFirst());
+            return cursor.getString(0);
+        } finally {
+            cursor.close();
+        }
+    }
+
+    private int servedCount(String iso) {
+        Cursor cursor = mDatabase.getCurrencies(new String[] {Contract.Currency.ISO},
+                Contract.Currency.ISO + " = ?", new String[] {iso}, null);
+        try {
+            return cursor == null ? 0 : cursor.getCount();
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+    }
+
+    private int servedDecimals(String iso) {
+        Cursor cursor = mDatabase.getCurrencies(new String[] {Contract.Currency.DECIMALS},
+                Contract.Currency.ISO + " = ?", new String[] {iso}, null);
+        assertNotNull(cursor);
+        try {
+            assertTrue("no served row for " + iso, cursor.moveToFirst());
+            return cursor.getInt(cursor.getColumnIndex(Contract.Currency.DECIMALS));
+        } finally {
+            cursor.close();
+        }
+    }
+
     private ContentValues currencyValues(String iso) {
         ContentValues contentValues = new ContentValues();
         contentValues.put(Contract.Currency.ISO, iso);

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
@@ -42,6 +42,11 @@ public class Contract {
         public static final String DECIMALS = Schema.Currency.DECIMALS;
         public static final String FAVOURITE = Schema.Currency.FAVOURITE;
         public static final String FIX_MONEY_DECIMALS = "action_fix_money_decimals";
+        /**
+         * Asks an insert to bring back a row that is present and not served instead of being
+         * refused by it. Only the default set sets this. See SQLDatabase.insertCurrency.
+         */
+        public static final String REVIVE_IF_DELETED = "action_revive_if_deleted";
     }
 
     public static final class Wallet {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -581,8 +581,50 @@ import java.util.function.Supplier;
         cv.put(Schema.Currency.UUID, "currency_" + contentValues.getAsString(Contract.Currency.ISO));
         cv.put(Schema.Currency.LAST_EDIT, System.currentTimeMillis());
         cv.put(Schema.Currency.DELETED, false);
+        String iso = contentValues.getAsString(Contract.Currency.ISO);
         if (getWritableDatabase().insert(Schema.Currency.TABLE, null, cv) > 0) {
-            return contentValues.getAsString(Contract.Currency.ISO);
+            return iso;
+        }
+        // The insert is refused when the iso is already there, and it answers -1 without raising,
+        // so nothing above here can tell that apart from any other failure. A row that is present
+        // and deleted is one getCurrencies will not return, so the currency is gone as far as the
+        // app is concerned while its iso still holds the primary key against the row that would
+        // bring it back. Revive it.
+        //
+        // This is what makes the default set loadable again. That set is written exactly when
+        // nothing is being served, and every insert of it collided with such a row and landed
+        // nothing, so the table stayed empty and the app had no currency to offer.
+        //
+        // NOTHING BUT THE DELETED FLAG IS WRITTEN, and that is the whole of the care here. The
+        // decimals on the row are the scale every amount held in that currency is already stored
+        // at. The other path that changes them, updateCurrency, at least asks: it reads the old
+        // value first and rescales every wallet, transaction, debt, saving and budget through
+        // fixCurrencyAmounts, though only when the caller sets FIX_MONEY_DECIMALS, which the
+        // editor decides by a dialog the user answers. Copying the caller's decimals onto an
+        // existing row here would move that scale under money nobody rescaled and nobody was
+        // asked about, so a currency the owner had set to two decimals would read a hundred times
+        // over once the default set claimed it back. The name, the symbol, the favourite flag and
+        // the uuid are left for the same reason in miniature: they are the owner's, not the asset
+        // file's, and the uuid is the row's identity in the backup it came from.
+        //
+        // Only when the caller asked, which is the default set and nothing else. The editor
+        // creates a currency through this same method, and for it a collision has to stay a
+        // refusal: a row that arrived from a backup as deleted carries that backup's name, symbol
+        // and decimals, so reviving one on the editor's behalf would answer a typed 8 decimal
+        // Bitcoin with whatever that row happened to hold, report success, and throw away
+        // everything typed. On master that create was a silent no op and the user knew to look
+        // again. The two callers want opposite things from a collision, so they have to say which.
+        if (!contentValues.containsKey(Contract.Currency.REVIVE_IF_DELETED)
+                || !contentValues.getAsBoolean(Contract.Currency.REVIVE_IF_DELETED)) {
+            return null;
+        }
+        // A row that is already served is refused either way.
+        ContentValues revived = new ContentValues();
+        revived.put(Schema.Currency.DELETED, false);
+        revived.put(Schema.Currency.LAST_EDIT, System.currentTimeMillis());
+        String where = Schema.Currency.ISO + " = ? AND " + Schema.Currency.DELETED + " = 1";
+        if (getWritableDatabase().update(Schema.Currency.TABLE, revived, where, new String[] {iso}) > 0) {
+            return iso;
         }
         return null;
     }

--- a/app/src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/CurrencyManager.java
@@ -212,9 +212,18 @@ public class CurrencyManager {
         return currencies;
     }
 
+    /**
+     * Seeds the currency table from the asset file and answers what the table holds
+     * afterwards, which is not always what was written. An insert that collides on the ISO
+     * primary key is refused, and a refused insert returns a null uri and raises nothing, so
+     * a table holding every currency already but with all of them deleted reads empty here and
+     * used to publish the whole file anyway, naming currencies the provider answers nothing for.
+     * insertCurrency brings such a row back now, and this answers with what the table holds
+     * afterwards so the two cannot disagree. It costs one more query every time a seed runs,
+     * which invalidateCache above reaches from the main thread.
+     */
     private static Map<String, CurrencyUnit> loadDefaultCurrencies(Context context) {
         final List<ContentValues> rows = new ArrayList<>();
-        Map<String, CurrencyUnit> currencies = new HashMap<>();
         try {
             // open assets file and load all the default currencies into a JSONArray
             StringBuilder jsonBuilder = new StringBuilder();
@@ -234,15 +243,11 @@ public class CurrencyManager {
                 contentValues.put(Contract.Currency.NAME, currency.getString("name"));
                 contentValues.put(Contract.Currency.SYMBOL, currency.optString("symbol", null));
                 contentValues.put(Contract.Currency.DECIMALS, currency.optInt("decimals", 2));
+                // bring back a row this installation holds and does not serve, which is the state
+                // that made this seed land nothing at all. The currency editor inserts without
+                // this and a collision stays a refusal for it
+                contentValues.put(Contract.Currency.REVIVE_IF_DELETED, true);
                 rows.add(contentValues);
-                // directly store the currency inside the local cache
-                CurrencyUnit currencyUnit = new CurrencyUnit(
-                        contentValues.getAsString(Contract.Currency.ISO),
-                        contentValues.getAsString(Contract.Currency.NAME),
-                        contentValues.getAsString(Contract.Currency.SYMBOL),
-                        contentValues.getAsInteger(Contract.Currency.DECIMALS)
-                );
-                currencies.put(currencyUnit.getIso(), currencyUnit);
             }
         } catch (IOException | JSONException e) {
             throw new RuntimeException("Exception while reading currencies file from assets: " + e.getMessage(), e);
@@ -262,7 +267,9 @@ public class CurrencyManager {
         } catch (Exception e) {
             throw new RuntimeException("Exception while storing the default currencies: " + e.getMessage(), e);
         }
-        return currencies;
+        // read back rather than answering with the file, so the cache holds what the
+        // provider will serve and never more than it
+        return loadUserCurrencies(context);
     }
 
     /**

--- a/app/src/test/java/com/oriondev/moneywallet/utils/CurrencyManagerSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/CurrencyManagerSourceTest.java
@@ -236,6 +236,28 @@ public class CurrencyManagerSourceTest {
         }
     }
 
+    /**
+     * The revive in SQLDatabase.insertCurrency is dead code unless a caller asks for it, and this
+     * is the only line in the app that does. Every case that exercises the revive calls
+     * insertCurrency directly with a flag it builds itself, so deleting this line leaves all of
+     * them green and quietly puts the behaviour back to what it was.
+     */
+    @Test
+    public void theDefaultSetAsksForARowThatIsThereToBeBroughtBack() {
+        String body = bodyOf(readSource(),
+                "private static Map<String, CurrencyUnit> loadDefaultCurrencies(Context context) {");
+        assertTrue("the default set no longer asks for a row that is present and not served to be "
+                        + "brought back, so its inserts collide with those rows and land nothing, "
+                        + "which is the whole of what this repairs",
+                body.contains("put(Contract.Currency.REVIVE_IF_DELETED, true)"));
+        // and it answers with the table and not with the file it just tried to write. Without
+        // this, a revive that stops working goes back to publishing currencies the provider
+        // serves none of, which is the failure the revive exists to end
+        assertTrue("the default set answers with the map it built from the asset file again, so a "
+                        + "seed that lands nothing still publishes every currency in that file",
+                body.contains("return loadUserCurrencies(context);"));
+    }
+
     @Test
     public void noReaderOfTheCacheTakesALock() {
         String source = readSource();


### PR DESCRIPTION
Restoring a backup made in another copy of this app can leave you with no currencies at all, and nothing in the app brings them back.

The currency list only offers currencies that are not marked as removed. Removing one here deletes it outright, so this app never sets that mark and its own backups never carry one. A backup from somewhere else can, and restoring it copies the mark across. Every currency then exists in your data and none is offered.

The app already repairs having no currencies by writing the standard set back in when it finds none. That repair could not work, because each of those writes met the row already sitting under the same code and was refused, quietly. Nothing failed and nothing was logged. The app then remembered the standard set as though it had been written, so it believed in 157 currencies while offering you none.

Writing the standard set now brings back a row that is there and not offered. The screen where you create a currency yourself does not, deliberately. A row restored in that state carries the name, symbol and decimal places of the backup it came from, so handing it to someone who just typed their own would report success and discard what they typed. There, a clash still fails, exactly as it does today.

Bringing a row back changes only the mark and the time. It leaves the decimal places alone, which matters because those decide how every amount already saved in that currency is stored. Overwriting them would silently rescale every one of those amounts, with nothing asked and nothing shown. The name, the symbol and the rest stay as their owner had them.

One thing this does not do. A currency you made yourself is not in the standard set, so writing that set never reaches it.

Tested on an emulator running Android 15, against data holding 157 currencies all marked removed, one of them at a different decimal count. A build of master leaves none offered. This leaves all of them, with that decimal count untouched.
