### PR TITLE
Pull the transaction editor's rules into a class a test can drive

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -69,7 +69,6 @@ import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.MoneyFormatter;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -107,18 +106,19 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
      */
     public static final String WALLET_ID = "NewEditTransactionActivity::WalletId";
 
-    public static final int TYPE_STANDARD = 0;
-    public static final int TYPE_TRANSFER = 1;
-    public static final int TYPE_DEBT = 2;
-    public static final int TYPE_SAVING = 3;
-    public static final int TYPE_MODEL = 4;
+    public static final int TYPE_STANDARD = TransactionEditorRules.TYPE_STANDARD;
+    public static final int TYPE_TRANSFER = TransactionEditorRules.TYPE_TRANSFER;
+    public static final int TYPE_DEBT = TransactionEditorRules.TYPE_DEBT;
+    public static final int TYPE_SAVING = TransactionEditorRules.TYPE_SAVING;
+    public static final int TYPE_MODEL = TransactionEditorRules.TYPE_MODEL;
 
-    public static final int DEBT_PAY = 1;
-    public static final int DEBT_RECEIVE = 2;
+    public static final int DEBT_PAY = TransactionEditorRules.DEBT_PAY;
+    public static final int DEBT_RECEIVE = TransactionEditorRules.DEBT_RECEIVE;
 
-    public static final int SAVING_DEPOSIT = 1;
-    public static final int SAVING_WITHDRAW = 2;
-    public static final int SAVING_WITHDRAW_EVERYTHING = 3;
+    public static final int SAVING_DEPOSIT = TransactionEditorRules.SAVING_DEPOSIT;
+    public static final int SAVING_WITHDRAW = TransactionEditorRules.SAVING_WITHDRAW;
+    public static final int SAVING_WITHDRAW_EVERYTHING =
+            TransactionEditorRules.SAVING_WITHDRAW_EVERYTHING;
 
     private static final String TAG_MONEY_PICKER = "NewEditTransactionActivity::Tag::MoneyPicker";
     private static final String TAG_CATEGORY_PICKER = "NewEditTransactionActivity::Tag::CategoryPicker";
@@ -129,11 +129,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private static final String TAG_PERSON_PICKER = "NewEditTransactionActivity::Tag::PersonPicker";
     private static final String TAG_ATTACHMENT_PICKER = "NewEditTransactionActivity::Tag::AttachmentPicker";
 
-    private static final String SS_TYPE = "NewEditTransactionActivity::SavedState::Type";
-    private static final String SS_DEBT_ID = "NewEditTransactionActivity::SavedState::DebtId";
-    private static final String SS_SAVING_ID = "NewEditTransactionActivity::SavedState::SavingId";
-    private static final String SS_SAVING_COMPLETED = "NewEditTransactionActivity::SavedState::SavingCompleted";
-    private static final String SS_DEBT_PAYMENT = "NewEditTransactionActivity::SavedState::DebtPayment";
+    private static final String SS_RULES = "NewEditTransactionActivity::SavedState::Rules";
 
     private TextView mCurrencyTextView;
     private TextView mMoneyTextView;
@@ -159,11 +155,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     private PersonPicker mPersonPicker;
     private AttachmentPicker mAttachmentPicker;
 
-    private int mType;
-    private Long mDebtId = null;
-    private Long mSavingId = null;
-    private boolean mSavingCompleted = false;
-    private boolean mDebtPayment = false;
+    private TransactionEditorRules mRules = new TransactionEditorRules();
 
     private MoneyFormatter mMoneyFormatter = MoneyFormatter.getInstance();
 
@@ -432,7 +424,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                                 Contract.CategoryType.fromValue(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CATEGORY_TYPE))),
                                 cursor.getString(cursor.getColumnIndex(Contract.Transaction.CATEGORY_TAG))
                         );
-                        mType = cursor.getInt(cursor.getColumnIndex(Contract.Transaction.TYPE));
+                        mRules.setType(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.TYPE)));
                         wallet = new Wallet(
                                 cursor.getLong(cursor.getColumnIndex(Contract.Transaction.WALLET_ID)),
                                 cursor.getString(cursor.getColumnIndex(Contract.Transaction.WALLET_NAME)),
@@ -461,10 +453,10 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             );
                         }
                         if (!cursor.isNull(cursor.getColumnIndex(Contract.Transaction.DEBT_ID))) {
-                            mDebtId = cursor.getLong(cursor.getColumnIndex(Contract.Transaction.DEBT_ID));
+                            mRules.setDebtId(cursor.getLong(cursor.getColumnIndex(Contract.Transaction.DEBT_ID)));
                         }
                         if (!cursor.isNull(cursor.getColumnIndex(Contract.Transaction.SAVING_ID))) {
-                            mSavingId = cursor.getLong(cursor.getColumnIndex(Contract.Transaction.SAVING_ID));
+                            mRules.setSavingId(cursor.getLong(cursor.getColumnIndex(Contract.Transaction.SAVING_ID)));
                         }
                         mConfirmedCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) == 1);
                         mCountInTotalCheckBox.setChecked(cursor.getInt(cursor.getColumnIndex(Contract.Transaction.COUNT_IN_TOTAL)) == 1);
@@ -472,7 +464,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     cursor.close();
                 }
                 // before continuing, check if the transaction is part of a transfer
-                if (mType == TYPE_TRANSFER) {
+                if (mRules.getType() == TYPE_TRANSFER) {
                     uri = DataContentProvider.CONTENT_TRANSFERS;
                     projection = new String[] {Contract.Transfer.ID};
                     String selection = Contract.Transfer.TRANSACTION_FROM_ID + " = ? OR " +
@@ -550,8 +542,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                 }
             } else {
                 Intent intent = getIntent();
-                mType = intent.getIntExtra(TYPE, TYPE_STANDARD);
-                if (mType == TYPE_STANDARD) {
+                mRules.setType(intent.getIntExtra(TYPE, TYPE_STANDARD));
+                if (mRules.getType() == TYPE_STANDARD) {
                     String[] projection = new String[] {
                             Contract.Wallet.ID,
                             Contract.Wallet.NAME,
@@ -610,15 +602,15 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             personCursor.close();
                         }
                     }
-                } else if (mType == TYPE_TRANSFER) {
+                } else if (mRules.getType() == TYPE_TRANSFER) {
                     // In this case the activity has been launched to insert a new transfer so we
                     // have to simply start the correct activity and finish the current one.
                     startActivity(new Intent(this, NewEditTransferActivity.class));
                     finish();
-                } else if (mType == TYPE_DEBT) {
-                    mDebtId = intent.getLongExtra(DEBT_ID, 0L);
+                } else if (mRules.getType() == TYPE_DEBT) {
+                    mRules.setDebtId(intent.getLongExtra(DEBT_ID, 0L));
                     Contract.DebtType debtType = null;
-                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, mDebtId);
+                    Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, mRules.getDebtId());
                     String[] projection = new String[] {
                             Contract.Debt.TYPE,
                             Contract.Debt.WALLET_ID,
@@ -689,26 +681,12 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             Contract.Category.TAG
                     };
                     String where = Contract.Category.TAG + " = ?";
-                    String[] whereArgs = new String[1];
                     if (debtType == null) {
-                        switch (intent.getIntExtra(DEBT_ACTION, 0)) {
-                            case DEBT_PAY:
-                                debtType = Contract.DebtType.DEBT;
-                                break;
-                            case DEBT_RECEIVE:
-                                debtType = Contract.DebtType.CREDIT;
-                                break;
-                        }
+                        debtType = TransactionEditorRules.debtTypeFor(intent.getIntExtra(DEBT_ACTION, 0));
                     }
-                    if (debtType != null) {
-                        switch (debtType) {
-                            case DEBT:
-                                whereArgs[0] = Contract.CategoryTag.PAID_DEBT;
-                                break;
-                            case CREDIT:
-                                whereArgs[0] = Contract.CategoryTag.PAID_CREDIT;
-                                break;
-                        }
+                    String debtTag = TransactionEditorRules.debtCategoryTag(debtType);
+                    if (debtTag != null) {
+                        String[] whereArgs = new String[] {debtTag};
                         cursor = contentResolver.query(uri, projection, where, whereArgs, null);
                         if (cursor != null) {
                             if (cursor.moveToFirst()) {
@@ -723,8 +701,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             cursor.close();
                         }
                     }
-                } else if (mType == TYPE_SAVING) {
-                    mSavingId = intent.getLongExtra(SAVING_ID, 0L);
+                } else if (mRules.getType() == TYPE_SAVING) {
+                    mRules.setSavingId(intent.getLongExtra(SAVING_ID, 0L));
                     long startMoney = 0L;
                     // getItemId is the id of the transaction being edited, and this branch only
                     // runs when there is no transaction yet, so it was always the -1 assigned for
@@ -734,7 +712,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     // against: it read the typed digits as minor units and 2000 became 20.00.
                     // Load the saving the intent names, the way the debt branch above loads its
                     // debt.
-                    Uri savingUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
+                    Uri savingUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mRules.getSavingId());
                     String[] projection = new String[] {
                             Contract.Saving.START_MONEY,
                             Contract.Saving.WALLET_ID,
@@ -765,38 +743,30 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                             Contract.Category.TAG
                     };
                     String selection = Contract.Category.TAG + " = ?";
-                    String[] selectionArgs = new String[1];
                     int action = intent.getIntExtra(SAVING_ACTION, 0);
-                    switch (action) {
-                        case SAVING_DEPOSIT:
-                            selectionArgs[0] = Contract.CategoryTag.SAVING_DEPOSIT;
-                            break;
-                        case SAVING_WITHDRAW_EVERYTHING:
-                            // The row this writes opens dated now, so what it can actually take
-                            // is the lowest the saving reaches from now onwards, which is the
-                            // same figure the check applies when the save is pressed. Prefilling
-                            // anything above it offers an amount this same screen then refuses.
-                            // END_MONEY is the target, and a saving can be deposited past its
-                            // target, so the target would strand the overshoot here.
-                            //
-                            // Never below zero either. A saving already carrying more
-                            // withdrawals than it holds gives a negative figure here, and the
-                            // check on the way out only refuses an amount above the ceiling, so
-                            // the field would open on a negative amount and saving it untouched
-                            // would write a withdrawal of a negative amount. A saving whose rows
-                            // do not come back offers nothing for the same reason.
-                            Long lowest = readLowestSavingBalanceFrom(contentResolver, savingUri,
-                                    startMoney, DateUtils.getSQLDateTimeString(new Date()), -1L);
-                            money = lowest != null ? Math.max(lowest, 0L) : 0L;
-                            mSavingCompleted = true;
-                            // Deliberate fall through: withdraw everything needs the withdraw
-                            // category set below. A break here, which is what an IDE inspection
-                            // offers, leaves selectionArgs[0] null, and the query below then
-                            // crashes the editor as it opens: the bind value at index 1 is null.
-                        case SAVING_WITHDRAW:
-                            selectionArgs[0] = Contract.CategoryTag.SAVING_WITHDRAW;
-                            break;
+                    // A saving row is filed under a category this screen picks, and an action it
+                    // does not know names none. There is no editor to draw: the category field is
+                    // hidden on a saving, so an empty picker cannot be filled in and its own
+                    // validator would refuse every save against a view the user cannot see. Close
+                    // instead. No launch inside the app reaches this, since every one of
+                    // SavingListFragment's three sets an action, and this activity is exported.
+                    if (TransactionEditorRules.savingCategoryTag(action) == null) {
+                        finish();
+                        return;
                     }
+                    if (TransactionEditorRules.completesTheSaving(action)) {
+                        // The row this writes opens dated now, so what it can actually take is
+                        // the lowest the saving reaches from now onwards, which is the same
+                        // figure the check applies when the save is pressed. Prefilling anything
+                        // above it offers an amount this same screen then refuses.
+                        Long lowest = readLowestSavingBalanceFrom(contentResolver, savingUri,
+                                startMoney, DateUtils.getSQLDateTimeString(new Date()), -1L);
+                        money = TransactionEditorRules.withdrawEverythingPrefill(lowest);
+                        mRules.setSavingCompleted(true);
+                    }
+                    String[] selectionArgs = new String[] {
+                            TransactionEditorRules.savingCategoryTag(action)
+                    };
                     cursor = contentResolver.query(uri, projection, selection, selectionArgs, null);
                     if (cursor != null) {
                         if (cursor.moveToFirst()) {
@@ -810,7 +780,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                         }
                         cursor.close();
                     }
-                } else if (mType == TYPE_MODEL) {
+                } else if (mRules.getType() == TYPE_MODEL) {
                     long modelId = intent.getLongExtra(MODEL_ID, 0L);
                     Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTION_MODELS, modelId);
                     String[] projection = new String[] {
@@ -888,29 +858,21 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                 datetime = new Date();
             }
         } else {
-            mType = savedInstanceState.getInt(SS_TYPE, TYPE_STANDARD);
-            mDebtId = savedInstanceState.containsKey(SS_DEBT_ID) ? savedInstanceState.getLong(SS_DEBT_ID) : null;
-            mSavingId = savedInstanceState.containsKey(SS_SAVING_ID) ? savedInstanceState.getLong(SS_SAVING_ID) : null;
-            mSavingCompleted = savedInstanceState.getBoolean(SS_SAVING_COMPLETED, false);
-            mDebtPayment = savedInstanceState.getBoolean(SS_DEBT_PAYMENT, false);
+            TransactionEditorRules restored =
+                    (TransactionEditorRules) savedInstanceState.getSerializable(SS_RULES);
+            if (restored != null) {
+                mRules = restored;
+            }
         }
         if (savedInstanceState == null && category != null) {
-            String categoryTag = category.getTag();
-            mDebtPayment = Contract.CategoryTag.PAID_DEBT.equals(categoryTag)
-                    || Contract.CategoryTag.PAID_CREDIT.equals(categoryTag);
+            mRules.setDebtPayment(TransactionEditorRules.isDebtPaymentTag(category.getTag()));
         }
         // depending on the type we must hide pickers that are now allowed to be changed
