### PR TITLE
Raise the AndroidX floor and take the map screen off the framework loaders

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'com.android.application'
 
 android {
     namespace "com.oriondev.moneywallet"
-    compileSdk 35
+    compileSdk 36
 
     buildFeatures {
         buildConfig true
@@ -161,9 +161,18 @@ dependencies {
     // Without this line documentfile resolves to 1.0.0, by way of legacy-support-core-utils.
     // In 1.0.0 fromTreeUri drops the document id, so every folder under a granted tree
     // resolves to the top of the tree. 1.0.1 keeps the id when the uri is a document uri.
-    implementation 'androidx.documentfile:documentfile:1.0.1'
-    implementation 'androidx.activity:activity:1.2.0-alpha08'
-    implementation 'androidx.fragment:fragment:1.3.0-alpha08'
+    implementation 'androidx.documentfile:documentfile:1.1.0'
+    implementation 'androidx.activity:activity:1.13.0'
+    implementation 'androidx.fragment:fragment:1.9.0'
+    // Used directly by the app and never declared until now.
+    implementation 'androidx.core:core:1.18.0'
+    implementation 'androidx.loader:loader:1.2.0'
+    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
+    implementation 'androidx.viewpager:viewpager:1.1.0'
+    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
+    implementation 'androidx.collection:collection:1.6.0'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.3.0'
+    implementation 'androidx.drawerlayout:drawerlayout:1.2.0'
     implementation 'net.lingala.zip4j:zip4j:1.3.2'
     implementation 'com.github.daniel-stoneuk:material-about-library:2.2.4'
     implementation 'com.github.apl-devs:appintro:v4.2.3'

--- a/app/src/main/java/com/oriondev/moneywallet/service/TaskReporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/TaskReporter.java
@@ -83,6 +83,8 @@ class TaskReporter {
      */
     void showNotification(int id, NotificationCompat.Builder builder) {
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(mContext);
-        notificationManager.notify(id, builder.build());
+        if (notificationManager.areNotificationsEnabled()) {
+            notificationManager.notify(id, builder.build());
+        }
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MapActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MapActivity.java
@@ -19,16 +19,18 @@
 
 package com.oriondev.moneywallet.ui.activity;
 
-import android.app.LoaderManager;
-import android.content.CursorLoader;
 import android.content.Intent;
-import android.content.Loader;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.loader.app.LoaderManager;
+import androidx.loader.content.CursorLoader;
+import androidx.loader.content.Loader;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Place;
@@ -48,6 +50,7 @@ public class MapActivity extends SinglePanelActivity implements LoaderManager.Lo
     private static final int LOADER_PLACES = 23748;
 
     private MapViewWrapper mMapView;
+    private boolean mPlacesDelivered;
 
     @Override
     protected void onCreatePanelView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
@@ -109,8 +112,9 @@ public class MapActivity extends SinglePanelActivity implements LoaderManager.Lo
         return false;
     }
 
+    @NonNull
     @Override
-    public Loader<Cursor> onCreateLoader(int id, Bundle args) {
+    public Loader<Cursor> onCreateLoader(int id, @Nullable Bundle args) {
         Uri uri = DataContentProvider.CONTENT_PLACES;
         String[] projection = new String[] {
                 Contract.Place.ID,
@@ -125,7 +129,14 @@ public class MapActivity extends SinglePanelActivity implements LoaderManager.Lo
     }
 
     @Override
-    public void onLoadFinished(Loader<Cursor> loader, Cursor cursor) {
+    public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
+        // The framework manager delivered to this screen once. The AndroidX one delivers again
+        // every time the screen is started and after writes elsewhere in the app, and addPlaces
+        // stacks a second overlay on the first and recenters the map.
+        if (mPlacesDelivered) {
+            return;
+        }
+        mPlacesDelivered = true;
         if (cursor != null) {
             if (mMapView.isMapReady() && cursor.moveToFirst()) {
                 List<Place> placeList = new ArrayList<>();
@@ -140,19 +151,18 @@ public class MapActivity extends SinglePanelActivity implements LoaderManager.Lo
                 // display the list of places on map
                 mMapView.addPlaces(placeList);
             }
-            cursor.close();
         }
     }
 
     @Override
-    public void onLoaderReset(Loader<Cursor> loader) {
+    public void onLoaderReset(@NonNull Loader<Cursor> loader) {
         // nothing to release
     }
 
     @Override
     public void onMapReady() {
         mMapView.setOnInfoClickListener(this);
-        getLoaderManager().restartLoader(LOADER_PLACES, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_PLACES, null, this);
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
@@ -80,7 +80,7 @@ public abstract class CursorListFragment extends Fragment implements SwipeRefres
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
     }
 
     @Override
@@ -100,7 +100,7 @@ public abstract class CursorListFragment extends Fragment implements SwipeRefres
 
     @Override
     public void onRefresh() {
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.REFRESHING);
     }
 
@@ -121,7 +121,7 @@ public abstract class CursorListFragment extends Fragment implements SwipeRefres
      */
     public void reloadList() {
         if (mAdvancedRecyclerView != null) {
-            getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+            LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
             mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
         }
     }
@@ -133,7 +133,7 @@ public abstract class CursorListFragment extends Fragment implements SwipeRefres
     @Override
     public void onCurrentWalletChanged(long walletId) {
         if (shouldRefreshOnCurrentWalletChange()) {
-            getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+            LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
             mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
         }
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelCursorListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelCursorListFragment.java
@@ -54,7 +54,7 @@ public abstract class MultiPanelCursorListFragment extends MultiPanelFragment im
         mAbstractCursorAdapter = onCreateAdapter();
         mAdvancedRecyclerView.setAdapter(mAbstractCursorAdapter);
         mAdvancedRecyclerView.setOnRefreshListener(this);
-        getLoaderManager().initLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).initLoader(DEFAULT_LOADER_ID, null, this);
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
     }
 
@@ -89,12 +89,12 @@ public abstract class MultiPanelCursorListFragment extends MultiPanelFragment im
 
     @Override
     public void onRefresh() {
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.REFRESHING);
     }
 
     protected void recreateLoader() {
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
@@ -284,30 +284,30 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
         if (walletId == PreferenceManager.TOTAL_WALLET_ID) {
             // synthetic, there is no row to load
             mPrimaryToolbar.setSubtitle(R.string.total_wallet_name);
-            getLoaderManager().destroyLoader(CURRENT_WALLET_LOADER_ID);
+            LoaderManager.getInstance(this).destroyLoader(CURRENT_WALLET_LOADER_ID);
         } else if (walletId == PreferenceManager.NO_CURRENT_WALLET) {
             mPrimaryToolbar.setSubtitle(null);
-            getLoaderManager().destroyLoader(CURRENT_WALLET_LOADER_ID);
+            LoaderManager.getInstance(this).destroyLoader(CURRENT_WALLET_LOADER_ID);
         } else if (reload) {
             // clear first: the load is asynchronous, and until it lands the old name would be
             // naming the wrong wallet rather than merely being out of date
             mPrimaryToolbar.setSubtitle(null);
             // a loader rather than a direct query: resolving a wallet row runs a balance
             // aggregate over the transactions table, and it redelivers when the row is renamed
-            getLoaderManager().restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+            LoaderManager.getInstance(this).restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
         } else if (isLoaderBuiltForAnotherWallet(walletId)) {
             // a retained loader outlives this fragment instance, so init would redeliver the row
             // it already holds, which belongs to a wallet that is no longer the selected one.
             // No clear needed before the reload, unlike the branch above: this path only runs
             // while the toolbar is freshly inflated, so there is no old name on it yet
-            getLoaderManager().restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+            LoaderManager.getInstance(this).restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
         } else {
-            getLoaderManager().initLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+            LoaderManager.getInstance(this).initLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
         }
     }
 
     private boolean isLoaderBuiltForAnotherWallet(long walletId) {
-        Loader<Cursor> loader = getLoaderManager().getLoader(CURRENT_WALLET_LOADER_ID);
+        Loader<Cursor> loader = LoaderManager.getInstance(this).getLoader(CURRENT_WALLET_LOADER_ID);
         if (loader instanceof CursorLoader) {
             return ContentUris.parseId(((CursorLoader) loader).getUri()) != walletId;
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SinglePanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SinglePanelFragment.java
@@ -202,30 +202,30 @@ public abstract class SinglePanelFragment extends Fragment implements Toolbar.On
         if (walletId == PreferenceManager.TOTAL_WALLET_ID) {
             // synthetic, there is no row to load
             mToolbar.setSubtitle(R.string.total_wallet_name);
-            getLoaderManager().destroyLoader(CURRENT_WALLET_LOADER_ID);
+            LoaderManager.getInstance(this).destroyLoader(CURRENT_WALLET_LOADER_ID);
         } else if (walletId == PreferenceManager.NO_CURRENT_WALLET) {
             mToolbar.setSubtitle(null);
-            getLoaderManager().destroyLoader(CURRENT_WALLET_LOADER_ID);
+            LoaderManager.getInstance(this).destroyLoader(CURRENT_WALLET_LOADER_ID);
         } else if (reload) {
             // clear first: the load is asynchronous, and until it lands the old name would be
             // naming the wrong wallet rather than merely being out of date
             mToolbar.setSubtitle(null);
             // a loader rather than a direct query: resolving a wallet row runs a balance
             // aggregate over the transactions table, and it redelivers when the row is renamed
-            getLoaderManager().restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+            LoaderManager.getInstance(this).restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
         } else if (isLoaderBuiltForAnotherWallet(walletId)) {
             // a retained loader outlives this fragment instance, so init would redeliver the row
             // it already holds, which belongs to a wallet that is no longer the selected one.
             // No clear needed before the reload, unlike the branch above: this path only runs
             // while the toolbar is freshly inflated, so there is no old name on it yet
-            getLoaderManager().restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+            LoaderManager.getInstance(this).restartLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
         } else {
-            getLoaderManager().initLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
+            LoaderManager.getInstance(this).initLoader(CURRENT_WALLET_LOADER_ID, null, mCurrentWalletCallbacks);
         }
     }
 
     private boolean isLoaderBuiltForAnotherWallet(long walletId) {
-        Loader<Cursor> loader = getLoaderManager().getLoader(CURRENT_WALLET_LOADER_ID);
+        Loader<Cursor> loader = LoaderManager.getInstance(this).getLoader(CURRENT_WALLET_LOADER_ID);
         if (loader instanceof CursorLoader) {
             return ContentUris.parseId(((CursorLoader) loader).getUri()) != walletId;
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ChangeLogDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ChangeLogDialog.java
@@ -69,7 +69,7 @@ public class ChangeLogDialog extends DialogFragment implements LoaderManager.Loa
                 .title(R.string.dialog_change_log_title)
                 .positiveText(android.R.string.ok)
                 .adapter(mAdapter, new LinearLayoutManager(activity));
-        getLoaderManager().restartLoader(LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_ID, null, this);
         return builder.build();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/EventPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/EventPickerDialog.java
@@ -109,7 +109,7 @@ public class EventPickerDialog extends DialogFragment implements EventSelectorCu
         }
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         return dialog;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/LicenseDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/LicenseDialog.java
@@ -72,7 +72,7 @@ public class LicenseDialog extends DialogFragment implements LoaderManager.Loade
                 .title(R.string.title_licenses)
                 .adapter(mAdapter, new LinearLayoutManager(activity))
                 .positiveText(android.R.string.ok);
-        getLoaderManager().restartLoader(LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_ID, null, this);
         return builder.build();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/MultiCategoryPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/MultiCategoryPickerDialog.java
@@ -119,7 +119,7 @@ public class MultiCategoryPickerDialog extends DialogFragment implements ParentC
         }
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         return dialog;
     }
 
@@ -225,7 +225,7 @@ public class MultiCategoryPickerDialog extends DialogFragment implements ParentC
         if (before != selectedType()) {
             // the first choice narrows the list to that direction, and dropping the last opens it
             // back up, so the rows on offer have to be asked for again
-            getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+            LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         } else {
             mCursorAdapter.notifyDataSetChanged();
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ParentCategoryPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ParentCategoryPickerDialog.java
@@ -109,7 +109,7 @@ public class ParentCategoryPickerDialog extends DialogFragment implements Parent
         }
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         return dialog;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/PeoplePickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/PeoplePickerDialog.java
@@ -125,7 +125,7 @@ public class PeoplePickerDialog extends DialogFragment implements PeopleSelector
         }
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         return dialog;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/PlacePickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/PlacePickerDialog.java
@@ -103,7 +103,7 @@ public class PlacePickerDialog extends DialogFragment implements PlaceSelectorCu
         }
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         return dialog;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/WalletPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/WalletPickerDialog.java
@@ -141,7 +141,7 @@ public class WalletPickerDialog extends DialogFragment implements LoaderManager.
         }
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);
         return dialog;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