-        switch (mType) {
-            case TYPE_DEBT:
-                mCategoryEditText.setVisibility(View.GONE);
-                if (mDebtPayment) {
-                    mWalletEditText.setVisibility(View.GONE);
-                }
-                break;
-            case TYPE_SAVING:
-                mCategoryEditText.setVisibility(View.GONE);
-                mWalletEditText.setVisibility(View.GONE);
-                break;
+        if (mRules.hidesCategoryField()) {
+            mCategoryEditText.setVisibility(View.GONE);
+        }
+        if (mRules.hidesWalletField()) {
+            mWalletEditText.setVisibility(View.GONE);
         }
         // now we can create pickers with default values or existing item parameters
         // and update all the views according to the data
@@ -973,15 +935,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
     @Override
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
-        outState.putInt(SS_TYPE, mType);
-        if (mDebtId != null) {
-            outState.putLong(SS_DEBT_ID, mDebtId);
-        }
-        if (mSavingId != null) {
-            outState.putLong(SS_SAVING_ID, mSavingId);
-        }
-        outState.putBoolean(SS_SAVING_COMPLETED, mSavingCompleted);
-        outState.putBoolean(SS_DEBT_PAYMENT, mDebtPayment);
+        outState.putSerializable(SS_RULES, mRules);
     }
 
     @Override
@@ -1034,17 +988,10 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
      * The lowest a saving's balance reaches from a moment onwards, over the rows it already
      * carries, or null when those rows do not come back at all.
      *
-     * They come back ordered on the raw date column, which is the order
-     * {@link Contract#lowestSavingBalanceFrom(long, String[], long[], String)} needs, and are
-     * held to the two saving categories so this walks the same rows the saving's own sums count.
-     * A deposit that is not confirmed is left out, because landing takes being confirmed and
-     * money that never arrives must not pay for a withdrawal that does. A withdrawal is counted
-     * whether it is confirmed or not, for the mirror reason, that leaving it out hands out a
-     * ceiling it can then take the saving under.
-     *
-     * excludedId names the row being edited, whose own drain has to come out before the walk or
-     * the row would be held against itself. A new row names nothing, since the id of a new item
-     * is minus one and no row carries it.
+     * The rows are held to the two saving categories, so this reads the same rows the saving's
+     * own sums count. Which of them are counted, how each is signed and what order they are
+     * walked in is
+     * {@link TransactionEditorRules#lowestSavingBalanceFrom(long, List, long, String)}.
      */
     private Long readLowestSavingBalanceFrom(ContentResolver contentResolver, Uri savingUri,
                                              long startMoney, String from, long excludedId) {
@@ -1065,38 +1012,24 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         if (cursor == null) {
             return null;
         }
-        String[] dates = new String[cursor.getCount()];
-        long[] signedMoney = new long[cursor.getCount()];
-        int rows = 0;
+        List<TransactionEditorRules.SavingRow> rows = new ArrayList<>();
         while (cursor.moveToNext()) {
-            if (cursor.getLong(cursor.getColumnIndex(Contract.Transaction.ID)) == excludedId) {
-                continue;
-            }
-            // A withdrawal is the income half of the pair, since it pays money into the wallet,
-            // and it is what takes the saving down.
-            boolean withdrawal = cursor.getInt(cursor.getColumnIndex(Contract.Transaction.DIRECTION))
-                    == Contract.Direction.INCOME;
-            if (!withdrawal && cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) != 1) {
-                continue;
-            }
-            long money = cursor.getLong(cursor.getColumnIndex(Contract.Transaction.MONEY));
-            dates[rows] = cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE));
-            signedMoney[rows] = withdrawal ? -money : money;
-            rows++;
+            rows.add(new TransactionEditorRules.SavingRow(
+                    cursor.getLong(cursor.getColumnIndex(Contract.Transaction.ID)),
+                    cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE)),
+                    cursor.getLong(cursor.getColumnIndex(Contract.Transaction.MONEY)),
+                    cursor.getInt(cursor.getColumnIndex(Contract.Transaction.DIRECTION)),
+                    cursor.getInt(cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) == 1
+            ));
         }
         cursor.close();
-        return Contract.lowestSavingBalanceFrom(startMoney, Arrays.copyOf(dates, rows),
-                Arrays.copyOf(signedMoney, rows), from);
+        return TransactionEditorRules.lowestSavingBalanceFrom(startMoney, rows, excludedId, from);
     }
 
     /**
-     * Whether the row being edited is being kept or lowered on a date it does not move back
-     * from. Such a save takes nothing the saving is not already giving, so it is never refused.
-     *
-     * Without this, two withdrawals that already have a saving under zero would freeze each
-     * other, since neither can be lowered while the other one alone is more than the saving
-     * holds, and deleting one would be the only way out. Moving a stored row earlier is a new
-     * drain on the dates it moves across and is held to the ceiling like any other.
+     * Reads the stored row this edit is replacing and asks
+     * {@link TransactionEditorRules#isStoredWithdrawalKeptOrLowered(long, String, long, String)}
+     * whether it is being kept or lowered.
      *
      * A new row answers false, since there is no stored row to compare with.
      */
@@ -1114,8 +1047,10 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         boolean unchangedOrSmaller = false;
         if (cursor != null) {
             if (cursor.moveToFirst()) {
-                unchangedOrSmaller = money <= cursor.getLong(cursor.getColumnIndex(Contract.Transaction.MONEY))
-                        && date.compareTo(cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE))) >= 0;
+                unchangedOrSmaller = TransactionEditorRules.isStoredWithdrawalKeptOrLowered(
+                        money, date,
+                        cursor.getLong(cursor.getColumnIndex(Contract.Transaction.MONEY)),
+                        cursor.getString(cursor.getColumnIndex(Contract.Transaction.DATE)));
             }
             cursor.close();
         }
@@ -1149,7 +1084,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
      * ceiling it can then take the saving under.
      */
     private boolean validateSavingWithdraw() {
-        if (mSavingId == null) {
+        if (mRules.getSavingId() == null) {
             return true;
         }
         Category category = mCategoryPicker.getCurrentCategory();
@@ -1157,7 +1092,7 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             return true;
         }
         ContentResolver contentResolver = getContentResolver();
-        Uri savingUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mSavingId);
+        Uri savingUri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, mRules.getSavingId());
         String[] projection = new String[] {
                 Contract.Saving.START_MONEY,
                 Contract.Saving.WALLET_CURRENCY
@@ -1173,12 +1108,9 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
             cursor.close();
         }
         CurrencyUnit currency = currencyIso != null ? CurrencyManager.getCurrency(currencyIso) : null;
-        // The ceiling is in the saving's own currency. If the row sits in a wallet held in another
-        // one the two are not comparable as they stand, and this screen converts nowhere else, so
-        // the check steps aside instead of comparing amounts that do not mean the same thing. A
-        // saving that gives back no row at all leaves the currency null and stops here too.
         CurrencyUnit walletCurrency = mWalletPicker.getCurrentWallet().getCurrency();
-        if (currency == null || walletCurrency == null || !currency.getIso().equals(walletCurrency.getIso())) {
+        if (!TransactionEditorRules.ceilingApplies(currency != null ? currency.getIso() : null,
+                walletCurrency != null ? walletCurrency.getIso() : null)) {
             return true;
         }
         long money = mMoneyPicker.getCurrentMoney();
@@ -1191,14 +1123,12 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         if (lowest == null) {
             return true;
         }
-        // Held at nothing, since a saving already under zero on some date from here on gives a
-        // negative figure and no amount at all would clear it. An amount of nothing is therefore
-        // never refused, and that matters. Refusing it would refuse every save of a stored
-        // withdrawal of nothing, whatever the saving holds, so its own note and date could never
-        // be corrected and only deletion would be open. The old withdraw everything path could
-        // write such a row.
-        long limit = Math.max(lowest, 0L);
-        if (money <= limit) {
+        // An amount of nothing is never refused, and that matters. Refusing it would refuse every
+        // save of a stored withdrawal of nothing, whatever the saving holds, so its own note and
+        // date could never be corrected and only deletion would be open. The old withdraw
+        // everything path could write such a row.
+        long limit = TransactionEditorRules.withdrawLimit(lowest);
+        if (TransactionEditorRules.isWithinLimit(money, limit)) {
             return true;
         }
         // The figure every time, with no separate wording for a ceiling of nothing. What a
@@ -1226,13 +1156,13 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     .description(mDescriptionEditText.getTextAsString())
                     .categoryId(mCategoryPicker.getCurrentCategory().getId())
                     .direction(mCategoryPicker.getCurrentCategory().getDirection())
-                    .type(mType)
+                    .type(mRules.getType())
                     .walletId(mWalletPicker.getCurrentWallet().getId())
                     .placeId(mPlacePicker.isSelected() ? mPlacePicker.getCurrentPlace().getId() : null)
                     .note(mNoteEditText.getTextAsString())
                     .eventId(mEventPicker.isSelected() ? mEventPicker.getCurrentEvent().getId() : null)
-                    .savingId(mSavingId)
-                    .debtId(mDebtId)
+                    .savingId(mRules.getSavingId())
+                    .debtId(mRules.getDebtId())
                     .confirmed(mConfirmedCheckBox.isChecked())
                     .countInTotal(mCountInTotalCheckBox.isChecked())
                     .peopleIds(Contract.getObjectIds(mPersonPicker.getCurrentPeople()))
@@ -1243,8 +1173,8 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                 switch (mode) {
                     case NEW_ITEM:
                         contentResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS, contentValues);
-                        if (mSavingId != null && mSavingCompleted) {
-                            setSavingCompleted(contentResolver, mSavingId);
+                        if (mRules.getSavingId() != null && mRules.isSavingCompleted()) {
+                            setSavingCompleted(contentResolver, mRules.getSavingId());
                         }
                         break;
                     case EDIT_ITEM:

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/TransactionEditorRules.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/TransactionEditorRules.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.activity;
+
+import com.oriondev.moneywallet.storage.database.Contract;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * What the transaction editor decides, apart from the screen it decides it on. Plain values in
+ * and plain values out, so each rule can be driven from a JVM test instead of being pinned by
+ * matching the text of the activity.
+ *
+ * The editor keeps the loading. Every branch of it chooses which row to read and reading takes a
+ * content resolver, so what lives here is only what is decided once the values are in hand.
+ *
+ * It carries the five pieces of state the editor holds across a recreate. They travel as one
+ * object under one bundle key, so the keys cannot collide with each other.
+ */
+public class TransactionEditorRules implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final int TYPE_STANDARD = 0;
+    public static final int TYPE_TRANSFER = 1;
+    public static final int TYPE_DEBT = 2;
+    public static final int TYPE_SAVING = 3;
+    public static final int TYPE_MODEL = 4;
+
+    public static final int DEBT_PAY = 1;
+    public static final int DEBT_RECEIVE = 2;
+
+    public static final int SAVING_DEPOSIT = 1;
+    public static final int SAVING_WITHDRAW = 2;
+    public static final int SAVING_WITHDRAW_EVERYTHING = 3;
+
+    private int mType = TYPE_STANDARD;
+    private Long mDebtId = null;
+    private Long mSavingId = null;
+    private boolean mSavingCompleted = false;
+    private boolean mDebtPayment = false;
+
+    public int getType() {
+        return mType;
+    }
+
+    public void setType(int type) {
+        mType = type;
+    }
+
+    public Long getDebtId() {
+        return mDebtId;
+    }
+
+    public void setDebtId(Long debtId) {
+        mDebtId = debtId;
+    }
+
+    public Long getSavingId() {
+        return mSavingId;
+    }
+
+    public void setSavingId(Long savingId) {
+        mSavingId = savingId;
+    }
+
+    public boolean isSavingCompleted() {
+        return mSavingCompleted;
+    }
+
+    public void setSavingCompleted(boolean savingCompleted) {
+        mSavingCompleted = savingCompleted;
+    }
+
+    public boolean isDebtPayment() {
+        return mDebtPayment;
+    }
+
+    public void setDebtPayment(boolean debtPayment) {
+        mDebtPayment = debtPayment;
+    }
+
+    /**
+     * A debt row and a saving row are both filed under a category the editor picks for them, so
+     * neither offers the field.
+     */
+    public boolean hidesCategoryField() {
+        return mType == TYPE_DEBT || mType == TYPE_SAVING;
+    }
+
+    /**
+     * A saving's progress and a debt's progress are each summed over the transactions filed
+     * against them with no currency anywhere in that sum, so a row moved onto a wallet held in
+     * another currency is added at face value and 500 euros count as 500 dollars.
+     *
+     * A debt's master transaction is not one of those rows. It carries the same TYPE_DEBT as a
+     * payment and is told apart only by its category, and editing its wallet moves the debt
+     * itself through syncDebtOfMasterTransaction, so it keeps the field.
+     */
+    public boolean hidesWalletField() {
+        return mType == TYPE_SAVING || (mType == TYPE_DEBT && mDebtPayment);
+    }
+
+    /** Whether a category this row is filed under makes it a payment and not a debt's own row. */
+    public static boolean isDebtPaymentTag(String categoryTag) {
+        return Contract.CategoryTag.PAID_DEBT.equals(categoryTag)
+                || Contract.CategoryTag.PAID_CREDIT.equals(categoryTag);
+    }
+
+    /**
+     * The kind of debt an action names, for a launch that carries no debt row of its own. Answers
+     * null for anything else, which is what a crafted intent naming no action gives.
+     */
+    public static Contract.DebtType debtTypeFor(int debtAction) {
+        switch (debtAction) {
+            case DEBT_PAY:
+                return Contract.DebtType.DEBT;
+            case DEBT_RECEIVE:
+                return Contract.DebtType.CREDIT;
+            default:
+                return null;
+        }
+    }
+
+    /** The category a new debt row is filed under, or null when the kind is not known. */
+    public static String debtCategoryTag(Contract.DebtType debtType) {
+        if (debtType == null) {
+            return null;
+        }
+        switch (debtType) {
+            case DEBT:
+                return Contract.CategoryTag.PAID_DEBT;
+            case CREDIT:
+                return Contract.CategoryTag.PAID_CREDIT;
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * The category a new saving row is filed under. Withdraw everything is a withdrawal, so the
+     * two answer the same tag; the activity used to reach that by falling through one case into
+     * the other, where a break left the tag null and the query below crashed the editor as it
+     * opened.
+     */
+    public static String savingCategoryTag(int savingAction) {
+        switch (savingAction) {
+            case SAVING_DEPOSIT:
+                return Contract.CategoryTag.SAVING_DEPOSIT;
+            case SAVING_WITHDRAW:
+            case SAVING_WITHDRAW_EVERYTHING:
+                return Contract.CategoryTag.SAVING_WITHDRAW;
+            default:
+                return null;
+        }
+    }
+
+    /** Only withdraw everything empties the saving, so only it marks the saving complete. */
+    public static boolean completesTheSaving(int savingAction) {
+        return savingAction == SAVING_WITHDRAW_EVERYTHING;
+    }
+
+    /**
+     * The most a withdrawal may take. Held at nothing, since a saving already under zero on some
+     * date from here on gives a negative figure and no amount at all would clear it.
+     */
+    public static long withdrawLimit(long lowestBalance) {
+        return Math.max(lowestBalance, 0L);
+    }
+
+    /**
+     * What withdraw everything opens on, which is the same figure the check applies when the save
+     * is pressed, since the row it writes is dated now. A saving whose rows do not come back
+     * offers nothing.
+     */
+    public static long withdrawEverythingPrefill(Long lowestBalance) {
+        return lowestBalance != null ? withdrawLimit(lowestBalance) : 0L;
+    }
+
+    /** Whether an amount clears the ceiling. */
+    public static boolean isWithinLimit(long money, long limit) {
+        return money <= limit;
+    }
+
+    /**
+     * The ceiling is in the saving's own currency. A row sitting in a wallet held in another one
+     * is not comparable with it as it stands and this screen converts nowhere else, so the check
+     * steps aside instead of comparing amounts that do not mean the same thing. A saving that
+     * gives back no row at all leaves its currency null and stops here too.
+     */
+    public static boolean ceilingApplies(String savingCurrencyIso, String walletCurrencyIso) {
+        return savingCurrencyIso != null && walletCurrencyIso != null
+                && savingCurrencyIso.equals(walletCurrencyIso);
+    }
+
+    /**
+     * Whether the row being edited is being kept or lowered on a date it does not move back from.
+     * Such a save takes nothing the saving is not already giving, so it is never refused.
+     *
+     * Without this, two withdrawals that already have a saving under zero would freeze each
+     * other, since neither can be lowered while the other one alone is more than the saving
+     * holds, and deleting one would be the only way out. Moving a stored row earlier is a new
+     * drain on the dates it moves across and is held to the ceiling like any other.
+     */
+    public static boolean isStoredWithdrawalKeptOrLowered(long money, String date,
+                                                          long storedMoney, String storedDate) {
+        return money <= storedMoney && date.compareTo(storedDate) >= 0;
+    }
+
+    /** A withdrawal is the income half of the pair, since it pays money into the wallet. */
+    public static boolean isWithdrawal(int direction) {
+        return direction == Contract.Direction.INCOME;
+    }
+
+    /**
+     * A deposit that is not confirmed is left out, because landing takes being confirmed and
+     * money that never arrives must not pay for a withdrawal that does. A withdrawal is counted
+     * whether it is confirmed or not, for the mirror reason, that leaving it out hands out a
+     * ceiling it can then take the saving under.
+     */
+    public static boolean countsTowardBalance(SavingRow row) {
+        return isWithdrawal(row.direction) || row.confirmed;
+    }
+
+    /** A withdrawal takes the saving down and a deposit puts money in. */
+    public static long signedAmount(SavingRow row) {
+        return isWithdrawal(row.direction) ? -row.money : row.money;
+    }
+
+    /**
+     * The lowest a saving's balance reaches from a moment onwards, over the rows it already
+     * carries.
+     *
+     * The rows are put in date order here rather than taken in the order they arrive, so the
+     * answer does not depend on how the caller asked for them. A date this app writes is a fixed
+     * width yyyy-MM-dd HH:mm:ss of ASCII, so comparing the strings is comparing the times, which
+     * is the same order {@link Contract#lowestSavingBalanceFrom(long, String[], long[], String)}
+     * compares against and the same order SQLite gives on that column.
+     *
+     * excludedId names the row being edited, whose own drain has to come out before the walk or
+     * the row would be held against itself. A new row names nothing, since the id of a new item
+     * is minus one and no row carries it.
+     */
+    public static long lowestSavingBalanceFrom(long startMoney, List<SavingRow> rows,
+                                               long excludedId, String from) {
+        List<SavingRow> counted = new ArrayList<>();
+        for (SavingRow row : rows) {
+            if (row.id != excludedId && countsTowardBalance(row)) {
+                counted.add(row);
+            }
+        }
+        Collections.sort(counted, new Comparator<SavingRow>() {
+
+            @Override
+            public int compare(SavingRow left, SavingRow right) {
+                return left.date.compareTo(right.date);
+            }
+
+        });
+        String[] dates = new String[counted.size()];
+        long[] signedMoney = new long[counted.size()];
+        for (int i = 0; i < counted.size(); i++) {
+            dates[i] = counted.get(i).date;
+            signedMoney[i] = signedAmount(counted.get(i));
+        }
+        return Contract.lowestSavingBalanceFrom(startMoney, dates, signedMoney, from);
+    }
+
+    /** One row filed against a saving, as the walk above needs it. */
+    public static final class SavingRow {
+
+        public final long id;
+        public final String date;
+        public final long money;
+        public final int direction;
+        public final boolean confirmed;
+
+        public SavingRow(long id, String date, long money, int direction, boolean confirmed) {
+            this.id = id;
+            this.date = date;
+            this.money = money;
+            this.direction = direction;
+            this.confirmed = confirmed;
+        }
+
+    }
+
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivitySourceTest.java
@@ -6,412 +6,301 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.regex.Pattern;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * The block checked here runs inside an Activity, reads instance fields and talks to a content
- * resolver, so it cannot be driven from a JVM unit test: there is no Robolectric on the unit test
- * classpath. An automated check of what the editor actually opens with would take an instrumented
- * test on a device or emulator, and none was written. The invariants are pinned by reading the
- * source instead.
+ * What the editor DOES with the rules, which is neither a rule nor a value and so cannot be
+ * driven from a JVM test. The rules themselves moved to {@link TransactionEditorRules} and are
+ * covered by TransactionEditorRulesTest, which sees the arguments a rule is given and never the
+ * call site that gives them. Reaching the call sites would take an Activity and a content
+ * resolver, and there is no Robolectric on the unit test classpath.
+ *
+ * Every invariant here breaks silently. None throws, none is visible in the database, and each
+ * ends with an amount stored at the wrong scale or a ceiling worked out from a number the saving
+ * never held. Two assertions that used to live here were dropped on the opposite reasoning: a
+ * column read but left out of its projection throws IllegalStateException from CursorWindow the
+ * moment the branch opens, so it cannot hide, and the twelve device pairs this change was tested
+ * against open every one of those branches.
+ *
+ * Each of the seven was checked by making the change it forbids and watching this file go red.
+ * That is worth saying because the first version of this file kept three assertions and let
+ * eleven mutants through, every one of them a live defect.
  *
  * Comments and string literals are stripped before anything is matched, so no assertion here can
- * be satisfied or broken by the wording of a comment. Text that goes through squash first also
- * tolerates any amount of whitespace between two tokens. Everything else is matched with its
- * spacing exactly as written, including the lines a region is found by, so a reformat or a line
- * wrap anywhere in that text fails the assertion with no defect present.
+ * be satisfied or broken by the wording of a comment. Runs of whitespace are collapsed, so the
+ * space between two tokens does not matter. Everything else is matched literally, including the
+ * lines a region is found by, so a rename or a line wrap in that text fails the assertion with no
+ * defect present. These are token matching, not behavior. A rewrite that keeps the tokens and
+ * still opens the editor on the wrong wallet goes through.
  *
- * What these assertions check is which token sequences the source does and does not carry: that
- * getItemId appears nowhere in the intent branch, that the saving uri is built from mSavingId,
- * that the saving's projection carries every column the block reads out of it, that the withdraw
- * everything prefill is the lowest the saving reaches from now onwards and sits in its own case,
- * that the case falls through, that the statement assigning wallet builds a Wallet from the
- * saving's wallet columns, that the walk over a saving's rows signs and skips them the way the
- * saving's own sums do, that every column the check's three queries read is in the projection
- * beside it, that the check counts from the date on screen over rows ordered by date, that the
- * debt case and the saving case of the visibility switch each read as the hides they should be and
- * nothing more, and that the flag the debt case reads is worked out from the two paid categories
- * before the switch and is carried across a recreate. That makes them a tripwire against a revert
- * or a careless rewrite. It does not make them a proof of behavior, and they cannot show the value
- * the keypad ends up with. A rewrite that keeps those tokens and still breaks the editor goes
- * through. One example, not a list: a second assignment written with += or -= is invisible here,
- * because "money -=" does not contain the "money =" a statement is found by.
+ * What each one holds:
  *
- * Invariant one: inside the branch that fills a new transaction from its intent, getItemId is
- * always -1, the value NewEditItemActivity assigns whenever it was not launched to edit an
- * existing item, because that branch is the else of a getMode() == EDIT_ITEM test. A saving uri
+ * getItemId is never read inside the branch that fills a new transaction from its intent, where
+ * it is always -1, because that branch is the else of a getMode() == EDIT_ITEM test. A saving uri
  * built from -1 is savings/-1, which matches no route in the content provider, so the query
- * returned null without reaching the database. The editor opened with no wallet, the amount keypad
- * had no currency to scale against, and a typed 2000 was stored as 20.00.
+ * returns null without reaching the database, the editor opens with no wallet, the amount keypad
+ * has no currency to scale against, and a typed 2000 is stored as 20.00. The saving is loaded by
+ * the id the intent carried, which is the other half of that. The same row builds the wallet the
+ * editor opens on, currency included, which is the third.
  *
- * Invariant two: the prefill that WITHDRAW EVERYTHING opens on is the lowest the saving reaches
- * from now onwards, which is the same figure the check applies when the save is pressed, since
- * the row it writes is dated now. Offering more than that offers an amount the same screen then
- * refuses. END_MONEY is the target. Reading END_MONEY there returns too little for any saving
- * deposited past its target and leaves the overshoot behind with the saving already marked
- * complete. The prefill is held at zero when the figure is negative, since the amount written out
- * would otherwise be a withdrawal of a negative amount, and a saving whose rows do not come back
- * offers nothing for the same reason.
- *
- * Invariant three: the same row builds the wallet the editor opens on, currency included. Without
- * that construction the wallet field is empty, the keypad has no currency to scale against, and a
- * typed 2000 is stored as 20.00.
- *
- * Invariant four: the walk that feeds the ceiling treats each row the way the saving's own sums
- * do. A withdrawal is the income half of the pair, since it pays money into the wallet, and it is
- * the one that takes the saving down, so it is signed negative. Both of those are a single token
- * that compiles either way and inverts every row when it is wrong, so both are pinned. Only a
- * deposit is dropped for being unconfirmed. An unconfirmed deposit never lands, since landing
- * takes being confirmed, and an unconfirmed withdrawal left out would hand out a ceiling it can
- * then take the saving under.
- *
- * Invariant five: the ceiling is the lowest balance from the date on screen onwards, over the
- * saving's rows in date order. Four things are pinned, because each is invisible to the unit test
- * that covers the walk itself. The rows are ordered by date, which is the order the walk needs
- * and cannot tell is missing. The row being edited is left out of the walk by id, or it is held
- * against its own drain. The moment counted from is the date on screen and not today, which is
- * the whole defect this replaced. And a stored row kept or lowered on a date it does not move
- * back from is never refused, or two withdrawals that already have a saving under zero freeze
- * each other and deleting one is the only way out.
- *
- * Invariant six: neither a saving transaction nor a debt payment offers its wallet field, and a
- * debt's master transaction still does. A saving's progress and a debt's progress are each summed
- * over the transactions filed against them with no currency anywhere in that sum, so a row moved
- * onto a wallet held in another currency is added at face value, and 500 euros count as 500
- * dollars. A debt's master transaction is not one of those rows. It carries the same TYPE_DEBT as
- * a payment and is told apart only by its category, and editing its wallet moves the debt itself
- * through syncDebtOfMasterTransaction, so hiding the field there would take that away and no test
- * on the database would see it, since SQLDatabaseTest drives the database and not this screen. So
- * both cases are read whole and compared, not searched. A second hide written above the guard, or a
- * break dropped so the debt case falls into the saving body below it, both hide the field on a
- * master transaction while a search for the guard still finds it, and the guard copied onto the
- * saving case is false on every saving row and gives that field back. The derivation is pinned
- * whole, its guard and the line the tag is read from included, and it carries the restore line
- * above it and the switch below it inside the same literal, so it is held against both of its
- * neighbors and nothing can be written on either side of it. That matters in three directions.
- * category is null everywhere above the loader, so a derivation hoisted there reads a guard that
- * is false on every path and the feature is gone with its own text unchanged. Moved below the
- * switch it leaves false to be read and every payment offers its wallet field again. Left where it
- * is with a single statement written under it, mDebtPayment = false on the edit path, it is
- * reverted just as completely. A guard flipped to run only on a recreate leaves false the same way
- * with the assignment still sitting there, and a tag read replaced by one of the two paid
- * constants makes every debt row a payment and takes the field off a master transaction, with both
- * case bodies untouched. The lines the tag is read from are pinned as well. The edit path's is
- * its own text; the two loads off the category table, the new payment one and the saving one, are
- * identical text, so those are counted and a swap on either drops the count. The derivation
- * compares whatever getTag returns, and a tag read off a name column, or a fifth argument dropped
- * for the four argument constructor the model branch already uses, is false on every row without
- * any of this text moving. Its
- * save and restore are pinned separately, because losing either one gives a payment its field back
- * on the next rotation and no assertion over the switch can see it.
- *
- * Comparing a case whole costs what searching it does not. A body that is behaviorally identical
- * and written differently fails, a guard without its braces or two statements swapped, and so does
- * any third statement a later change has a good reason to add. That is a false alarm to be read
- * and corrected, not a defect, and it is the price of catching a hide that a search finds in the
- * wrong place.
+ * The withdraw everything prefill is fed the lowest balance the saving reaches from now onwards
+ * and never END_MONEY, which is the target and would strand the overshoot on a saving deposited
+ * past it. The walk's rows are built from the cursor in the order SavingRow takes them, since its
+ * id and its money are both long and swapping them compiles. Each hide answers for its own field.
+ * And the ceiling counts from the date on screen, leaves out the row being edited, and is what
+ * the dialog names.
  */
 public class NewEditTransactionActivitySourceTest {
 
     private static final String SOURCE_PATH =
             "src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java";
 
-    private static final String INTENT_BRANCH_START = "mType = intent.getIntExtra(TYPE, TYPE_STANDARD);";
+    private static final String INTENT_BRANCH_START =
+            "mRules.setType(intent.getIntExtra(TYPE, TYPE_STANDARD));";
     private static final String INTENT_BRANCH_END = "datetime = new Date();";
 
-    private static final String SAVING_BRANCH_START = "} else if (mType == TYPE_SAVING) {";
-    private static final String SAVING_BRANCH_END = "} else if (mType == TYPE_MODEL) {";
+    private static final String SAVING_BRANCH_START = "} else if (mRules.getType() == TYPE_SAVING) {";
+    private static final String SAVING_BRANCH_END = "} else if (mRules.getType() == TYPE_MODEL) {";
 
-    private static final String WITHDRAW_EVERYTHING_CASE = "case SAVING_WITHDRAW_EVERYTHING:";
-    private static final String WITHDRAW_CASE = "case SAVING_WITHDRAW:";
-    private static final String CATEGORY_QUERY_START = "uri = DataContentProvider.CONTENT_CATEGORIES;";
+    private static final String DERIVATION_AND_HIDES =
+            "if (restored != null) { mRules = restored; } } if (savedInstanceState == null && "
+                    + "category != null) { mRules.setDebtPayment(TransactionEditorRules"
+                    + ".isDebtPaymentTag(category.getTag())); } if (mRules.hidesCategoryField()) "
+                    + "{ mCategoryEditText.setVisibility(View.GONE); } if (mRules"
+                    + ".hidesWalletField()) { mWalletEditText.setVisibility(View.GONE); }";
 
-    /** Squashed, since it is two statements over three lines in the source. */
-    private static final String PREFILL =
-            "Long lowest = readLowestSavingBalanceFrom(contentResolver, savingUri, startMoney, "
-                    + "DateUtils.getSQLDateTimeString(new Date()), -1L); "
-                    + "money = lowest != null ? Math.max(lowest, 0L) : 0L;";
-
-    private static final String CHECK_START = "private boolean validateSavingWithdraw() {";
-    private static final String CHECK_END = "ThemedDialog.buildMaterialDialog(this)";
-
-    private static final String DEBT_CASE = "case TYPE_DEBT:";
-    private static final String SAVING_CASE = "case TYPE_SAVING:";
-    private static final String CASE_BREAK = "break;";
-    private static final String WALLET_HIDE = "mWalletEditText.setVisibility(View.GONE)";
-    private static final String CATEGORY_HIDE = "mCategoryEditText.setVisibility(View.GONE)";
-    private static final String PAYMENT_GUARD = "if (mDebtPayment) { " + WALLET_HIDE + "; }";
-    private static final String DEBT_CASE_BODY =
-            DEBT_CASE + " " + CATEGORY_HIDE + "; " + PAYMENT_GUARD + " ";
-    private static final String SAVING_CASE_BODY =
-            SAVING_CASE + " " + CATEGORY_HIDE + "; " + WALLET_HIDE + "; ";
-    private static final String SWITCH_ON_TYPE = "switch (mType) {";
-    private static final String DEBT_PAYMENT_DERIVATION =
-            "mDebtPayment = savedInstanceState.getBoolean(SS_DEBT_PAYMENT, false); }"
-                    + " if (savedInstanceState == null && category != null) {"
-                    + " String categoryTag = category.getTag();"
-                    + " mDebtPayment = Contract.CategoryTag.PAID_DEBT.equals(categoryTag)"
-                    + " || Contract.CategoryTag.PAID_CREDIT.equals(categoryTag); } "
-                    + SWITCH_ON_TYPE;
     private static final String EDIT_PATH_TAG_READ =
-            "cursor.getString(cursor.getColumnIndex(Contract.Transaction.CATEGORY_TAG)) );";
+            "cursor.getString(cursor.getColumnIndex(Contract.Transaction.CATEGORY_TAG)) )";
     private static final String CATEGORY_TABLE_TAG_READ =
-            "cursor.getString(cursor.getColumnIndex(Contract.Category.TAG)) );";
+            "cursor.getString(cursor.getColumnIndex(Contract.Category.TAG)) )";
+
+    private static final String SAVING_ACTION_READ =
+            "int action = intent.getIntExtra(SAVING_ACTION, 0);";
+    private static final String SAVING_ACTION_BLOCK = SAVING_ACTION_READ
+            + " if (TransactionEditorRules.savingCategoryTag(action) == null) { finish(); return; }"
+            + " if (TransactionEditorRules.completesTheSaving(action)) { Long lowest = "
+            + "readLowestSavingBalanceFrom(contentResolver, savingUri, startMoney, DateUtils"
+            + ".getSQLDateTimeString(new Date()), -1L); money = TransactionEditorRules"
+            + ".withdrawEverythingPrefill(lowest); mRules.setSavingCompleted(true); } String[] "
+            + "selectionArgs = new String[] { TransactionEditorRules.savingCategoryTag(action) };"
+            + " cursor = contentResolver.query(uri, projection, selection, selectionArgs, null);";
+
+    private static final String CHECK_BLOCK =
+            "if (isStoredWithdrawalKeptOrLowered(contentResolver, money, date)) { return true; } "
+                    + "Long lowest = readLowestSavingBalanceFrom(contentResolver, savingUri, "
+                    + "startMoney, date, getItemId()); if (lowest == null) { return true; } long "
+                    + "limit = TransactionEditorRules.withdrawLimit(lowest); if "
+                    + "(TransactionEditorRules.isWithinLimit(money, limit)) {";
 
     @Test
     public void newItemBranchDoesNotReadTheItemId() throws IOException {
         assertEquals("getItemId is read inside the branch that fills a new transaction from its "
                 + "intent, where it is always -1", -1,
-                region(INTENT_BRANCH_START, INTENT_BRANCH_END).indexOf("getItemId"));
+                region(INTENT_BRANCH_START, INTENT_BRANCH_END, 9000).indexOf("getItemId"));
     }
 
     @Test
     public void savingIsLoadedByTheIdTheIntentCarried() throws IOException {
-        assertTrue("the saving must be loaded with mSavingId, the id the launching intent put in "
-                + "SAVING_ID", region(SAVING_BRANCH_START, SAVING_BRANCH_END)
-                .contains("CONTENT_SAVINGS, mSavingId"));
-    }
-
-    @Test
-    public void withdrawEverythingPrefillsWhatTheSavingCanGiveFromNow() throws IOException {
-        String saving = squash(region(SAVING_BRANCH_START, SAVING_BRANCH_END));
-        assertTrue("the withdraw everything prefill must be the lowest the saving reaches from "
-                + "now onwards, which is the figure the check applies when the save is pressed, "
-                + "held at zero so a saving already over withdrawn cannot prefill a negative "
-                + "amount: " + saving, saving.contains(PREFILL));
-        assertTrue("END_MONEY is the target, not what the saving holds, so it must not be read "
-                + "in this block at all: " + saving, !saving.contains("Contract.Saving.END_MONEY"));
-    }
-
-    @Test
-    public void withdrawEverythingPrefillsOnlyItsOwnCase() throws IOException {
-        String saving = squash(region(SAVING_BRANCH_START, SAVING_BRANCH_END));
-        String everything = saving.substring(saving.indexOf(WITHDRAW_EVERYTHING_CASE));
-        int ownCaseEnd = everything.indexOf(WITHDRAW_CASE);
-        assertTrue("the prefill has to sit in the withdraw everything case: moved into the deposit "
-                + "case it fills in what the saving can give every time a deposit is opened",
-                everything.substring(0, ownCaseEnd).contains(PREFILL));
-    }
-
-    @Test
-    public void withdrawEverythingFallsThroughToTheWithdrawCategory() throws IOException {
-        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
-        String everything = saving.substring(saving.indexOf(WITHDRAW_EVERYTHING_CASE));
-        String ownCase = everything.substring(0, everything.indexOf(WITHDRAW_CASE));
-        assertEquals("the withdraw everything case falls through on purpose to pick up the "
-                + "withdraw category below it. A break here, which is what an IDE inspection "
-                + "offers, leaves the category selection argument null, and the query below then "
-                + "crashes the editor as it opens: the bind value at index 1 is null",
-                -1, ownCase.indexOf("break"));
-    }
-
-    @Test
-    public void everyColumnTheSavingRowReadsIsInTheProjection() throws IOException {
-        // The saving branch builds two projections, one for the saving and one for its category,
-        // so this looks only at the part before the category query starts.
-        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END);
-        String projection = statementAssigning(
-                saving.substring(0, saving.indexOf(CATEGORY_QUERY_START)), "projection =");
-        assertTrue("a column read through getColumnIndex but left out of the projection returns "
-                + "index -1 and throws when it is read: " + projection,
-                projection.contains("Contract.Saving.START_MONEY")
-                        && projection.contains("Contract.Saving.WALLET_ID")
-                        && projection.contains("Contract.Saving.WALLET_CURRENCY"));
-    }
-
-    @Test
-    public void theWalkSignsAndSkipsRowsTheWayTheSavingsSumsDo() throws IOException {
-        String source = squash(stripCommentsAndStrings(readSource()));
-        assertTrue("a withdrawal is the income half of the pair, since it pays money into the "
-                + "wallet. Reading the other constant here compiles and turns every row into its "
-                + "opposite", source.contains("boolean withdrawal = cursor.getInt(cursor"
-                        + ".getColumnIndex(Contract.Transaction.DIRECTION)) == Contract.Direction"
-                        + ".INCOME;"));
-        assertTrue("and a withdrawal takes the saving down while a deposit puts money in, so the "
-                + "withdrawal is the negative one. Swapping the two arms compiles as well",
-                source.contains("signedMoney[rows] = withdrawal ? -money : money;"));
-        assertTrue("only a deposit is dropped for being unconfirmed, because landing takes being "
-                + "confirmed and money that never arrives must not pay for a withdrawal that "
-                + "does. Dropping an unconfirmed withdrawal too hands out a ceiling it can then "
-                + "take the saving under", source.contains("if (!withdrawal && cursor.getInt("
-                        + "cursor.getColumnIndex(Contract.Transaction.CONFIRMED)) != 1) {"));
-    }
-
-    @Test
-    public void everyColumnTheCheckReadsIsInItsOwnProjection() throws IOException {
-        // A column read through getColumnIndex but left out of the projection beside it returns
-        // index -1 and throws when it is read. These three are the queries the check runs on the
-        // way out, so a column dropped from any of them is a crash on saving a withdrawal.
-        String source = squash(stripCommentsAndStrings(readSource()));
-        assertTrue("the walk reads five columns off every row of the saving: " + source,
-                source.contains("String[] projection = new String[] { Contract.Transaction.ID, "
-                        + "Contract.Transaction.DATE, Contract.Transaction.MONEY, "
-                        + "Contract.Transaction.DIRECTION, Contract.Transaction.CONFIRMED };"));
-        assertTrue("the stored row is read for both the amount and the date, since it is kept or "
-                + "lowered only when neither has moved the wrong way: " + source,
-                source.contains("String[] projection = new String[] { Contract.Transaction.MONEY,"
-                        + " Contract.Transaction.DATE };"));
-        assertTrue("and the saving itself is read for what the walk starts from and the currency "
-                + "the ceiling is in: " + source, source.contains("String[] projection = new "
-                        + "String[] { Contract.Saving.START_MONEY, "
-                        + "Contract.Saving.WALLET_CURRENCY };"));
+        assertTrue("the saving must be loaded with the id the launching intent put in SAVING_ID, "
+                + "not with the id of the item being edited, which a new item does not have",
+                region(SAVING_BRANCH_START, SAVING_BRANCH_END, 1800)
+                        .contains("CONTENT_SAVINGS, mRules.getSavingId()"));
     }
 
     @Test
     public void savingWalletIsBuiltFromTheSavingRow() throws IOException {
-        String built = statementAssigning(region(SAVING_BRANCH_START, SAVING_BRANCH_END), "wallet =");
-        assertTrue("the editor has to open on the saving's own wallet, built from the row just "
-                + "read, but the assignment is: " + built, built.contains("new Wallet("));
-        assertTrue("that wallet has to carry the saving's currency, or the amount keypad has "
-                + "nothing to scale a typed amount against, but the assignment is: " + built,
-                built.contains("Contract.Saving.WALLET_ID")
-                        && built.contains("Contract.Saving.WALLET_CURRENCY"));
+        String built = statementAssigning(
+                region(SAVING_BRANCH_START, SAVING_BRANCH_END, 1800), "wallet =");
+        assertEquals("the editor has to open on the saving's own wallet, built from the row just "
+                + "read, and the whole statement is compared because Wallet takes its name and "
+                + "its currency as neighboring Strings. Asking only that both columns appear "
+                + "somewhere lets them be swapped, which opens the editor on a wallet named EUR "
+                + "with no currency the keypad can scale against, and a typed 2000 is stored as "
+                + "20.00",
+                "wallet = new Wallet( cursor.getLong(cursor.getColumnIndex(Contract.Saving"
+                + ".WALLET_ID)), cursor.getString(cursor.getColumnIndex(Contract.Saving"
+                + ".WALLET_NAME)), IconLoader.parse(cursor.getString(cursor.getColumnIndex("
+                + "Contract.Saving.WALLET_ICON))), CurrencyManager.getCurrency(cursor.getString("
+                + "cursor.getColumnIndex(Contract.Saving.WALLET_CURRENCY))), 0L, 0L )", built);
     }
 
     @Test
-    public void aSavingTransactionDoesNotOfferItsWalletField() throws IOException {
-        assertEquals("a saving's progress is summed with no currency in it, so the wallet a saving "
-                + "transaction sits in must not be changeable from the editor. The whole case is "
-                + "compared, since the debt guard four lines above it is false on every saving row "
-                + "and would give the field back if it were copied down here",
-                SAVING_CASE_BODY, squash(region(SAVING_CASE, CASE_BREAK)));
+    public void theSavingBranchIsComparedWhole() throws IOException {
+        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END, 1800);
+        int at = saving.indexOf(SAVING_ACTION_READ);
+        assertTrue("the saving action is no longer read here, so this test can no longer check "
+                + "what follows it", at >= 0);
+        assertEquals("everything the action decides is compared whole and in order, because each "
+                + "of these found on its own is satisfied while the defect it names is present. "
+                + "The guard moved below the query puts back master's crash on a null bind value "
+                + "with its own text untouched. The prefill hoisted out of its case fills in what "
+                + "the saving holds every time a deposit is opened. The query handed a literal "
+                + "array leaves the declaration sitting there unused and files every withdraw as "
+                + "a deposit, which writes the row in the wrong direction and makes "
+                + "validateSavingWithdraw step aside so the ceiling never runs",
+                SAVING_ACTION_BLOCK, saving.substring(at, at + SAVING_ACTION_BLOCK.length()));
     }
 
     @Test
-    public void aDebtPaymentDoesNotOfferItsWalletField() throws IOException {
-        assertEquals("a debt's progress is summed with no currency in it either, so the wallet a "
-                + "debt payment sits in must not be changeable from the editor. The whole case is "
-                + "compared, since a second hide above the guard, or a break dropped so this case "
-                + "falls into the saving body, takes the field off a master transaction too",
-                DEBT_CASE_BODY, squash(region(DEBT_CASE, CASE_BREAK)));
+    public void theStateIsCarriedAcrossARecreate() throws IOException {
+        String source = stripCommentsAndStrings(readSource());
+        assertTrue("the rules object has to go into the bundle, or a rotation loses the debt "
+                + "payment flag and the wallet field comes back on a payment",
+                source.contains("outState.putSerializable(SS_RULES, mRules);"));
+        assertTrue("and it has to be read back out, which fails the same way and is the half a "
+                + "test on the put alone still passes without", source.contains(
+                        "TransactionEditorRules restored = (TransactionEditorRules) "
+                        + "savedInstanceState.getSerializable(SS_RULES); if (restored != null) { "
+                        + "mRules = restored; }"));
+        assertTrue("and the flag is worked out from the loaded category's own tag on first open. "
+                + "A literal here makes every debt row a master transaction and hands every "
+                + "stored payment its wallet field back", source.contains(
+                        "mRules.setDebtPayment(TransactionEditorRules.isDebtPaymentTag("
+                        + "category.getTag()));"));
     }
 
     @Test
-    public void aDebtsMasterTransactionKeepsItsWalletField() throws IOException {
-        String source = squash(stripCommentsAndStrings(readSource()));
-        int derived = source.indexOf(DEBT_PAYMENT_DERIVATION);
-        int read = source.indexOf(SWITCH_ON_TYPE);
-        assertTrue("only a payment loses the field, and the derivation is compared whole, its "
-                + "guard and the line the tag is read from included, because a tag read replaced "
-                + "by one of the two paid constants makes every debt row a payment: " + source,
-                derived >= 0);
-        assertEquals("this reads the first switch on the type and there has to be only one, or a "
-                + "second one added anywhere above the derivation calls it late when it is not",
-                -1, source.indexOf(SWITCH_ON_TYPE, read + 1));
-        assertTrue("and the tag has to come off the category's own tag column on the edit path. "
-                + "Every other column on that row is a name or an icon, and a tag read swapped for "
-                + "one of them, or a fifth argument dropped for the four argument constructor the "
-                + "model branch already uses, leaves the tag null or a display name, which never "
-                + "equals either paid constant and hands every stored payment its wallet field "
-                + "back", source.contains(EDIT_PATH_TAG_READ));
+    public void theWithdrawEverythingPrefillComesFromTheSavingsOwnBalance() throws IOException {
+        String saving = region(SAVING_BRANCH_START, SAVING_BRANCH_END, 1800);
+        assertTrue("the prefill has to be fed the lowest the saving reaches from now onwards. "
+                + "The rules class is handed a number and cannot see which number it is: "
+                + saving, saving.contains("Long lowest = readLowestSavingBalanceFrom("
+                        + "contentResolver, savingUri, startMoney, DateUtils."
+                        + "getSQLDateTimeString(new Date()), -1L); money = TransactionEditorRules"
+                        + ".withdrawEverythingPrefill(lowest);"));
+        assertTrue("END_MONEY is the target, and a saving can be deposited past its target, so "
+                + "reading it here strands the overshoot. It must not be read in this block at "
+                + "all: " + saving, !saving.contains("Contract.Saving.END_MONEY"));
+    }
+
+    @Test
+    public void theWalkIsBuiltFromTheColumnsInTheOrderItTakesThem() throws IOException {
+        assertTrue("SavingRow takes five positional arguments and its id and its money are both "
+                + "long, so swapping them compiles and turns every amount into a row id. The "
+                + "rules test builds its own rows and cannot see this call",
+                stripCommentsAndStrings(readSource()).contains(
+                        "rows.add(new TransactionEditorRules.SavingRow( cursor.getLong(cursor"
+                        + ".getColumnIndex(Contract.Transaction.ID)), cursor.getString(cursor"
+                        + ".getColumnIndex(Contract.Transaction.DATE)), cursor.getLong(cursor"
+                        + ".getColumnIndex(Contract.Transaction.MONEY)), cursor.getInt(cursor"
+                        + ".getColumnIndex(Contract.Transaction.DIRECTION)), cursor.getInt(cursor"
+                        + ".getColumnIndex(Contract.Transaction.CONFIRMED)) == 1 ));"));
+    }
+
+    @Test
+    public void theRulesAreHandedTheirArgumentsInOrder() throws IOException {
+        String source = stripCommentsAndStrings(readSource());
+        assertTrue("isStoredWithdrawalKeptOrLowered takes the amount and date on screen and then "
+                + "the stored pair. Both pairs are a long and a String, so writing the stored "
+                + "pair first compiles, and raising a stored withdrawal is then waved through "
+                + "before the ceiling is ever worked out", source.contains(
+                        "unchangedOrSmaller = TransactionEditorRules"
+                        + ".isStoredWithdrawalKeptOrLowered( money, date, cursor.getLong(cursor"
+                        + ".getColumnIndex(Contract.Transaction.MONEY)), cursor.getString(cursor"
+                        + ".getColumnIndex(Contract.Transaction.DATE)));"));
+        assertTrue("and lowestSavingBalanceFrom takes the start money before the excluded id. "
+                + "Both are long, so swapping them makes the row id the saving's opening balance, "
+                + "and a new row names -1", source.contains(
+                        "return TransactionEditorRules.lowestSavingBalanceFrom(startMoney, rows, "
+                        + "excludedId, from);"));
+    }
+
+    @Test
+    public void theDerivationAndTheHidesAreComparedWhole() throws IOException {
+        String source = stripCommentsAndStrings(readSource());
+        int at = source.indexOf("if (restored != null)");
+        assertTrue("the restore block is gone, so this test can no longer find what it checks",
+                at >= 0);
+        String block = source.substring(at, at + DERIVATION_AND_HIDES.length());
+        assertEquals("the flag a debt payment loses its wallet field by is worked out here, and "
+                + "the block is compared whole, with the restore above it and both hides below "
+                + "it, because nothing about this survives being found by a search. A statement "
+                + "written inside the guard, the guard flipped to run only on a recreate, which "
+                + "leaves it running on no path at all since category is null everywhere else, "
+                + "and the derivation moved below the hides all leave this text sitting where it "
+                + "is and hand every stored debt payment its wallet field back. Swapping which "
+                + "field each hide answers for is the same kind of edit",
+                DERIVATION_AND_HIDES, block);
+    }
+
+    @Test
+    public void theCategoryTagIsReadFromTheTagColumn() throws IOException {
+        String source = stripCommentsAndStrings(readSource());
+        assertEquals("the tag has to come off the category's own tag column on the edit path. "
+                + "Category has a four argument constructor that the model branch already uses, "
+                + "so dropping the fifth argument compiles and leaves the tag null. A null tag "
+                + "makes isDebtPaymentTag false for every row, and Category.getDirection falls "
+                + "through to expense, so a stored saving withdrawal is rewritten as a deposit",
+                1, count(source, EDIT_PATH_TAG_READ));
         assertEquals("and off the category table's tag column on both of the loads that read it, "
-                + "the new payment one and the saving one. Those two are identical text, so they "
-                + "are counted and not found. A swap on the new payment load is the half a check "
-                + "on the edit path alone cannot see, and finding one of the two would have gone "
-                + "on passing on the strength of the other", 2,
-                source.split(Pattern.quote(CATEGORY_TABLE_TAG_READ), -1).length - 1);
+                + "the new debt payment one and the saving one. Those two are identical text, so "
+                + "they are counted and not found, or finding one would go on passing on the "
+                + "strength of the other. With a null tag there, validateSavingWithdraw steps "
+                + "aside at its own tag check and the ceiling never runs at all",
+                2, count(source, CATEGORY_TABLE_TAG_READ));
     }
 
     @Test
-    public void theDebtPaymentFlagIsCarriedAcrossARecreate() throws IOException {
-        String source = squash(stripCommentsAndStrings(readSource()));
-        assertTrue("the derivation is skipped on a recreate, since it runs only when there is no "
-                + "saved state, so the flag has to come back out of the bundle or a rotation gives "
-                + "a payment its wallet field back: " + source,
-                source.contains("mDebtPayment = savedInstanceState.getBoolean(SS_DEBT_PAYMENT, "
-                        + "false);"));
-        assertTrue("and it has to be put in the bundle, which fails the same way and is the half a "
-                + "rotation test on the restore alone still passes without",
-                source.contains("outState.putBoolean(SS_DEBT_PAYMENT, mDebtPayment);"));
-        assertTrue("and it starts false, so a debt row the flag was never worked out for keeps its "
-                + "wallet field instead of losing it",
-                source.contains("private boolean mDebtPayment = false;"));
-        assertTrue("and its key has to be its own. The five saved state keys are near identical "
-                + "lines and this one was written by copying its neighbor, so a key repeated from "
-                + "one of them puts two values in one bundle entry and the one read back is "
-                + "whichever was written last. This is the one assertion here that reads the "
-                + "source with its string literals left in, since the key is a literal",
-                squash(stripComments(readSource())).contains(
-                        "SS_DEBT_PAYMENT = \"NewEditTransactionActivity::SavedState::DebtPayment\";"));
+    public void theCheckIsComparedWhole() throws IOException {
+        String source = stripCommentsAndStrings(readSource());
+        int at = source.indexOf("if (isStoredWithdrawalKeptOrLowered");
+        assertTrue("the stored row escape is gone from the check, and with it the only thing "
+                + "that lets a withdrawal on a saving already under zero be lowered, saved "
+                + "unchanged, or have its own note corrected", at >= 0);
+        assertEquals("the check is compared whole and in order. Deleting the stored row escape "
+                + "leaves the call inside its own helper, which another assertion here pins, so "
+                + "the helper becomes unreachable and the coverage only looks present",
+                CHECK_BLOCK, source.substring(at, at + CHECK_BLOCK.length()));
     }
 
-    /**
-     * Runs of whitespace are collapsed to one space before these are matched, so the amount of
-     * space between two tokens does not matter. A break inserted where the pattern has no space
-     * at all still fails them, which is a false alarm and not a defect in the code. Everything
-     * else about them is literal. They are token matching, not behavior, and a rewrite that keeps
-     * these sequences and still gets the ceiling wrong goes through.
-     */
     @Test
-    public void theCheckCountsFromTheDateOnScreenOverRowsInDateOrder() throws IOException {
-        String source = squash(stripCommentsAndStrings(readSource()));
-        // The order clause is a string literal, so this one assertion reads a source with its
-        // comments taken out and its literals left in. A comment carrying the same text would
-        // satisfy it, which nothing else here can be.
-        assertTrue("the rows come back ordered by date, which is the order the walk needs and "
-                + "cannot tell is missing. In any other order the number it returns is not the "
-                + "lowest balance at all", squash(stripComments(readSource())).contains(
-                        "projection, selection, selectionArgs, Contract.Transaction.DATE + \" ASC\");"));
-        assertTrue("the row being edited is left out of the walk, or its own drain is counted "
-                + "against it and it can never be raised. A new item names -1, which no row "
-                + "carries", source.contains("if (cursor.getLong(cursor.getColumnIndex("
-                        + "Contract.Transaction.ID)) == excludedId) { continue; }"));
-        assertTrue("and the id left out is the one being edited", source.contains(
-                "readLowestSavingBalanceFrom(contentResolver, savingUri, startMoney, date, "
-                        + "getItemId());"));
+    public void theCheckCountsFromTheDateOnScreenAndLeavesOutTheRowBeingEdited()
+            throws IOException {
+        String source = stripCommentsAndStrings(readSource());
+        assertTrue("the amount the check holds to the ceiling is the one on screen. It is the "
+                + "fourth of the four values this check is built from, and the other three are "
+                + "pinned on the lines below, so a literal here refuses nothing and leaves no "
+                + "mark on the database", source.contains(
+                        "long money = mMoneyPicker.getCurrentMoney();"));
         assertTrue("the moment counted from is the date on screen. Counting from today is the "
-                + "defect this replaced, since a row dated earlier drains every day from its own "
-                + "date onwards", source.contains("String date = DateUtils.getSQLDateTimeString("
-                        + "mDateTimePicker.getCurrentDateTime());"));
-        assertTrue("a stored row kept or lowered on a date it does not move back from is never "
-                + "refused. Without that, two withdrawals that already have a saving under zero "
-                + "freeze each other and deleting one is the only way out", source.contains(
-                "unchangedOrSmaller = money <= cursor.getLong(cursor.getColumnIndex("
-                        + "Contract.Transaction.MONEY)) && date.compareTo(cursor.getString("
-                        + "cursor.getColumnIndex(Contract.Transaction.DATE))) >= 0;"));
-        // Inside the check itself and in this order, because each of these read on its own is
-        // satisfied by a body that works the ceiling out and then never uses it.
-        String check = squash(region(CHECK_START, CHECK_END));
-        int keeps = check.indexOf("if (isStoredWithdrawalKeptOrLowered(contentResolver, money, date)) {");
-        int works = check.indexOf("long limit = Math.max(lowest, 0L);");
-        int compares = check.indexOf("if (money <= limit) {");
-        assertTrue("the stored row is let through before anything is worked out: " + check,
-                keeps >= 0);
-        assertTrue("the ceiling is held at nothing, or a saving already under zero on some date "
-                + "from here on refuses every save of every row it carries, an amount of nothing "
-                + "included: " + check, works > keeps);
-        assertTrue("and the amount is compared against what was worked out, after working it out. "
-                + "Comparing first leaves every literal here in place and the ceiling binding "
-                + "nothing: " + check, compares > works);
-        assertTrue("the dialog names what the check worked out. Naming the raw figure instead "
-                + "tells the user a negative number on a saving that is already under zero",
+                + "defect this replaced, and the rules class is handed the date as a string",
+                source.contains("String date = DateUtils.getSQLDateTimeString(mDateTimePicker"
+                        + ".getCurrentDateTime());"));
+        assertTrue("and the row left out of the walk is the one being edited, or its own drain "
+                + "is counted against it and it can never be raised", source.contains(
+                        "readLowestSavingBalanceFrom(contentResolver, savingUri, startMoney, "
+                        + "date, getItemId());"));
+        assertTrue("the ceiling is held at nothing before it is compared against. Without "
+                + "that a saving already under zero on some later date refuses every save of "
+                + "every row it carries, an amount of nothing included", source.contains(
+                        "long limit = TransactionEditorRules.withdrawLimit(lowest);"));
+        assertTrue("and the amount is the first argument and the ceiling the second. Both are "
+                + "long, so the transposed call compiles and accepts everything over the ceiling "
+                + "while refusing everything under it", source.contains(
+                        "if (TransactionEditorRules.isWithinLimit(money, limit)) {"));
+        assertTrue("the dialog names the ceiling that was worked out. Naming the raw figure "
+                + "instead tells the user a negative number on a saving already under zero",
                 source.contains("mMoneyFormatter.getNotTintedString(currency, limit)"));
     }
 
     /**
-     * Returns the statement that assigns to the given left hand side, skipping any long
-     * declaration of the same name, which is how each figure is declared before the block fills
-     * it. Fails when the literal text passed in matches more than once, so a second plain
-     * assignment cannot slip past unread. Compound assignments do not contain that text:
-     * "landedMoney -=" does not contain "landedMoney =", so a later += or -= is not seen.
+     * Returns the statement that assigns to the given left hand side. Fails when the literal text
+     * passed in matches more than once, so a second plain assignment cannot slip past unread.
+     * Compound assignments do not contain that text, so a later += or -= is not seen.
      */
     private static String statementAssigning(String block, String assignment) {
         String found = null;
         for (int at = block.indexOf(assignment); at >= 0; at = block.indexOf(assignment, at + 1)) {
-            if (block.lastIndexOf("long ", at) == at - "long ".length()) {
-                continue;
-            }
             int end = block.indexOf(';', at);
             if (end < 0) {
                 fail("the assignment to " + assignment + " has no end");
             }
             if (found != null) {
                 fail("more than one assignment to " + assignment + " in the saving branch, so "
-                        + "this test can no longer tell which one feeds the prefill");
+                        + "this test can no longer tell which one the editor opens on");
             }
             found = block.substring(at, end);
         }
@@ -421,15 +310,40 @@ public class NewEditTransactionActivitySourceTest {
         return found;
     }
 
-    private static String region(String start, String end) throws IOException {
+    /**
+     * The text between two anchors, taking the LAST end anchor and not the first, and refusing
+     * a region that has collapsed.
+     *
+     * Both matter. INTENT_BRANCH_END is an ordinary statement that already appears twice in this
+     * method, and moving it to the top of the branch it ends is behavior preserving; with the
+     * first match it took the region shrinks to one line and every assertion over it passes over
+     * whatever was left behind. The floor catches the same thing when the anchor is moved to a
+     * spot that is still last.
+     */
+    private static String region(String start, String end, int atLeast) throws IOException {
         String text = stripCommentsAndStrings(readSource());
         int from = text.indexOf(start);
-        int to = from < 0 ? -1 : text.indexOf(end, from + 1);
-        if (from < 0 || to < 0) {
+        int to = from < 0 ? -1 : text.lastIndexOf(end);
+        if (from < 0 || to < from) {
             fail("could not find the region between \"" + start + "\" and \"" + end + "\" in "
                     + SOURCE_PATH + ", so this test can no longer check it");
         }
-        return text.substring(from, to);
+        String found = text.substring(from, to);
+        if (found.length() < atLeast) {
+            fail("the region between \"" + start + "\" and \"" + end + "\" is " + found.length()
+                    + " characters, under the " + atLeast + " it should be. An anchor has moved, "
+                    + "and every assertion over this region is passing over whatever is left");
+        }
+        return found;
+    }
+
+    /** How many times a literal occurs, so two identical loads cannot cover for each other. */
+    private static int count(String text, String literal) {
+        int n = 0;
+        for (int at = text.indexOf(literal); at >= 0; at = text.indexOf(literal, at + 1)) {
+            n++;
+        }
+        return n;
     }
 
     private static String readSource() throws IOException {
@@ -445,22 +359,10 @@ public class NewEditTransactionActivitySourceTest {
 
     /**
      * Removes comments and string literals, replacing each with a single space so that the tokens
-     * on either side of a removed comment do not run together. Without this the assertions above
-     * could be satisfied, or broken, by prose that no compiler ever sees.
+     * on either side of a removed comment do not run together, then collapses every run of
+     * whitespace to one space.
      */
     private static String stripCommentsAndStrings(String text) {
-        return strip(text, true);
-    }
-
-    /**
-     * The same with the string literals left in, for the assertions whose invariant is written as
-     * a literal. Comments still go, so the text they look for cannot come from prose.
-     */
-    private static String stripComments(String text) {
-        return strip(text, false);
-    }
-
-    private static String strip(String text, boolean strings) {
         StringBuilder out = new StringBuilder(text.length());
         int i = 0;
         while (i < text.length()) {
@@ -471,7 +373,7 @@ public class NewEditTransactionActivitySourceTest {
             } else if (c == '/' && i + 1 < text.length() && text.charAt(i + 1) == '*') {
                 i = skipTo(text, i + 2, "*/") + 2;
                 out.append(' ');
-            } else if (strings && (c == '"' || c == '\'')) {
+            } else if (c == '"' || c == '\'') {
                 i++;
                 while (i < text.length() && text.charAt(i) != c) {
                     i += text.charAt(i) == '\\' ? 2 : 1;
@@ -483,16 +385,12 @@ public class NewEditTransactionActivitySourceTest {
                 i++;
             }
         }
-        return out.toString();
-    }
-
-    /** Collapses every run of whitespace to one space. */
-    private static String squash(String text) {
-        return text.replaceAll("\\s+", " ");
+        return out.toString().replaceAll("\\s+", " ");
     }
 
     private static int skipTo(String text, int from, String token) {
         int at = text.indexOf(token, from);
         return at < 0 ? text.length() : at;
     }
+
 }

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/TransactionEditorRulesTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/TransactionEditorRulesTest.java
@@ -1,0 +1,406 @@
+package com.oriondev.moneywallet.ui.activity;
+
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.ui.activity.TransactionEditorRules.SavingRow;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The transaction editor's rules, driven directly. Every case here used to be pinned by matching
+ * the text of NewEditTransactionActivity, or was not pinned at all.
+ */
+public class TransactionEditorRulesTest {
+
+    private static final int DEPOSIT = Contract.Direction.EXPENSE;
+    private static final int WITHDRAWAL = Contract.Direction.INCOME;
+
+    private static TransactionEditorRules rules(int type, boolean debtPayment) {
+        TransactionEditorRules rules = new TransactionEditorRules();
+        rules.setType(type);
+        rules.setDebtPayment(debtPayment);
+        return rules;
+    }
+
+    // ---- what the editor hides -------------------------------------------------------------
+
+    @Test
+    public void anOrdinaryTransactionOffersBothFields() {
+        TransactionEditorRules rules = rules(TransactionEditorRules.TYPE_STANDARD, false);
+        assertFalse(rules.hidesCategoryField());
+        assertFalse(rules.hidesWalletField());
+    }
+
+    @Test
+    public void aSavingTransactionHidesBothFields() {
+        TransactionEditorRules rules = rules(TransactionEditorRules.TYPE_SAVING, false);
+        assertTrue(rules.hidesCategoryField());
+        assertTrue("a saving's progress is summed with no currency in it, so the wallet a saving "
+                + "transaction sits in must not be changeable from the editor",
+                rules.hidesWalletField());
+    }
+
+    @Test
+    public void aSavingTransactionHidesItsWalletFieldWhateverTheDebtFlagSays() {
+        assertTrue("the debt payment flag must not reach the saving case, or a saving row "
+                + "carrying a paid category gets its wallet field back",
+                rules(TransactionEditorRules.TYPE_SAVING, true).hidesWalletField());
+    }
+
+    @Test
+    public void aTransactionFromAModelOffersBothFields() {
+        TransactionEditorRules rules = rules(TransactionEditorRules.TYPE_MODEL, false);
+        assertFalse("a row entered from a model is an ordinary transaction and has to be filed "
+                + "under a category the user picks", rules.hidesCategoryField());
+        assertFalse(rules.hidesWalletField());
+    }
+
+    @Test
+    public void aTransferOffersBothFields() {
+        TransactionEditorRules rules = rules(TransactionEditorRules.TYPE_TRANSFER, false);
+        assertFalse(rules.hidesCategoryField());
+        assertFalse(rules.hidesWalletField());
+    }
+
+    @Test
+    public void anOrdinaryTransactionKeepsItsWalletFieldEvenWithTheFlagSet() {
+        assertFalse("only a debt row reads the flag at all",
+                rules(TransactionEditorRules.TYPE_STANDARD, true).hidesWalletField());
+    }
+
+    @Test
+    public void aDebtPaymentHidesBothFields() {
+        TransactionEditorRules rules = rules(TransactionEditorRules.TYPE_DEBT, true);
+        assertTrue(rules.hidesCategoryField());
+        assertTrue("a debt's progress is summed with no currency in it either",
+                rules.hidesWalletField());
+    }
+
+    @Test
+    public void aDebtsMasterTransactionKeepsItsWalletField() {
+        TransactionEditorRules rules = rules(TransactionEditorRules.TYPE_DEBT, false);
+        assertTrue("a master transaction is filed under the debt's own category, so the field "
+                + "stays hidden", rules.hidesCategoryField());
+        assertFalse("editing a master transaction's wallet moves the debt itself through "
+                + "syncDebtOfMasterTransaction, so hiding the field there would take that away",
+                rules.hidesWalletField());
+    }
+
+    @Test
+    public void theDebtPaymentFlagStartsFalse() {
+        assertFalse("a debt row the flag was never worked out for keeps its wallet field",
+                new TransactionEditorRules().isDebtPayment());
+    }
+
+    // ---- what makes a row a payment --------------------------------------------------------
+
+    /** Never the constant itself, since a cursor hands this out and nothing interns it. */
+    private static String read(String value) {
+        return new StringBuilder(value).toString();
+    }
+
+    @Test
+    public void onlyThePaidCategoriesMakeARowAPayment() {
+        assertTrue(TransactionEditorRules.isDebtPaymentTag(read(Contract.CategoryTag.PAID_DEBT)));
+        assertTrue(TransactionEditorRules.isDebtPaymentTag(read(Contract.CategoryTag.PAID_CREDIT)));
+        assertFalse("the debt's own category is a master transaction, not a payment",
+                TransactionEditorRules.isDebtPaymentTag(Contract.CategoryTag.DEBT));
+        assertFalse(TransactionEditorRules.isDebtPaymentTag(Contract.CategoryTag.CREDIT));
+        assertFalse("a tag read off a name column, or a fifth constructor argument dropped, "
+                + "leaves this null", TransactionEditorRules.isDebtPaymentTag(null));
+        assertFalse(TransactionEditorRules.isDebtPaymentTag("Groceries"));
+    }
+
+    // ---- which category a new row is filed under -------------------------------------------
+
+    @Test
+    public void theDebtActionNamesTheKindOfDebt() {
+        assertEquals(Contract.DebtType.DEBT,
+                TransactionEditorRules.debtTypeFor(TransactionEditorRules.DEBT_PAY));
+        assertEquals(Contract.DebtType.CREDIT,
+                TransactionEditorRules.debtTypeFor(TransactionEditorRules.DEBT_RECEIVE));
+        assertNull("a launch naming no action names no kind",
+                TransactionEditorRules.debtTypeFor(0));
+    }
+
+    @Test
+    public void eachKindOfDebtIsFiledUnderItsOwnPaidCategory() {
+        assertEquals(Contract.CategoryTag.PAID_DEBT,
+                TransactionEditorRules.debtCategoryTag(Contract.DebtType.DEBT));
+        assertEquals(Contract.CategoryTag.PAID_CREDIT,
+                TransactionEditorRules.debtCategoryTag(Contract.DebtType.CREDIT));
+        assertNull("no kind, no category, and the editor runs no query",
+                TransactionEditorRules.debtCategoryTag(null));
+    }
+
+    @Test
+    public void aDepositAndAWithdrawAreFiledUnderTheirOwnCategories() {
+        assertEquals(Contract.CategoryTag.SAVING_DEPOSIT, TransactionEditorRules
+                .savingCategoryTag(TransactionEditorRules.SAVING_DEPOSIT));
+        assertEquals(Contract.CategoryTag.SAVING_WITHDRAW, TransactionEditorRules
+                .savingCategoryTag(TransactionEditorRules.SAVING_WITHDRAW));
+    }
+
+    @Test
+    public void withdrawEverythingIsFiledUnderTheWithdrawCategory() {
+        assertEquals("withdraw everything is a withdrawal. The activity used to reach this by "
+                + "falling through one case into the other, where a break left the tag null and "
+                + "the query below crashed the editor as it opened",
+                Contract.CategoryTag.SAVING_WITHDRAW, TransactionEditorRules
+                        .savingCategoryTag(TransactionEditorRules.SAVING_WITHDRAW_EVERYTHING));
+    }
+
+    @Test
+    public void anActionThatNamesNothingIsFiledNowhere() {
+        assertNull("a crafted intent carrying no saving action used to bind null into the "
+                + "category query and crash the editor as it opened",
+                TransactionEditorRules.savingCategoryTag(0));
+    }
+
+    @Test
+    public void onlyWithdrawEverythingCompletesTheSaving() {
+        assertTrue(TransactionEditorRules
+                .completesTheSaving(TransactionEditorRules.SAVING_WITHDRAW_EVERYTHING));
+        assertFalse(TransactionEditorRules
+                .completesTheSaving(TransactionEditorRules.SAVING_WITHDRAW));
+        assertFalse(TransactionEditorRules
+                .completesTheSaving(TransactionEditorRules.SAVING_DEPOSIT));
+        assertFalse(TransactionEditorRules.completesTheSaving(0));
+    }
+
+    // ---- the prefill and the ceiling -------------------------------------------------------
+
+    @Test
+    public void theWithdrawEverythingPrefillIsWhatTheSavingCanGive() {
+        assertEquals(76000L, TransactionEditorRules.withdrawEverythingPrefill(76000L));
+    }
+
+    @Test
+    public void theWithdrawEverythingPrefillIsNeverNegative() {
+        assertEquals("a saving already carrying more withdrawals than it holds gives a negative "
+                + "figure, and saving the field untouched would write a withdrawal of a negative "
+                + "amount", 0L, TransactionEditorRules.withdrawEverythingPrefill(-4240L));
+    }
+
+    @Test
+    public void aSavingWhoseRowsDoNotComeBackPrefillsNothing() {
+        assertEquals(0L, TransactionEditorRules.withdrawEverythingPrefill(null));
+    }
+
+    @Test
+    public void theCeilingIsHeldAtNothing() {
+        assertEquals("a saving already under zero on some date from here on would otherwise "
+                + "refuse every save of every row it carries, an amount of nothing included",
+                0L, TransactionEditorRules.withdrawLimit(-1L));
+        assertEquals(76000L, TransactionEditorRules.withdrawLimit(76000L));
+    }
+
+    @Test
+    public void anAmountOfNothingIsNeverRefused() {
+        assertTrue("or a stored withdrawal of nothing could never have its own note or date "
+                + "corrected, and only deletion would be open",
+                TransactionEditorRules.isWithinLimit(0L, 0L));
+    }
+
+    @Test
+    public void theCeilingRefusesOnlyWhatIsOverIt() {
+        assertTrue(TransactionEditorRules.isWithinLimit(75999L, 76000L));
+        assertTrue("the ceiling itself is allowed",
+                TransactionEditorRules.isWithinLimit(76000L, 76000L));
+        assertFalse(TransactionEditorRules.isWithinLimit(76001L, 76000L));
+    }
+
+    // ---- when the ceiling applies at all ---------------------------------------------------
+
+    @Test
+    public void theCeilingAppliesInTheSavingsOwnCurrency() {
+        assertTrue(TransactionEditorRules.ceilingApplies(read("EUR"), read("EUR")));
+    }
+
+    @Test
+    public void theCeilingStepsAsideForAWalletInAnotherCurrency() {
+        assertFalse("the two amounts are not comparable as they stand and this screen converts "
+                + "nowhere else", TransactionEditorRules.ceilingApplies("EUR", "USD"));
+    }
+
+    @Test
+    public void theCeilingStepsAsideWhenEitherCurrencyIsUnresolvable() {
+        assertFalse("a saving whose own currency the app cannot resolve, which a restored backup "
+                + "can produce", TransactionEditorRules.ceilingApplies(null, "EUR"));
+        assertFalse(TransactionEditorRules.ceilingApplies("EUR", null));
+        assertFalse(TransactionEditorRules.ceilingApplies(null, null));
+    }
+
+    // ---- the stored row that is kept or lowered --------------------------------------------
+
+    @Test
+    public void aStoredWithdrawalKeptExactlyAsItWasIsNeverRefused() {
+        assertTrue(TransactionEditorRules.isStoredWithdrawalKeptOrLowered(
+                500L, "2026-09-01 10:00:00", 500L, "2026-09-01 10:00:00"));
+    }
+
+    @Test
+    public void aStoredWithdrawalLoweredIsNeverRefused() {
+        assertTrue("two withdrawals that already have a saving under zero would otherwise freeze "
+                + "each other, and deleting one would be the only way out",
+                TransactionEditorRules.isStoredWithdrawalKeptOrLowered(
+                        400L, "2026-09-01 10:00:00", 500L, "2026-09-01 10:00:00"));
+    }
+
+    @Test
+    public void aStoredWithdrawalRaisedIsHeldToTheCeiling() {
+        assertFalse(TransactionEditorRules.isStoredWithdrawalKeptOrLowered(
+                600L, "2026-09-01 10:00:00", 500L, "2026-09-01 10:00:00"));
+    }
+
+    @Test
+    public void aStoredWithdrawalMovedEarlierIsHeldToTheCeiling() {
+        assertFalse("moving a stored row earlier is a new drain on every date it moves across",
+                TransactionEditorRules.isStoredWithdrawalKeptOrLowered(
+                        500L, "2026-08-01 10:00:00", 500L, "2026-09-01 10:00:00"));
+    }
+
+    @Test
+    public void aStoredWithdrawalMovedLaterIsNeverRefused() {
+        assertTrue(TransactionEditorRules.isStoredWithdrawalKeptOrLowered(
+                500L, "2026-10-01 10:00:00", 500L, "2026-09-01 10:00:00"));
+    }
+
+    // ---- how the walk reads one row --------------------------------------------------------
+
+    @Test
+    public void aWithdrawalIsTheIncomeHalfOfThePair() {
+        assertTrue("it pays money into the wallet. Reading the other constant here compiles and "
+                + "turns every row into its opposite",
+                TransactionEditorRules.isWithdrawal(Contract.Direction.INCOME));
+        assertFalse(TransactionEditorRules.isWithdrawal(Contract.Direction.EXPENSE));
+    }
+
+    @Test
+    public void aWithdrawalTakesTheSavingDownAndADepositPutsMoneyIn() {
+        assertEquals(-500L, TransactionEditorRules.signedAmount(
+                new SavingRow(1L, "2026-09-01 10:00:00", 500L, WITHDRAWAL, true)));
+        assertEquals(500L, TransactionEditorRules.signedAmount(
+                new SavingRow(1L, "2026-09-01 10:00:00", 500L, DEPOSIT, true)));
+    }
+
+    @Test
+    public void anUnconfirmedDepositIsLeftOut() {
+        assertFalse("landing takes being confirmed, and money that never arrives must not pay "
+                + "for a withdrawal that does", TransactionEditorRules.countsTowardBalance(
+                        new SavingRow(1L, "2026-09-01 10:00:00", 500L, DEPOSIT, false)));
+    }
+
+    @Test
+    public void anUnconfirmedWithdrawalIsCounted() {
+        assertTrue("leaving it out hands out a ceiling it can then take the saving under",
+                TransactionEditorRules.countsTowardBalance(
+                        new SavingRow(1L, "2026-09-01 10:00:00", 500L, WITHDRAWAL, false)));
+    }
+
+    @Test
+    public void aConfirmedDepositIsCounted() {
+        assertTrue(TransactionEditorRules.countsTowardBalance(
+                new SavingRow(1L, "2026-09-01 10:00:00", 500L, DEPOSIT, true)));
+    }
+
+    // ---- the walk ---------------------------------------------------------------------------
+
+    private static List<SavingRow> ledger() {
+        return new ArrayList<>(Arrays.asList(
+                new SavingRow(3L, "2026-09-01 10:00:00", 90000L, DEPOSIT, true),
+                new SavingRow(1L, "2026-09-10 10:00:00", 15000L, WITHDRAWAL, true),
+                new SavingRow(2L, "2026-09-20 10:00:00", 30000L, DEPOSIT, true)));
+    }
+
+    @Test
+    public void theWalkCountsEveryRowFromTheDateOnScreen() {
+        assertEquals("start 10000 plus 90000 in, minus 15000 out, is 85000 before the deposit on "
+                + "the 20th lifts it", 85000L, TransactionEditorRules.lowestSavingBalanceFrom(
+                        10000L, ledger(), -1L, "2026-09-01 10:00:00"));
+    }
+
+    @Test
+    public void theWalkCountsFromTheDateItIsGivenAndNotFromToday() {
+        assertEquals("the same rows from a date after all of them answer what the saving ends "
+                + "up holding, not the 85000 it dips to on the way. A row dated earlier drains "
+                + "every day from its own date onwards, which is the defect this replaced",
+                115000L, TransactionEditorRules.lowestSavingBalanceFrom(
+                        10000L, ledger(), -1L, "2026-09-25 10:00:00"));
+    }
+
+    @Test
+    public void theWalkLeavesOutTheRowBeingEdited() {
+        assertEquals("the row being edited must not be held against its own drain, or it could "
+                + "never be raised", 100000L, TransactionEditorRules.lowestSavingBalanceFrom(
+                        10000L, ledger(), 1L, "2026-09-01 10:00:00"));
+    }
+
+    @Test
+    public void theWalkOrdersTheRowsItself() {
+        List<SavingRow> shuffled = ledger();
+        Collections.reverse(shuffled);
+        assertEquals("the answer must not depend on the order the caller read the rows in. "
+                + "The ids run against the dates on purpose, or a sort by id passes as a sort "
+                + "by date",
+                85000L, TransactionEditorRules.lowestSavingBalanceFrom(
+                        10000L, shuffled, -1L, "2026-09-01 10:00:00"));
+    }
+
+    @Test
+    public void theWalkLeavesOutAnUnconfirmedDepositThatWouldPayForAWithdrawal() {
+        List<SavingRow> rows = new ArrayList<>(Arrays.asList(
+                new SavingRow(1L, "2026-09-01 10:00:00", 300000L, DEPOSIT, false),
+                new SavingRow(2L, "2026-10-01 10:00:00", 300000L, WITHDRAWAL, true)));
+        assertEquals("an unconfirmed deposit funding a withdrawal dated next month is the "
+                + "reported defect: the goal went to 3,000.00 negative when that row landed",
+                -300000L, TransactionEditorRules.lowestSavingBalanceFrom(
+                        0L, rows, -1L, "2026-09-01 10:00:00"));
+    }
+
+    @Test
+    public void theWalkOverNoRowsAnswersTheStartMoney() {
+        assertEquals(10000L, TransactionEditorRules.lowestSavingBalanceFrom(
+                10000L, new ArrayList<SavingRow>(), -1L, "2026-09-01 10:00:00"));
+    }
+
+    // ---- the state the editor carries across a recreate ------------------------------------
+
+    @Test
+    public void theRulesCarryTheirStateAcrossASerializeRoundTrip() throws Exception {
+        TransactionEditorRules before = new TransactionEditorRules();
+        before.setType(TransactionEditorRules.TYPE_DEBT);
+        before.setDebtId(7L);
+        before.setSavingId(88L);
+        before.setSavingCompleted(true);
+        before.setDebtPayment(true);
+        TransactionEditorRules after = roundTrip(before);
+        assertEquals(TransactionEditorRules.TYPE_DEBT, after.getType());
+        assertEquals(Long.valueOf(7L), after.getDebtId());
+        assertEquals("asserting null here passes whether or not the field survives, which is "
+                + "how a lost saving id would read", Long.valueOf(88L), after.getSavingId());
+        assertTrue(after.isSavingCompleted());
+        assertTrue("losing this gives a payment its wallet field back on the next rotation",
+                after.isDebtPayment());
+    }
+
+    private static TransactionEditorRules roundTrip(TransactionEditorRules rules) throws Exception {
+        java.io.ByteArrayOutputStream bytes = new java.io.ByteArrayOutputStream();
+        java.io.ObjectOutputStream out = new java.io.ObjectOutputStream(bytes);
+        out.writeObject(rules);
+        out.close();
+        java.io.ObjectInputStream in = new java.io.ObjectInputStream(
+                new java.io.ByteArrayInputStream(bytes.toByteArray()));
+        return (TransactionEditorRules) in.readObject();
+    }
+
+}


### PR DESCRIPTION
The transaction editor works out a lot on its way up. Which category a new debt or savings row is filed under, whether the category and wallet fields are offered at all, what a withdraw everything opens prefilled with, and the ceiling a withdrawal is held to. All of that sat inside one very long method that needs a live screen and a live database to run, so none of it could be checked without a device, and the checks that existed matched the text of the file instead of running the code.

Those decisions now live in a plain class with nothing Android in it, which a test can drive directly. The editor keeps every database read and every dialog and asks that class for the answers.

Nothing changes on screen, with one exception. Another app could open this editor for a savings goal without saying whether it was a deposit or a withdrawal, and the editor crashed as it opened. It now closes instead. Nothing inside the app can reach that, because every place that opens the editor for a savings goal says which of the three it is.

Three faults can no longer happen at all, instead of being tested for. One case used to fall into the next one to pick up its category, and tidying that up left the editor crashing as it opened. The five values the editor carries through a screen rotation were near identical lines, one written by copying its neighbor, and a repeated name would have quietly lost one of them; they travel as one value now. And the balance walk puts its rows in date order itself, so the answer no longer depends on how they were asked for.

Tested against a build of master on the same six month ledger, on nineteen matched pairs covering a new entry, a copy, an edit, all three savings actions, both debt actions, an entry from a saved model, a share from another app, a debt and one of its payments, and a rotation of each. Every pair agreed.