@@ -136,7 +136,7 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
         mTimelineView.setSelectedDate(year, month, day);
         mTimelineView.setOnDateSelectedListener(this);
         onDateSelected(year, month, day, mTimelineView.getSelectedPosition());
-        getLoaderManager().initLoader(MARKED_DAYS_LOADER_ID, null, mMarkedDaysCallbacks);
+        LoaderManager.getInstance(this).initLoader(MARKED_DAYS_LOADER_ID, null, mMarkedDaysCallbacks);
     }
 
     /**
@@ -366,7 +366,7 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
         arguments.putInt(ARG_SELECTED_YEAR, year);
         arguments.putInt(ARG_SELECTED_MONTH, month);
         arguments.putInt(ARG_SELECTED_DAY, day);
-        getLoaderManager().restartLoader(DEFAULT_LOADER_ID, arguments, this);
+        LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, arguments, this);
     }
 
     /**
@@ -375,6 +375,6 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
      * because the cursor is watching the transactions it came from.
      */
     private void loadMarkedDays() {
-        getLoaderManager().restartLoader(MARKED_DAYS_LOADER_ID, null, mMarkedDaysCallbacks);
+        LoaderManager.getInstance(this).restartLoader(MARKED_DAYS_LOADER_ID, null, mMarkedDaysCallbacks);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/TransactionMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/TransactionMultiPanelFragment.java
@@ -236,9 +236,9 @@ public class TransactionMultiPanelFragment extends MultiPanelCursorListItemFragm
         }
         super.onLoadFinished(loader, cursor);
         if (empty) {
-            getLoaderManager().restartLoader(HIDDEN_TRANSACTIONS_LOADER_ID, null, mHiddenTransactionsCallbacks);
+            LoaderManager.getInstance(this).restartLoader(HIDDEN_TRANSACTIONS_LOADER_ID, null, mHiddenTransactionsCallbacks);
         } else {
-            getLoaderManager().destroyLoader(HIDDEN_TRANSACTIONS_LOADER_ID);
+            LoaderManager.getInstance(this).destroyLoader(HIDDEN_TRANSACTIONS_LOADER_ID);
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/WalletMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/WalletMultiPanelFragment.java
@@ -86,7 +86,7 @@ public class WalletMultiPanelFragment extends MultiPanelAppBarItemFragment imple
         mAdvancedRecyclerView.setEmptyText(R.string.message_no_wallet_found);
         mAdvancedRecyclerView.setOnRefreshListener(this);
         // attach a background loader to retrieve data from the content provider
-        getLoaderManager().initLoader(LOADER_ID, null, this);
+        LoaderManager.getInstance(this).initLoader(LOADER_ID, null, this);
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
     }
 
@@ -183,7 +183,7 @@ public class WalletMultiPanelFragment extends MultiPanelAppBarItemFragment imple
 
     @Override
     public void onRefresh() {
-        getLoaderManager().restartLoader(LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_ID, null, this);
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.REFRESHING);
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransactionListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransactionListFragment.java
@@ -119,9 +119,9 @@ public class TransactionListFragment extends CursorListFragment implements Trans
         }
         super.onLoadFinished(loader, cursor);
         if (empty) {
-            getLoaderManager().restartLoader(HIDDEN_TRANSACTIONS_LOADER_ID, null, mHiddenTransactionsCallbacks);
+            LoaderManager.getInstance(this).restartLoader(HIDDEN_TRANSACTIONS_LOADER_ID, null, mHiddenTransactionsCallbacks);
         } else {
-            getLoaderManager().destroyLoader(HIDDEN_TRANSACTIONS_LOADER_ID);
+            LoaderManager.getInstance(this).destroyLoader(HIDDEN_TRANSACTIONS_LOADER_ID);
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransferListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransferListFragment.java
@@ -125,9 +125,9 @@ public class TransferListFragment extends CursorListFragment implements Transfer
         }
         super.onLoadFinished(loader, cursor);
         if (empty) {
-            getLoaderManager().restartLoader(HIDDEN_TRANSFERS_LOADER_ID, null, mHiddenTransfersCallbacks);
+            LoaderManager.getInstance(this).restartLoader(HIDDEN_TRANSFERS_LOADER_ID, null, mHiddenTransfersCallbacks);
         } else {
-            getLoaderManager().destroyLoader(HIDDEN_TRANSFERS_LOADER_ID);
+            LoaderManager.getInstance(this).destroyLoader(HIDDEN_TRANSFERS_LOADER_ID);
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BudgetItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BudgetItemFragment.java
@@ -156,8 +156,8 @@ public class BudgetItemFragment extends SecondaryPanelFragment implements Loader
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(BUDGET_LOADER_ID, null, this);
-        getLoaderManager().restartLoader(WALLETS_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(BUDGET_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(WALLETS_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/CategoryItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/CategoryItemFragment.java
@@ -170,7 +170,7 @@ public class CategoryItemFragment extends SecondaryPanelFragment implements Load
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(CATEGORY_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(CATEGORY_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/DebtItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/DebtItemFragment.java
@@ -221,8 +221,8 @@ public class DebtItemFragment extends SecondaryPanelFragment implements LoaderMa
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(DEBT_LOADER_ID, null, this);
-        getLoaderManager().restartLoader(PEOPLE_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(DEBT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(PEOPLE_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/EventItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/EventItemFragment.java
@@ -143,7 +143,7 @@ public class EventItemFragment extends SecondaryPanelFragment implements LoaderM
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(EVENT_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(EVENT_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PersonItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PersonItemFragment.java
@@ -143,7 +143,7 @@ public class PersonItemFragment extends SecondaryPanelFragment implements Loader
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(PERSON_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(PERSON_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PlaceItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PlaceItemFragment.java
@@ -216,7 +216,7 @@ public class PlaceItemFragment extends SecondaryPanelFragment implements LoaderM
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(PLACE_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(PLACE_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransactionItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransactionItemFragment.java
@@ -160,7 +160,7 @@ public class RecurrentTransactionItemFragment extends SecondaryPanelFragment imp
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(RECURRENT_TRANSACTION_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(RECURRENT_TRANSACTION_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransferItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransferItemFragment.java
@@ -162,7 +162,7 @@ public class RecurrentTransferItemFragment extends SecondaryPanelFragment implem
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(RECURRENT_TRANSFER_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(RECURRENT_TRANSFER_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/SavingItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/SavingItemFragment.java
@@ -214,7 +214,7 @@ public class SavingItemFragment extends SecondaryPanelFragment implements Loader
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(SAVING_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(SAVING_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragment.java
@@ -184,9 +184,9 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(TRANSACTION_LOADER_ID, null, this);
-        getLoaderManager().restartLoader(PEOPLE_LOADER_ID, null, this);
-        getLoaderManager().restartLoader(ATTACHMENTS_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(TRANSACTION_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(PEOPLE_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(ATTACHMENTS_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionModelItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionModelItemFragment.java
@@ -150,7 +150,7 @@ public class TransactionModelItemFragment extends SecondaryPanelFragment impleme
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(TRANSACTION_MODEL_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(TRANSACTION_MODEL_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferItemFragment.java
@@ -170,9 +170,9 @@ public class TransferItemFragment extends SecondaryPanelFragment implements Atta
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(TRANSFER_LOADER_ID, null, this);
-        getLoaderManager().restartLoader(PEOPLE_LOADER_ID, null, this);
-        getLoaderManager().restartLoader(ATTACHMENTS_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(TRANSFER_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(PEOPLE_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(ATTACHMENTS_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferModelItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferModelItemFragment.java
@@ -152,7 +152,7 @@ public class TransferModelItemFragment extends SecondaryPanelFragment implements
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(TRANSFER_MODEL_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(TRANSFER_MODEL_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/WalletItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/WalletItemFragment.java
@@ -214,7 +214,7 @@ public class WalletItemFragment extends SecondaryPanelFragment implements Loader
     @Override
     protected void onShowItemId(long itemId) {
         setLoadingScreen(true);
-        getLoaderManager().restartLoader(WALLET_LOADER_ID, null, this);
+        LoaderManager.getInstance(this).restartLoader(WALLET_LOADER_ID, null, this);
     }
 
     private void setLoadingScreen(boolean loading) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/single/PeriodDetailFlowFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/single/PeriodDetailFlowFragment.java
@@ -147,7 +147,7 @@ public class PeriodDetailFlowFragment extends Fragment implements PeriodDetailFl
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         mHeaderLeftTextView.setText(mIncomes ? R.string.hint_incomes : R.string.hint_expenses);
-        getLoaderManager().restartLoader(LOADER_FRAGMENT_DATA, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_FRAGMENT_DATA, null, this);
     }
 
     @Override
@@ -192,6 +192,6 @@ public class PeriodDetailFlowFragment extends Fragment implements PeriodDetailFl
 
     @Override
     public void onCurrentWalletChanged(long walletId) {
-        getLoaderManager().restartLoader(LOADER_FRAGMENT_DATA, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_FRAGMENT_DATA, null, this);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/single/PeriodDetailSummaryFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/single/PeriodDetailSummaryFragment.java
@@ -128,7 +128,7 @@ public class PeriodDetailSummaryFragment extends Fragment implements PeriodDetai
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         mHeaderLeftTextView.setText(R.string.hint_net_incomes);
-        getLoaderManager().restartLoader(LOADER_FRAGMENT_DATA, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_FRAGMENT_DATA, null, this);
     }
 
     @Override
@@ -184,6 +184,6 @@ public class PeriodDetailSummaryFragment extends Fragment implements PeriodDetai
 
     @Override
     public void onCurrentWalletChanged(long walletId) {
-        getLoaderManager().restartLoader(LOADER_FRAGMENT_DATA, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_FRAGMENT_DATA, null, this);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/singlepanel/OverviewSinglePanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/singlepanel/OverviewSinglePanelFragment.java
@@ -124,7 +124,7 @@ public class OverviewSinglePanelFragment extends SinglePanelFragment implements 
 
     @Override
     public void onOverviewSettingChanged(String tag, OverviewSetting overviewSetting) {
-        getLoaderManager().restartLoader(LOADER_OVERVIEW_DATA, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_OVERVIEW_DATA, null, this);
     }
 
     @NonNull
@@ -155,6 +155,6 @@ public class OverviewSinglePanelFragment extends SinglePanelFragment implements 
 
     @Override
     public void onCurrentWalletChanged(long walletId) {
-        getLoaderManager().restartLoader(LOADER_OVERVIEW_DATA, null, this);
+        LoaderManager.getInstance(this).restartLoader(LOADER_OVERVIEW_DATA, null, this);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -41,17 +41,19 @@ allprojects {
 }
 
 ext {
-    versions = [
-            supportLib: "27.1.1"
-    ]
     supportDependencies = [
-            appcompat : 'androidx.appcompat:appcompat:1.0.0',
-            recyclerview : 'androidx.recyclerview:recyclerview:1.0.0',
+            // Held with material. appcompat-resources 1.6.0 replaced the DrawableWrapper that
+            // material 1.0.0's ShadowDrawableWrapper extends. Past 1.5.1 the JVM cannot load
+            // material's floating action button implementation, so Robolectric cannot inflate a
+            // screen that holds one, and a device would load that class the first time a button
+            // asked for useCompatPadding. Both move together.
+            appcompat : 'androidx.appcompat:appcompat:1.5.1',
+            recyclerview : 'androidx.recyclerview:recyclerview:1.4.0',
             cardview: 'androidx.cardview:cardview:1.0.0',
-            annotations : 'androidx.annotation:annotation:1.0.0',
+            annotations : 'androidx.annotation:annotation:1.10.0',
             design : 'com.google.android.material:material:1.0.0',
-            preference: 'androidx.preference:preference:1.0.0',
-            constraintlayout : 'androidx.constraintlayout:constraintlayout:1.1.3'
+            preference: 'androidx.preference:preference:1.2.1',
+            constraintlayout : 'androidx.constraintlayout:constraintlayout:2.2.2'
     ]
     googlePlayServices = [
             auth: "com.google.android.gms:play-services-auth:15.0.1",


### PR DESCRIPTION
The app's Android support libraries had been pinned at their first releases from 2018, two of them on 2020 preview builds. This moves them to current stable versions and moves the build's compile target up one release because they require it. The release the app targets does not change, so no new platform behavior switches on.

Every library the code already used without saying so is now named in the build, so no later bump can quietly take one away.

Two things stay put on purpose. The material components library keeps its old version because the app's theme still descends from the navigation drawer library, and moving both is its own change. The main compatibility library stops short of current, at the last release that still ships a class the old material library builds on. Past that, the desktop test harness cannot open any screen with a floating button, and a device would crash the first time a button asked for compat padding, which nothing does today. Lists inside the pull to refresh wrapper now draw a stretch at their end, except under a toolbar that scrolls away.

The map screen was the one place still on the platform's deprecated loading path and now uses the same one as every other screen, draws its markers once per visit and leaves the data it is handed to the loader that owns it, so a change elsewhere in the app cannot pile a second set of markers on the first or reset where the user had panned.

One shared helper that posts error notifications now checks that notifications are enabled first. The system dropped that post anyway, so nothing changes for users, and a new build check that would otherwise fail is satisfied.

Tested: 330 unit tests and 138 instrumented tests green, no new issues from the build's checks against the unchanged baseline, two clean release builds hash identical, and on an emulator every reachable screen opens, the two pane layout survives rotation, the map keeps its marker and position across a round trip and a change, and the PIN lock works.
