### PR TITLE
Move the navigation drawer to NavigationView and drop the drawer library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -119,17 +119,6 @@ dependencies {
     implementation supportDependencies.preference
     implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
     implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
-    implementation('com.mikepenz:materialdrawer:6.0.8@aar') {
-        transitive = true
-    }
-    // materialdrawer 6.0.8 transitively pulls fastadapter-extensions-expandable:3.2.6, whose POM
-    // references the dead jcenter-only artifacts com.mikepenz:library / :library-core:3.2.6 (the old
-    // Android-Iconics artifact ids, never on mavenCentral). The 3.2.7 fastadapter chain (still
-    // support-lib era, on mavenCentral) dropped those deps, so pinning it removes the unresolved
-    // transitives without bumping materialdrawer itself.
-    implementation 'com.mikepenz:fastadapter:3.2.7'
-    implementation 'com.mikepenz:fastadapter-commons:3.2.7'
-    implementation 'com.mikepenz:fastadapter-extensions-expandable:3.2.7'
     implementation 'com.pnikosis:materialish-progress:1.7'
     // jcenter-orphaned. No 1.6.1 git tag ever existed (Bintray-only publish); rubensousa's repo only
     // has buildable tags up to 1.5.1 on JitPack. kizitonwose/BottomSheetBuilder is a direct fork at

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -13081,7 +13081,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="            floatingActionButton.setVisibility(View.GONE);"
         errorLine2="                                 ~~~~~~~~~~~~~">
         <location
@@ -13092,7 +13092,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="            floatingActionButton.setVisibility(View.GONE);"
         errorLine2="                                               ~~~~~~~~~">
         <location
@@ -13103,7 +13103,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="                mFloatingActionButton.setVisibility(View.GONE);"
         errorLine2="                                      ~~~~~~~~~~~~~">
         <location
@@ -13114,7 +13114,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="                mFloatingActionButton.setVisibility(View.GONE);"
         errorLine2="                                                    ~~~~~~~~~">
         <location
@@ -13125,7 +13125,7 @@
 
     <issue
         id="RestrictedApi"
-        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="        return dependency instanceof AppBarLayout || dependency instanceof Snackbar.SnackbarLayout;"
         errorLine2="                                                                           ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -13136,7 +13136,7 @@
 
     <issue
         id="RestrictedApi"
-        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="        } else if (dependency instanceof Snackbar.SnackbarLayout) {"
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -13147,7 +13147,7 @@
 
     <issue
         id="RestrictedApi"
-        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="            if (view instanceof Snackbar.SnackbarLayout &amp;&amp; parent.doViewsOverlap(fab, view)) {"
         errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -13158,7 +13158,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="                floatingActionButton.setVisibility(View.GONE);"
         errorLine2="                                     ~~~~~~~~~~~~~">
         <location
@@ -13169,7 +13169,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="                floatingActionButton.setVisibility(View.GONE);"
         errorLine2="                                                   ~~~~~~~~~">
         <location
@@ -13180,7 +13180,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="                floatingActionButton.setVisibility(View.GONE);"
         errorLine2="                                     ~~~~~~~~~~~~~">
         <location
@@ -13191,7 +13191,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix9`)"
+        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
         errorLine1="                floatingActionButton.setVisibility(View.GONE);"
         errorLine2="                                                   ~~~~~~~~~">
         <location
@@ -19693,17 +19693,6 @@
     <issue
         id="NotifyDataSetChanged"
         message="It will always be more efficient to use more specific change events if you can. Rely on `notifyDataSetChanged` as a last resort."
-        errorLine1="        recyclerView.getAdapter().notifyDataSetChanged();"
-        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java"
-            line="654"
-            column="9"/>
-    </issue>
-
-    <issue
-        id="NotifyDataSetChanged"
-        message="It will always be more efficient to use more specific change events if you can. Rely on `notifyDataSetChanged` as a last resort."
         errorLine1="            adapter.notifyDataSetChanged();"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -19895,7 +19884,7 @@
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/res/values/descriptions.xml"
-            line="34"
+            line="36"
             column="13"/>
     </issue>
 

--- a/app/src/main/assets/resources/libraries_base.json
+++ b/app/src/main/assets/resources/libraries_base.json
@@ -7,13 +7,6 @@
     "copyright":"Copyright (c) 2014-2016 Aidan Michael Follestad",
     "license":"MIT"
   },{
-    "name":"MaterialDrawer",
-    "author":"mikepenz",
-    "website":"https://github.com/mikepenz/MaterialDrawer",
-    "version":"6.0.8",
-    "copyright":"Copyright 2018 Mike Penz",
-    "license":"APACHE"
-  },{
     "name":"Material-ish Progress",
     "author":"pnikosis",
     "website":"https://github.com/pnikosis/materialish-progress",

--- a/app/src/main/java/com/oriondev/moneywallet/model/WalletAccount.java
+++ b/app/src/main/java/com/oriondev/moneywallet/model/WalletAccount.java
@@ -19,112 +19,41 @@
 
 package com.oriondev.moneywallet.model;
 
-import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.drawable.Drawable;
-import android.net.Uri;
-import androidx.annotation.DrawableRes;
+import androidx.annotation.NonNull;
 
-import com.mikepenz.iconics.typeface.IIcon;
-import com.mikepenz.materialdrawer.holder.StringHolder;
-import com.mikepenz.materialdrawer.model.ProfileDrawerItem;
 import com.oriondev.moneywallet.utils.IconLoader;
-import com.oriondev.moneywallet.utils.MoneyFormatter;
 
 /**
- * Created by andrea on 23/01/18.
+ * One entry of the wallet switcher in the navigation drawer: a wallet, or the total of them.
  */
-public class WalletAccount extends ProfileDrawerItem {
+public class WalletAccount {
 
-    private MoneyFormatter mMoneyFormatter = MoneyFormatter.getInstance();
+    private final long mId;
+    private final String mName;
+    private final Icon mIcon;
+    private final Money mMoney;
 
-    private long mId;
-    private Money mMoney;
-
-    @Override
-    public WalletAccount withIdentifier(long identifier) {
-        super.withIdentifier(identifier);
-        return this;
-    }
-
-    @Override
-    public WalletAccount withName(String name) {
-        super.withName(name);
-        return this;
-    }
-
-    @Override
-    public WalletAccount withEmail(String email) {
-        throw new IllegalStateException("Email field is not supported in WalletAccount.");
-    }
-
-    @Override
-    public StringHolder getEmail() {
-        return new StringHolder(mMoneyFormatter.getNotTintedString(mMoney));
-    }
-
-    public WalletAccount withIcon(Context context, Icon icon) {
-        Icon safeIcon = icon != null ? icon : IconLoader.UNKNOWN;
-        if (safeIcon instanceof VectorIcon) {
-            super.withIcon(((VectorIcon) safeIcon).getResource(context));
-        } else if (safeIcon instanceof ColorIcon) {
-            super.withIcon(((ColorIcon) safeIcon).getDrawable());
-        }
-        return this;
-    }
-
-    @Override
-    public WalletAccount withIcon(Drawable icon) {
-        super.withIcon(icon);
-        return this;
-    }
-
-    @Override
-    public WalletAccount withIcon(@DrawableRes int iconRes) {
-        super.withIcon(iconRes);
-        return this;
-    }
-
-    @Override
-    public WalletAccount withIcon(Bitmap iconBitmap) {
-        super.withIcon(iconBitmap);
-        return this;
-    }
-
-    @Override
-    public WalletAccount withIcon(IIcon icon) {
-        super.withIcon(icon);
-        return this;
-    }
-
-    @Override
-    public WalletAccount withIcon(String url) {
-        super.withIcon(url);
-        return this;
-    }
-
-    @Override
-    public WalletAccount withIcon(Uri uri) {
-        super.withIcon(uri);
-        return this;
-    }
-
-    public WalletAccount withId(long id) {
+    public WalletAccount(long id, String name, Icon icon, Money money) {
         mId = id;
-        return this;
+        mName = name;
+        mIcon = icon != null ? icon : IconLoader.UNKNOWN;
+        mMoney = money;
     }
 
     public long getId() {
         return mId;
     }
 
-    public WalletAccount withMoney(String currency, long money) {
-        mMoney = new Money(currency, money);
-        return this;
+    public String getName() {
+        return mName;
     }
 
-    public WalletAccount withMoney(Money money) {
-        mMoney = money;
-        return this;
+    @NonNull
+    public Icon getIcon() {
+        return mIcon;
+    }
+
+    public Money getMoney() {
+        return mMoney;
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
@@ -24,14 +24,24 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.res.ColorStateList;
 import android.database.Cursor;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.StateListDrawable;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.appcompat.app.ActionBarDrawerToggle;
+import androidx.core.graphics.ColorUtils;
+import androidx.core.graphics.drawable.DrawableCompat;
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.loader.app.LoaderManager;
@@ -40,21 +50,15 @@ import androidx.loader.content.Loader;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.appcompat.widget.Toolbar;
+import android.view.Gravity;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.mikepenz.materialdrawer.AccountHeader;
-import com.mikepenz.materialdrawer.AccountHeaderBuilder;
-import com.mikepenz.materialdrawer.Drawer;
-import com.mikepenz.materialdrawer.DrawerBuilder;
-import com.mikepenz.materialdrawer.model.DividerDrawerItem;
-import com.mikepenz.materialdrawer.model.PrimaryDrawerItem;
-import com.mikepenz.materialdrawer.model.ProfileDrawerItem;
-import com.mikepenz.materialdrawer.model.ProfileSettingDrawerItem;
-import com.mikepenz.materialdrawer.model.interfaces.IDrawerItem;
-import com.mikepenz.materialdrawer.model.interfaces.IProfile;
+import com.google.android.material.navigation.NavigationView;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.ColorIcon;
@@ -83,40 +87,67 @@ import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.ui.view.theme.ThemedRecyclerView;
 import com.oriondev.moneywallet.utils.IconLoader;
+import com.oriondev.moneywallet.utils.MoneyFormatter;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
 
-public class MainActivity extends BaseActivity implements DrawerController, AccountHeader.OnAccountHeaderListener, Drawer.OnDrawerItemClickListener, LoaderManager.LoaderCallbacks<Cursor>  {
+public class MainActivity extends BaseActivity implements DrawerController, NavigationView.OnNavigationItemSelectedListener, LoaderManager.LoaderCallbacks<Cursor>  {
 
     private static final String SAVED_SELECTION = "MainActivity::current_selection";
 
     private static final int LOADER_WALLETS = 1;
 
-    private static final int ID_SECTION_TRANSACTIONS = 0;
-    private static final int ID_SECTION_CATEGORIES = 1;
-    private static final int ID_SECTION_OVERVIEW = 2;
-    private static final int ID_SECTION_DEBTS = 3;
-    private static final int ID_SECTION_BUDGETS = 4;
-    private static final int ID_SECTION_SAVINGS = 5;
-    private static final int ID_SECTION_EVENTS = 6;
-    private static final int ID_SECTION_RECURRENCES = 7;
-    private static final int ID_SECTION_MODELS = 8;
-    private static final int ID_SECTION_PLACES = 9;
-    private static final int ID_SECTION_PEOPLE = 10;
-    private static final int ID_SECTION_CALCULATOR = 11;
-    private static final int ID_SECTION_CONVERTER = 12;
-    private static final int ID_SECTION_ATM = 13;
-    private static final int ID_SECTION_BANK = 14;
-    private static final int ID_SECTION_SETTING = 15;
-    private static final int ID_SECTION_ABOUT = 17;
+    // The drawer menu holds the sections in the first three groups and the wallet list in the
+    // last one; the header arrow swaps which of the two is visible.
+    private static final int GROUP_SECTIONS = 1;
+    private static final int GROUP_TOOLS = 2;
+    private static final int GROUP_SETTINGS = 3;
+    private static final int GROUP_WALLETS = 4;
 
-    private final static int ID_ACTION_NEW_WALLET = 1;
-    private final static int ID_ACTION_MANAGE_WALLET = 2;
+    /*package-local*/ static final int ID_SECTION_TRANSACTIONS = 0;
+    /*package-local*/ static final int ID_SECTION_CATEGORIES = 1;
+    /*package-local*/ static final int ID_SECTION_OVERVIEW = 2;
+    /*package-local*/ static final int ID_SECTION_DEBTS = 3;
+    /*package-local*/ static final int ID_SECTION_BUDGETS = 4;
+    /*package-local*/ static final int ID_SECTION_SAVINGS = 5;
+    /*package-local*/ static final int ID_SECTION_EVENTS = 6;
+    /*package-local*/ static final int ID_SECTION_RECURRENCES = 7;
+    /*package-local*/ static final int ID_SECTION_MODELS = 8;
+    /*package-local*/ static final int ID_SECTION_PLACES = 9;
+    /*package-local*/ static final int ID_SECTION_PEOPLE = 10;
+    /*package-local*/ static final int ID_SECTION_CALCULATOR = 11;
+    /*package-local*/ static final int ID_SECTION_CONVERTER = 12;
+    /*package-local*/ static final int ID_SECTION_ATM = 13;
+    /*package-local*/ static final int ID_SECTION_BANK = 14;
+    /*package-local*/ static final int ID_SECTION_SETTING = 15;
+    /*package-local*/ static final int ID_SECTION_ABOUT = 17;
 
-    private AccountHeader mAccountHeader;
-    private Drawer mDrawer;
+    /*package-local*/ static final int ID_ACTION_NEW_WALLET = 18;
+    /*package-local*/ static final int ID_ACTION_MANAGE_WALLET = 19;
+    // Every wallet entry takes this plus the wallet's own id, above every other id, so a lookup
+    // by id can never land on a section, and a row bound before a reload still names its wallet.
+    /*package-local*/ static final int ID_WALLET_FIRST = 100;
 
-    private long mCurrentSelection;
+    private final MoneyFormatter mMoneyFormatter = MoneyFormatter.getInstance();
+    private final List<WalletAccount> mWallets = new ArrayList<>();
+
+    private DrawerLayout mDrawerLayout;
+    private NavigationView mNavigationView;
+    private ActionBarDrawerToggle mDrawerToggle;
+    private View mHeaderView;
+    private ImageView mWalletIconView;
+    private ImageView mFirstWalletView;
+    private ImageView mSecondWalletView;
+    private TextView mWalletNameView;
+    private TextView mWalletMoneyView;
+    private ImageView mWalletListArrowView;
+
+    private WalletAccount mCurrentWallet;
+    private boolean mWalletListShown;
+
+    private int mCurrentSelection;
     private Fragment mCurrentFragment;
 
     private Cursor mCursor;
@@ -133,7 +164,7 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
      * Initialize all the ui elements of the activity.
      */
     private void initializeUi() {
-        setContentView(R.layout.activity_root_container);
+        setContentView(R.layout.activity_main);
         initializeNavigationDrawer();
     }
 
@@ -142,62 +173,75 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
      * setup the account header and the navigation drawer.
      */
     private void initializeNavigationDrawer() {
-        mAccountHeader = new AccountHeaderBuilder()
-                .withActivity(this)
-                .withHeaderBackground(R.color.colorPrimary)
-                .withOnAccountHeaderListener(this)
-                .build();
-        mDrawer = new DrawerBuilder()
-                .withActivity(this)
-                .withAccountHeader(mAccountHeader)
-                .addDrawerItems(
-                        createDrawerItem(ID_SECTION_TRANSACTIONS, R.drawable.ic_shopping_cart_24dp, R.string.menu_transaction),
-                        createDrawerItem(ID_SECTION_CATEGORIES, R.drawable.ic_table_large_24dp, R.string.menu_category),
-                        createDrawerItem(ID_SECTION_OVERVIEW, R.drawable.ic_equalizer_24dp, R.string.menu_overview),
-                        createDrawerItem(ID_SECTION_DEBTS, R.drawable.ic_debt_24dp, R.string.menu_debt),
-                        createDrawerItem(ID_SECTION_BUDGETS, R.drawable.ic_budget_24dp, R.string.menu_budget),
-                        createDrawerItem(ID_SECTION_SAVINGS, R.drawable.ic_saving_24dp, R.string.menu_saving),
-                        createDrawerItem(ID_SECTION_EVENTS, R.drawable.ic_assistant_photo_24dp, R.string.menu_event),
-                        createDrawerItem(ID_SECTION_RECURRENCES, R.drawable.ic_restore_24dp, R.string.menu_recurrences),
-                        createDrawerItem(ID_SECTION_MODELS, R.drawable.ic_bookmark_black_24dp, R.string.menu_models),
-                        createDrawerItem(ID_SECTION_PLACES, R.drawable.ic_place_24dp, R.string.menu_place),
-                        createDrawerItem(ID_SECTION_PEOPLE, R.drawable.ic_people_black_24dp, R.string.menu_people),
-                        new DividerDrawerItem(),
-                        createDrawerItem(ID_SECTION_CALCULATOR, R.drawable.ic_calculator_24dp, R.string.menu_calculator),
-                        createDrawerItem(ID_SECTION_CONVERTER, R.drawable.ic_converter_24dp,R.string.menu_converter),
-                        createDrawerItem(ID_SECTION_ATM, R.drawable.ic_credit_card_24dp, R.string.menu_search_atm),
-                        createDrawerItem(ID_SECTION_BANK, R.drawable.ic_account_balance_24dp, R.string.menu_search_bank),
-                        new DividerDrawerItem(),
-                        createDrawerItem(ID_SECTION_SETTING, R.drawable.ic_settings_24dp, R.string.menu_setting),
-                        createDrawerItem(ID_SECTION_ABOUT, R.drawable.ic_info_outline_24dp, R.string.menu_about)
-                )
-                .withOnDrawerItemClickListener(this)
-                .build();
+        mDrawerLayout = findViewById(R.id.drawer_layout);
+        mNavigationView = findViewById(R.id.navigation_view);
+        mNavigationView.setNavigationItemSelectedListener(this);
+        // the section icons are tinted one by one below, so the wallet icons keep their colors
+        mNavigationView.setItemIconTintList(null);
+        Menu menu = mNavigationView.getMenu();
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_TRANSACTIONS, R.drawable.ic_shopping_cart_24dp, R.string.menu_transaction);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_CATEGORIES, R.drawable.ic_table_large_24dp, R.string.menu_category);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_OVERVIEW, R.drawable.ic_equalizer_24dp, R.string.menu_overview);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_DEBTS, R.drawable.ic_debt_24dp, R.string.menu_debt);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_BUDGETS, R.drawable.ic_budget_24dp, R.string.menu_budget);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_SAVINGS, R.drawable.ic_saving_24dp, R.string.menu_saving);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_EVENTS, R.drawable.ic_assistant_photo_24dp, R.string.menu_event);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_RECURRENCES, R.drawable.ic_restore_24dp, R.string.menu_recurrences);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_MODELS, R.drawable.ic_bookmark_black_24dp, R.string.menu_models);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_PLACES, R.drawable.ic_place_24dp, R.string.menu_place);
+        addEntry(menu, GROUP_SECTIONS, ID_SECTION_PEOPLE, R.drawable.ic_people_black_24dp, R.string.menu_people);
+        menu.setGroupCheckable(GROUP_SECTIONS, true, false);
+        addEntry(menu, GROUP_TOOLS, ID_SECTION_CALCULATOR, R.drawable.ic_calculator_24dp, R.string.menu_calculator);
+        addEntry(menu, GROUP_TOOLS, ID_SECTION_CONVERTER, R.drawable.ic_converter_24dp, R.string.menu_converter);
+        addEntry(menu, GROUP_TOOLS, ID_SECTION_ATM, R.drawable.ic_credit_card_24dp, R.string.menu_search_atm);
+        addEntry(menu, GROUP_TOOLS, ID_SECTION_BANK, R.drawable.ic_account_balance_24dp, R.string.menu_search_bank);
+        addEntry(menu, GROUP_SETTINGS, ID_SECTION_SETTING, R.drawable.ic_settings_24dp, R.string.menu_setting).setCheckable(true);
+        addEntry(menu, GROUP_SETTINGS, ID_SECTION_ABOUT, R.drawable.ic_info_outline_24dp, R.string.menu_about);
+        mHeaderView = mNavigationView.getHeaderView(0);
+        mHeaderView.setOnClickListener(view -> showWalletList(!mWalletListShown));
+        mWalletIconView = mHeaderView.findViewById(R.id.wallet_icon_image_view);
+        mFirstWalletView = mHeaderView.findViewById(R.id.first_wallet_image_view);
+        mSecondWalletView = mHeaderView.findViewById(R.id.second_wallet_image_view);
+        mWalletNameView = mHeaderView.findViewById(R.id.wallet_name_text_view);
+        mWalletMoneyView = mHeaderView.findViewById(R.id.wallet_money_text_view);
+        mWalletListArrowView = mHeaderView.findViewById(R.id.wallet_list_arrow_image_view);
+        View.OnClickListener quickSwitch = view -> switchWallet((WalletAccount) view.getTag(view.getId()));
+        mFirstWalletView.setOnClickListener(quickSwitch);
+        mSecondWalletView.setOnClickListener(quickSwitch);
     }
 
     /**
-     * This method is responsible to create a new PrimaryDrawerItem entry for the navigation drawer.
-     * @param identifier integer id of the item.
-     * @param icon drawable resource of the icon of the item.
-     * @param name string resource of the name of the item.
-     * @return the created drawer item.
+     * Add one entry to the navigation drawer, with its icon tinted from the current theme.
+     * @param menu the drawer menu.
+     * @param group of the entry, the drawer draws a divider where the group changes.
+     * @param identifier integer id of the entry.
+     * @param icon drawable resource of the icon of the entry.
+     * @param name string resource of the name of the entry.
+     * @return the created entry.
      */
-    private IDrawerItem createDrawerItem(int identifier, @DrawableRes int icon, @StringRes int name) {
-        return new PrimaryDrawerItem()
-                .withIdentifier(identifier)
-                .withIconTintingEnabled(true)
-                .withIcon(icon)
-                .withName(name);
+    private MenuItem addEntry(Menu menu, int group, int identifier, @DrawableRes int icon, @StringRes int name) {
+        MenuItem item = menu.add(group, identifier, Menu.NONE, name).setIcon(icon);
+        tintEntry(item, ThemeEngine.getTheme());
+        return item;
+    }
+
+    private void tintEntry(MenuItem item, ITheme theme) {
+        Drawable icon = DrawableCompat.wrap(item.getIcon()).mutate();
+        DrawableCompat.setTintList(icon, checkedStates(theme.getDrawerSelectedIconColor(), theme.getDrawerIconColor()));
+        item.setIcon(icon);
+    }
+
+    private static ColorStateList checkedStates(int checkedColor, int color) {
+        return new ColorStateList(new int[][] {{android.R.attr.state_checked}, {}}, new int[] {checkedColor, color});
     }
 
     private void loadUi(Bundle savedInstanceState) {
+        int selection = ID_SECTION_TRANSACTIONS;
         if (savedInstanceState != null) {
-            mCurrentSelection = savedInstanceState.getLong(SAVED_SELECTION);
-        } else {
-            // TODO maybe we can let the user to specify a preference for the first section to load
-            mCurrentSelection = ID_SECTION_TRANSACTIONS;
+            selection = savedInstanceState.getInt(SAVED_SELECTION, ID_SECTION_TRANSACTIONS);
         }
-        mDrawer.setSelection(mCurrentSelection, true);
+        // TODO maybe we can let the user to specify a preference for the first section to load
+        selectSection(selection);
         getSupportLoaderManager().restartLoader(LOADER_WALLETS, null, this);
     }
 
@@ -215,7 +259,7 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
     @Override
     protected void onSaveInstanceState(Bundle savedState) {
         super.onSaveInstanceState(savedState);
-        savedState.putLong(SAVED_SELECTION, mCurrentSelection);
+        savedState.putInt(SAVED_SELECTION, mCurrentSelection);
     }
 
     /**
@@ -224,8 +268,8 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
      */
     @Override
     public void onBackPressed() {
-        if (mDrawer != null && mDrawer.isDrawerOpen()) {
-            mDrawer.closeDrawer();
+        if (mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
+            closeDrawer();
         } else if (mCurrentFragment instanceof NavigableFragment) {
             if (!((NavigableFragment) mCurrentFragment).navigateBack() && !selectTransactionsSection()) {
                 super.onBackPressed();
@@ -239,16 +283,30 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
      * Move back to the transactions section the way a drawer tap does, so the highlighted
      * drawer entry and the fragment on screen cannot drift apart.
      * @return true when the section change has been queued, false when transactions is
-     * already showing or the drawer does not exist yet, in which case the caller should
-     * fall back to the default behavior. The fragment transaction is committed, not run,
-     * so the previous section is still on screen when this returns.
+     * already showing, in which case the caller should fall back to the default behavior.
+     * The fragment transaction is committed, not run, so the previous section is still on
+     * screen when this returns.
      */
     private boolean selectTransactionsSection() {
-        if (mDrawer == null || mCurrentSelection == ID_SECTION_TRANSACTIONS) {
+        if (mCurrentSelection == ID_SECTION_TRANSACTIONS) {
             return false;
         }
-        mDrawer.setSelection(ID_SECTION_TRANSACTIONS, true);
+        selectSection(ID_SECTION_TRANSACTIONS);
         return true;
+    }
+
+    /**
+     * Highlight a section in the drawer and load its fragment.
+     * @param identifier of the section.
+     */
+    private void selectSection(int identifier) {
+        mCurrentSelection = identifier;
+        mNavigationView.setCheckedItem(identifier);
+        loadSection(identifier);
+    }
+
+    private void closeDrawer() {
+        mDrawerLayout.closeDrawer(GravityCompat.START);
     }
 
     @Override
@@ -258,12 +316,19 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
     }
 
     /**
-     * Set toolbar for this activity.
+     * Set toolbar for this activity. Every section brings its own toolbar, so the toggle that
+     * draws the drawer icon on it and opens the drawer from it is rebuilt on each one.
      * @param toolbar to set as main toolbar.
      */
     @Override
     public void setToolbar(Toolbar toolbar) {
-        mDrawer.setToolbar(this, toolbar, true);
+        if (mDrawerToggle != null) {
+            mDrawerLayout.removeDrawerListener(mDrawerToggle);
+        }
+        mDrawerToggle = new ActionBarDrawerToggle(this, mDrawerLayout, toolbar,
+                R.string.description_navigation_drawer_open, R.string.description_navigation_drawer_close);
+        mDrawerLayout.addDrawerListener(mDrawerToggle);
+        mDrawerToggle.syncState();
     }
 
     /**
@@ -272,69 +337,93 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
      */
     @Override
     public void setDrawerLockMode(int lockMode) {
-        mDrawer.getDrawerLayout().setDrawerLockMode(lockMode);
+        mDrawerLayout.setDrawerLockMode(lockMode);
     }
 
     /**
-     * This method is called by the navigation drawer whenever a profile is clicked.
-     * @param view of the clicked profile.
-     * @param profile clicked.
-     * @param current true if is the current profile.
-     * @return always false.
+     * Callback when a drawer entry is tapped, a section, a tool, or one of the wallet list
+     * entries the header shows in their place.
+     * @param item tapped.
+     * @return true if the entry should be highlighted, which is only right for a section.
      */
     @Override
-    public boolean onProfileChanged(View view, IProfile profile, boolean current) {
-        long id = profile.getIdentifier();
-        if (profile instanceof ProfileDrawerItem) {
-            PreferenceManager.setCurrentWallet(this, id);
-        } else if (profile instanceof ProfileSettingDrawerItem) {
-            if (id == ID_ACTION_NEW_WALLET) {
-                Intent intent = new Intent(MainActivity.this, NewEditWalletActivity.class);
-                startActivity(intent);
-            } else if (id == ID_ACTION_MANAGE_WALLET) {
-                Intent intent = new Intent(MainActivity.this, WalletListActivity.class);
-                startActivity(intent);
+    public boolean onNavigationItemSelected(@NonNull MenuItem item) {
+        int identifier = item.getItemId();
+        if (item.getGroupId() == GROUP_WALLETS) {
+            if (identifier == ID_ACTION_NEW_WALLET) {
+                startActivity(new Intent(this, NewEditWalletActivity.class));
+            } else if (identifier == ID_ACTION_MANAGE_WALLET) {
+                startActivity(new Intent(this, WalletListActivity.class));
+            } else {
+                WalletAccount wallet = findWallet(identifier - ID_WALLET_FIRST);
+                if (wallet != null) {
+                    switchWallet(wallet);
+                    return false;
+                }
             }
+            showWalletList(false);
+            closeDrawer();
+            return false;
         }
+        switch (identifier) {
+            case ID_SECTION_CALCULATOR:
+                startActivity(new Intent(this, CalculatorActivity.class));
+                break;
+            case ID_SECTION_CONVERTER:
+                startActivity(new Intent(this, CurrencyConverterActivity.class));
+                break;
+            case ID_SECTION_ATM:
+                showAtmSearchDialog();
+                break;
+            case ID_SECTION_BANK:
+                showBankSearchDialog();
+                break;
+            case ID_SECTION_ABOUT:
+                startActivity(new Intent(this, AboutActivity.class));
+                break;
+            default:
+                selectSection(identifier);
+                closeDrawer();
+                return true;
+        }
+        closeDrawer();
         return false;
     }
 
     /**
-     * Callback when a drawer item is clicked.
-     * @param view of the drawer item.
-     * @param position of the drawer item.
-     * @param drawerItem clicked.
-     * @return true if the event was consumed.
+     * Make a wallet the current one: the header shows it, the preference that every screen
+     * filters by is written, and the drawer goes back to the sections and closes.
+     * @param wallet to switch to.
      */
-    @Override
-    public boolean onItemClick(View view, int position, IDrawerItem drawerItem) {
-        if (drawerItem instanceof PrimaryDrawerItem) {
-            int identifier = (int) drawerItem.getIdentifier();
-            switch (identifier) {
-                case ID_SECTION_CALCULATOR:
-                    startActivity(new Intent(this, CalculatorActivity.class));
-                    break;
-                case ID_SECTION_CONVERTER:
-                    startActivity(new Intent(this, CurrencyConverterActivity.class));
-                    break;
-                case ID_SECTION_ATM:
-                    showAtmSearchDialog();
-                    break;
-                case ID_SECTION_BANK:
-                    showBankSearchDialog();
-                    break;
-                case ID_SECTION_ABOUT:
-                    startActivity(new Intent(this, AboutActivity.class));
-                    break;
-                default:
-                    mCurrentSelection = identifier;
-                    loadSection(identifier);
-                    return false;
+    private void switchWallet(WalletAccount wallet) {
+        mCurrentWallet = wallet;
+        PreferenceManager.setCurrentWallet(this, wallet.getId());
+        bindHeader();
+        buildWalletMenu();
+        showWalletList(false);
+        closeDrawer();
+    }
+
+    /**
+     * Swap the sections for the wallet list, or back. The highlighted entry follows: the
+     * current wallet while the list is shown, the current section otherwise.
+     * @param show true for the wallet list.
+     */
+    private void showWalletList(boolean show) {
+        mWalletListShown = show;
+        Menu menu = mNavigationView.getMenu();
+        menu.setGroupVisible(GROUP_SECTIONS, !show);
+        menu.setGroupVisible(GROUP_TOOLS, !show);
+        menu.setGroupVisible(GROUP_SETTINGS, !show);
+        menu.setGroupVisible(GROUP_WALLETS, show);
+        if (show) {
+            if (mCurrentWallet != null) {
+                mNavigationView.setCheckedItem(walletItemId(mCurrentWallet));
             }
+        } else {
+            mNavigationView.setCheckedItem(mCurrentSelection);
         }
-        mDrawer.closeDrawer();
-        mDrawer.setSelection(mCurrentSelection, false);
-        return true;
+        mWalletListArrowView.animate().rotation(show ? 180 : 0).start();
     }
 
     private void showAtmSearchDialog() {
@@ -473,121 +562,125 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
     @Override
     public void onLoadFinished(@NonNull Loader<Cursor> loader, Cursor cursor) {
         mCursor = cursor;
-        mAccountHeader.clear();
-        ITheme theme = ThemeEngine.getTheme();
-        // applyNavigationDrawerBodyTheme runs against an empty profile list before the wallets
-        // load, and again on a theme change after they have, so the two write the same profiles
-        // in either order and have to agree on where the colors come from.
-        int iconColor = theme.getDrawerIconColor();
-        int textColor = theme.getDrawerTextColor();
-        int selectedTextColor = theme.getDrawerSelectedTextColor();
-        int selectedColor = theme.getDrawerSelectedItemColor();
-        if (mCursor != null) {
-            int indexWalletId = mCursor.getColumnIndex(Contract.Wallet.ID);
-            int indexWalletName = mCursor.getColumnIndex(Contract.Wallet.NAME);
-            int indexWalletIcon = mCursor.getColumnIndex(Contract.Wallet.ICON);
-            int indexCurrency = mCursor.getColumnIndex(Contract.Wallet.CURRENCY);
-            int indexWalletInitial = mCursor.getColumnIndex(Contract.Wallet.START_MONEY);
-            int indexWalletTotal = mCursor.getColumnIndex(Contract.Wallet.TOTAL_MONEY);
-            int indexWalletArchived = mCursor.getColumnIndex(Contract.Wallet.ARCHIVED);
-            for (int i = 0, c = 0; i < mCursor.getCount(); i++) {
-                mCursor.moveToPosition(i);
+        mWallets.clear();
+        Money total = new Money();
+        if (cursor != null) {
+            int indexWalletId = cursor.getColumnIndex(Contract.Wallet.ID);
+            int indexWalletName = cursor.getColumnIndex(Contract.Wallet.NAME);
+            int indexWalletIcon = cursor.getColumnIndex(Contract.Wallet.ICON);
+            int indexCurrency = cursor.getColumnIndex(Contract.Wallet.CURRENCY);
+            int indexWalletInitial = cursor.getColumnIndex(Contract.Wallet.START_MONEY);
+            int indexWalletTotal = cursor.getColumnIndex(Contract.Wallet.TOTAL_MONEY);
+            int indexWalletArchived = cursor.getColumnIndex(Contract.Wallet.ARCHIVED);
+            int indexInTotal = cursor.getColumnIndex(Contract.Wallet.COUNT_IN_TOTAL);
+            for (int i = 0; i < cursor.getCount(); i++) {
+                cursor.moveToPosition(i);
+                String currency = cursor.getString(indexCurrency);
+                long money = cursor.getLong(indexWalletInitial) + cursor.getLong(indexWalletTotal);
                 if (cursor.getInt(indexWalletArchived) == 0) {
-                    String currency = cursor.getString(indexCurrency);
-                    long money = cursor.getLong(indexWalletInitial) + cursor.getLong(indexWalletTotal);
-                    mAccountHeader.addProfile(new WalletAccount()
-                                    .withIdentifier(cursor.getLong(indexWalletId))
-                                    .withName(cursor.getString(indexWalletName))
-                                    .withIcon(this, IconLoader.parse(cursor.getString(indexWalletIcon)))
-                                    .withMoney(currency, money)
-                                    .withNameShown(true)
-                                    .withTextColor(textColor)
-                                    .withSelectedTextColor(selectedTextColor)
-                                    .withSelectedColor(selectedColor)
-                            , c);
-                    c += 1;
+                    mWallets.add(new WalletAccount(
+                            cursor.getLong(indexWalletId),
+                            cursor.getString(indexWalletName),
+                            IconLoader.parse(cursor.getString(indexWalletIcon)),
+                            new Money(currency, money)
+                    ));
+                }
+                // an archived wallet stays out of the list but still counts toward the total
+                if (cursor.getInt(indexInTotal) == 1) {
+                    total.addMoney(currency, money);
                 }
             }
         }
-        if (mAccountHeader.getProfiles().size() > 0) {
-            mAccountHeader.setSelectionFirstLine(null);
-            mAccountHeader.setSelectionSecondLine(null);
-            ProfileDrawerItem totalAccount = createTotalWalletAccount(mCursor);
-            if (totalAccount != null) {
-                totalAccount.withTextColor(textColor);
-                totalAccount.withSelectedTextColor(selectedTextColor);
-                totalAccount.withSelectedColor(selectedColor);
-                mAccountHeader.addProfiles(totalAccount);
-            }
-            long currentWalletId = PreferenceManager.getCurrentWallet();
-            if (currentWalletId == PreferenceManager.NO_CURRENT_WALLET) {
-                // if no wallet is set as current wallet, let the drawer to select the first
-                // wallet found and then fire the onProfileChanged callback that will automatically
-                // register the id inside the PreferenceManager and notify the changed to all the
-                // observer registered at that uri.
-                IProfile profile = mAccountHeader.getProfiles().get(0);
-                mAccountHeader.setActiveProfile(profile, true);
-            } else {
-                mAccountHeader.setActiveProfile(currentWalletId);
-            }
-        } else {
-            mAccountHeader.setSelectionFirstLine(getString(R.string.msg_no_wallet_found));
-            mAccountHeader.setSelectionSecondLine(getString(R.string.msg_add_one_wallet));
+        if (!mWallets.isEmpty() && total.getNumberOfCurrencies() > 0) {
+            String name = getString(R.string.total_wallet_name);
+            mWallets.add(new WalletAccount(PreferenceManager.TOTAL_WALLET_ID, name, new ColorIcon("#000000", name.substring(0, 1)), total));
         }
-        mAccountHeader.addProfiles(
-                new ProfileSettingDrawerItem()
-                        .withIdentifier(ID_ACTION_NEW_WALLET)
-                        .withIcon(R.drawable.ic_add_24dp)
-                        .withName(getString(R.string.action_new_wallet))
-                        .withIconTinted(true)
-                        .withIconColor(iconColor)
-                        .withTextColor(textColor)
-                        .withSelectedColor(selectedColor),
-                new ProfileSettingDrawerItem()
-                        .withIdentifier(ID_ACTION_MANAGE_WALLET)
-                        .withIcon(R.drawable.ic_settings_24dp)
-                        .withName(getString(R.string.action_manage_wallets))
-                        .withIconTinted(true)
-                        .withIconColor(iconColor)
-                        .withTextColor(textColor)
-                        .withSelectedColor(selectedColor)
-        );
+        long currentWalletId = PreferenceManager.getCurrentWallet();
+        mCurrentWallet = findWallet(currentWalletId);
+        if (mCurrentWallet == null && !mWallets.isEmpty()) {
+            // the header falls back to the first wallet. Only when no wallet has ever been chosen
+            // is that choice written as the current one, which also broadcasts the change
+            mCurrentWallet = mWallets.get(0);
+            if (currentWalletId == PreferenceManager.NO_CURRENT_WALLET) {
+                PreferenceManager.setCurrentWallet(this, mCurrentWallet.getId());
+            }
+        }
+        buildWalletMenu();
+        bindHeader();
     }
 
-    /**
-     * Create a total wallet profile from returned cursor.
-     * @param cursor not null that contains all available wallets.
-     * @return the total wallet profile if it can be created, null otherwise.
-     */
-    private ProfileDrawerItem createTotalWalletAccount(@NonNull Cursor cursor) {
-        Money money = new Money();
-        int indexCurrency = mCursor.getColumnIndex(Contract.Wallet.CURRENCY);
-        int indexInTotal = mCursor.getColumnIndex(Contract.Wallet.COUNT_IN_TOTAL);
-        int indexWalletInitial = mCursor.getColumnIndex(Contract.Wallet.START_MONEY);
-        int indexWalletTotal = mCursor.getColumnIndex(Contract.Wallet.TOTAL_MONEY);
-        for (int i = 0; i < cursor.getCount(); i++) {
-            cursor.moveToPosition(i);
-            if (cursor.getInt(indexInTotal) == 1) {
-                String currency = cursor.getString(indexCurrency);
-                long amount = cursor.getLong(indexWalletInitial) + cursor.getLong(indexWalletTotal);
-                money.addMoney(currency, amount);
+    private WalletAccount findWallet(long id) {
+        for (WalletAccount wallet : mWallets) {
+            if (wallet.getId() == id) {
+                return wallet;
             }
-        }
-        if (money.getNumberOfCurrencies() > 0) {
-            String name = getString(R.string.total_wallet_name);
-            return new WalletAccount()
-                    .withIdentifier(PreferenceManager.TOTAL_WALLET_ID)
-                    .withName(name)
-                    .withIcon(this, new ColorIcon("#000000", name.substring(0, 1)))
-                    .withMoney(money)
-                    .withNameShown(true);
         }
         return null;
     }
 
+    /**
+     * Rebuild the wallet group of the drawer menu from the wallet list: one entry per wallet
+     * with its balance at the end of the row, then the two wallet actions.
+     */
+    private void buildWalletMenu() {
+        ITheme theme = ThemeEngine.getTheme();
+        Menu menu = mNavigationView.getMenu();
+        menu.removeGroup(GROUP_WALLETS);
+        for (WalletAccount wallet : mWallets) {
+            TextView moneyView = new TextView(this);
+            moneyView.setText(mMoneyFormatter.getNotTintedString(wallet.getMoney()));
+            moneyView.setTextColor(wallet == mCurrentWallet ? theme.getDrawerSelectedTextColor() : theme.getDrawerTextColor());
+            moneyView.setGravity(Gravity.CENTER_VERTICAL);
+            menu.add(GROUP_WALLETS, walletItemId(wallet), Menu.NONE, wallet.getName())
+                    .setIcon(wallet.getIcon().getDrawable(this))
+                    .setActionView(moneyView)
+                    .setCheckable(true);
+        }
+        addEntry(menu, GROUP_WALLETS, ID_ACTION_NEW_WALLET, R.drawable.ic_add_24dp, R.string.action_new_wallet);
+        addEntry(menu, GROUP_WALLETS, ID_ACTION_MANAGE_WALLET, R.drawable.ic_settings_24dp, R.string.action_manage_wallets);
+        menu.setGroupVisible(GROUP_WALLETS, mWalletListShown);
+        if (mWalletListShown && mCurrentWallet != null) {
+            mNavigationView.setCheckedItem(walletItemId(mCurrentWallet));
+        }
+    }
+
+    private static int walletItemId(WalletAccount wallet) {
+        return ID_WALLET_FIRST + (int) wallet.getId();
+    }
+
+    /**
+     * Show the current wallet in the header, and the first two other wallets as the one tap
+     * switches at its top end.
+     */
+    private void bindHeader() {
+        if (mCurrentWallet != null) {
+            IconLoader.loadInto(mCurrentWallet.getIcon(), mWalletIconView);
+            mWalletIconView.setVisibility(View.VISIBLE);
+            mWalletNameView.setText(mCurrentWallet.getName());
+            mWalletMoneyView.setText(mMoneyFormatter.getNotTintedString(mCurrentWallet.getMoney()));
+        } else {
+            mWalletIconView.setVisibility(View.INVISIBLE);
+            mWalletNameView.setText(R.string.msg_no_wallet_found);
+            mWalletMoneyView.setText(R.string.msg_add_one_wallet);
+        }
+        List<WalletAccount> others = new ArrayList<>(mWallets);
+        others.remove(mCurrentWallet);
+        bindQuickSwitch(mFirstWalletView, others.size() > 0 ? others.get(0) : null);
+        bindQuickSwitch(mSecondWalletView, others.size() > 1 ? others.get(1) : null);
+    }
+
+    private void bindQuickSwitch(ImageView view, WalletAccount wallet) {
+        // keyed, because Glide keeps its own request in the plain tag of any view it loads into
+        view.setTag(view.getId(), wallet);
+        view.setVisibility(wallet != null ? View.VISIBLE : View.GONE);
+        if (wallet != null) {
+            IconLoader.loadInto(wallet.getIcon(), view);
+            view.setContentDescription(wallet.getName());
+        }
+    }
+
     @Override
     public void onLoaderReset(@NonNull Loader<Cursor> loader) {
-        mAccountHeader.clear();
         if (mCursor != null) {
             if (!mCursor.isClosed()) {
                 mCursor.close();
@@ -610,52 +703,50 @@ public class MainActivity extends BaseActivity implements DrawerController, Acco
     private void applyNavigationDrawerHeaderTheme(ITheme theme) {
         int backgroundColor = theme.getColorPrimary();
         int textColor = theme.getBestTextColor(backgroundColor);
-        mAccountHeader.setBackground(new ColorDrawable(theme.getColorPrimary()));
-        View headerView = mAccountHeader.getView();
-        TextView nameTextView = headerView.findViewById(com.mikepenz.materialdrawer.R.id.material_drawer_account_header_name);
-        TextView emailTextView = headerView.findViewById(com.mikepenz.materialdrawer.R.id.material_drawer_account_header_email);
-        ImageView switcherImageView = headerView.findViewById(com.mikepenz.materialdrawer.R.id.material_drawer_account_header_text_switcher);
-        if (nameTextView != null) {nameTextView.setTextColor(textColor);}
-        if (emailTextView != null) {emailTextView.setTextColor(textColor);}
-        if (switcherImageView != null) {
-            switcherImageView.setColorFilter(textColor, PorterDuff.Mode.SRC_ATOP);
-        }
+        mHeaderView.setBackgroundColor(backgroundColor);
+        mWalletNameView.setTextColor(textColor);
+        mWalletMoneyView.setTextColor(textColor);
+        mWalletListArrowView.setColorFilter(textColor, PorterDuff.Mode.SRC_ATOP);
+        // a thin ring keeps the wallet icon visible when its color is the header's own
+        GradientDrawable ring = new GradientDrawable();
+        ring.setShape(GradientDrawable.OVAL);
+        ring.setStroke(Math.round(getResources().getDisplayMetrics().density), ColorUtils.setAlphaComponent(textColor, 0x66));
+        mWalletIconView.setBackground(ring);
     }
 
     private void applyNavigationDrawerBodyTheme(ITheme theme) {
-        RecyclerView recyclerView = mDrawer.getRecyclerView();
-        ThemedRecyclerView.applyTheme(recyclerView, theme);
-        recyclerView.setBackgroundColor(theme.getDrawerBackgroundColor());
-        int iconColor = theme.getDrawerIconColor();
-        int selectedIconColor = theme.getDrawerSelectedIconColor();
-        int textColor = theme.getDrawerTextColor();
-        int selectedTextColor = theme.getDrawerSelectedTextColor();
-        int selectedColor = theme.getDrawerSelectedItemColor();
-        for (IDrawerItem item : mDrawer.getDrawerItems()) {
-            if (item instanceof PrimaryDrawerItem) {
-                ((PrimaryDrawerItem) item).withIconColor(iconColor);
-                ((PrimaryDrawerItem) item).withTextColor(textColor);
-                ((PrimaryDrawerItem) item).withSelectedIconColor(selectedIconColor);
-                ((PrimaryDrawerItem) item).withSelectedTextColor(selectedTextColor);
-                ((PrimaryDrawerItem) item).withSelectedColor(selectedColor);
+        mNavigationView.setBackgroundColor(theme.getDrawerBackgroundColor());
+        mNavigationView.setItemTextColor(checkedStates(theme.getDrawerSelectedTextColor(), theme.getDrawerTextColor()));
+        // the row's own foreground is the theme's ripple, so the background only marks the open entry
+        StateListDrawable checkedBackground = new StateListDrawable();
+        checkedBackground.addState(new int[] {android.R.attr.state_checked}, new ColorDrawable(theme.getDrawerSelectedItemColor()));
+        checkedBackground.addState(new int[0], new ColorDrawable(Color.TRANSPARENT));
+        mNavigationView.setItemBackground(checkedBackground);
+        Menu menu = mNavigationView.getMenu();
+        for (int i = 0; i < menu.size(); i++) {
+            MenuItem item = menu.getItem(i);
+            if (item.getGroupId() != GROUP_WALLETS) {
+                tintEntry(item, theme);
             }
         }
-        for (IProfile profile : mAccountHeader.getProfiles()) {
-            if (profile instanceof ProfileDrawerItem) {
-                ((ProfileDrawerItem) profile).withTextColor(textColor);
-                ((ProfileDrawerItem) profile).withSelectedTextColor(selectedTextColor);
-                ((ProfileDrawerItem) profile).withSelectedColor(selectedColor);
-            } else if (profile instanceof ProfileSettingDrawerItem) {
-                ((ProfileSettingDrawerItem) profile).withIconColor(iconColor);
-                ((ProfileSettingDrawerItem) profile).withTextColor(textColor);
-                ((ProfileSettingDrawerItem) profile).withSelectedColor(selectedColor);
+        buildWalletMenu();
+        for (int i = 0; i < mNavigationView.getChildCount(); i++) {
+            View child = mNavigationView.getChildAt(i);
+            if (child instanceof RecyclerView) {
+                ThemedRecyclerView.applyTheme((RecyclerView) child, theme);
             }
         }
-        recyclerView.getAdapter().notifyDataSetChanged();
     }
 
+    /**
+     * Below Android 15 the drawer slides under a see through status bar and the drawer layout
+     * paints the band behind it, so the window's own color is cleared here. From Android 15 the
+     * base class pads the content and paints that band itself.
+     */
+    @Override
     protected void onThemeStatusBar(ITheme theme) {
-        mDrawer.getDrawerLayout().setStatusBarBackgroundColor(theme.getColorPrimaryDark());
+        getWindow().setStatusBarColor(Color.TRANSPARENT);
+        mDrawerLayout.setStatusBarBackgroundColor(theme.getColorPrimaryDark());
     }
 
     private BroadcastReceiver mBroadcastReceiver = new BroadcastReceiver() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.drawerlayout.widget.DrawerLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/drawer_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fitsSystemWindows="true">
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.google.android.material.navigation.NavigationView
+        android:id="@+id/navigation_view"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="start"
+        android:maxWidth="320dp"
+        app:headerLayout="@layout/layout_navigation_drawer_header" />
+
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/layout_navigation_drawer_header.xml
+++ b/app/src/main/res/layout/layout_navigation_drawer_header.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!-- The drawer header: the current wallet, two more wallets one tap away, and the arrow that
+     swaps the sections below for the wallet list. Below Android 15 the drawer slides under the
+     status bar, so the root fits the system windows and grows by that height. -->
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/navigation_drawer_header"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clickable="true"
+    android:fitsSystemWindows="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="148dp">
+
+        <ImageView
+            android:id="@+id/wallet_icon_image_view"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:importantForAccessibility="no"
+            android:padding="1dp" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentTop="true"
+            android:layout_marginTop="16dp"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/first_wallet_image_view"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginEnd="16dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/description_wallet_icon"
+                android:focusable="true" />
+
+            <ImageView
+                android:id="@+id/second_wallet_image_view"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginEnd="16dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:clickable="true"
+                android:contentDescription="@string/description_wallet_icon"
+                android:focusable="true" />
+
+        </LinearLayout>
+
+        <ImageView
+            android:id="@+id/wallet_list_arrow_image_view"
+            android:layout_width="22dp"
+            android:layout_height="22dp"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentEnd="true"
+            android:layout_marginBottom="14dp"
+            android:layout_marginEnd="16dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_expand_more_black_24dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentStart="true"
+            android:layout_marginBottom="8dp"
+            android:layout_marginStart="16dp"
+            android:layout_toStartOf="@id/wallet_list_arrow_image_view"
+            android:gravity="center_vertical"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/wallet_name_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif-medium"
+                android:maxLines="1"
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/wallet_money_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:fontFamily="sans-serif"
+                android:maxLines="1"
+                android:textSize="14sp" />
+
+        </LinearLayout>
+
+    </RelativeLayout>
+
+</FrameLayout>

--- a/app/src/main/res/values-fr/descriptions.xml
+++ b/app/src/main/res/values-fr/descriptions.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="description_navigation_drawer_open">"Ouvrir"</string>
+    <string name="description_navigation_drawer_close">"Fermer"</string>
+</resources>

--- a/app/src/main/res/values-pt-rBR/descriptions.xml
+++ b/app/src/main/res/values-pt-rBR/descriptions.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="description_navigation_drawer_open">"Abrir"</string>
+    <string name="description_navigation_drawer_close">"Fechar"</string>
+</resources>

--- a/app/src/main/res/values-pt-rPT/descriptions.xml
+++ b/app/src/main/res/values-pt-rPT/descriptions.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="description_navigation_drawer_open">"Abrir"</string>
+    <string name="description_navigation_drawer_close">"Fechar"</string>
+</resources>

--- a/app/src/main/res/values/descriptions.xml
+++ b/app/src/main/res/values/descriptions.xml
@@ -24,6 +24,8 @@
     <string name="description_backup_service_icon">"Backup service icon"</string>
     <string name="description_currency_icon">"Currency icon"</string>
     <string name="description_wallet_icon">"Wallet icon"</string>
+    <string name="description_navigation_drawer_open">"Open navigation drawer"</string>
+    <string name="description_navigation_drawer_close">"Close navigation drawer"</string>
     <string name="description_transaction_icon">"Transaction icon"</string>
     <string name="description_transfer_icon">"Transfer icon"</string>
     <string name="description_category_icon">"Category icon"</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,13 +19,24 @@
 
 <resources>
 
-    <!-- Base application theme. -->
-    <style name="MoneyWalletAppTheme" parent="MaterialDrawerTheme.Light.DarkToolbar">
+    <!-- Base application theme. The screens carry their own toolbar, so the window's action bar
+         and title stay off, which is what the drawer library's theme used to set on top of this
+         same AppCompat parent. -->
+    <style name="MoneyWalletAppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
+        <item name="windowActionBar">false</item>
+        <item name="windowNoTitle">true</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="preferenceTheme">@style/PreferenceThemeOverlay</item>
+        <item name="drawerArrowStyle">@style/MoneyWalletDrawerArrowStyle</item>
+    </style>
+
+    <!-- The drawer icon morphs into the back arrow without spinning, as the drawer library's own
+         style had it. -->
+    <style name="MoneyWalletDrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">
+        <item name="spinBars">false</item>
     </style>
 
 </resources>

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/MainActivityTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/MainActivityTest.java
@@ -1,0 +1,459 @@
+package com.oriondev.moneywallet.ui.activity;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Looper;
+import android.view.Menu;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.fragment.app.Fragment;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.google.android.material.navigation.NavigationView;
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.broadcast.LocalAction;
+import com.oriondev.moneywallet.model.Money;
+import com.oriondev.moneywallet.model.WalletAccount;
+import com.oriondev.moneywallet.service.BackupHandlerIntentService;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.TestDatabases;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.ui.fragment.multipanel.CategoryMultiPanelViewPagerFragment;
+import com.oriondev.moneywallet.ui.fragment.multipanel.TransactionMultiPanelViewPagerFragment;
+import com.oriondev.moneywallet.utils.MoneyFormatter;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+/**
+ * Drives the main screen's drawer on the JVM against the real content provider: which section
+ * opens, what back does, and which wallet the header and the preference end up on.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class MainActivityTest {
+
+    private static final String ICON = "{\"type\":\"color\",\"color\":\"#000000\",\"name\":\"T\"}";
+    private static final String VECTOR_ICON = "{\"type\":\"resource\",\"resource\":\"ic_icon_slippers\"}";
+    private static final int TOTAL_ITEM = MainActivity.ID_WALLET_FIRST + (int) PreferenceManager.TOTAL_WALLET_ID;
+
+    private ContentResolver mResolver;
+    private long mFirstWallet;
+    private long mSecondWallet;
+
+    @Before
+    public void setUp() {
+        Context context = ApplicationProvider.getApplicationContext();
+        TestDatabases.useFreshDatabase(context);
+        mResolver = context.getContentResolver();
+        PreferenceManager.setCurrentWallet(context, PreferenceManager.NO_CURRENT_WALLET);
+        // named against their order, so a list sorted by name instead of by index shows
+        mFirstWallet = insertWallet("Cash", 0, 0L, true, false);
+        mSecondWallet = insertWallet("Bank", 1, 0L, true, false);
+    }
+
+    @Test
+    public void theFirstLaunchOpensTransactionsOnTheFirstWallet() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                assertEquals(mFirstWallet, PreferenceManager.getCurrentWallet());
+                assertEquals("Cash", headerName(activity));
+                assertEquals(MainActivity.ID_SECTION_TRANSACTIONS, drawer(activity).getCheckedItem().getItemId());
+                assertTrue(section(activity) instanceof TransactionMultiPanelViewPagerFragment);
+                ImageView icon = activity.findViewById(R.id.wallet_icon_image_view);
+                assertNotNull(icon.getDrawable());
+                assertNotNull(icon.getBackground());
+                assertNotNull(drawer(activity).getItemBackground());
+                assertNull(drawer(activity).getItemIconTintList());
+            });
+        }
+    }
+
+    @Test
+    public void aLaunchOpensOnTheWalletThePreferenceNames() {
+        PreferenceManager.setCurrentWallet(ApplicationProvider.getApplicationContext(), mSecondWallet);
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                assertEquals("Bank", headerName(activity));
+                assertEquals(mSecondWallet, PreferenceManager.getCurrentWallet());
+            });
+        }
+    }
+
+    @Test
+    public void anEmptyLedgerShowsNoWalletAndOffersOnlyTheTwoActions() {
+        for (long id : new long[] {mFirstWallet, mSecondWallet}) {
+            mResolver.delete(ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, id), null, null);
+        }
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                assertEquals(activity.getString(R.string.msg_no_wallet_found), headerName(activity));
+                assertEquals(PreferenceManager.NO_CURRENT_WALLET, PreferenceManager.getCurrentWallet());
+                Menu menu = drawer(activity).getMenu();
+                assertNull(menu.findItem(TOTAL_ITEM));
+                activity.findViewById(R.id.navigation_drawer_header).performClick();
+                assertTrue(menu.findItem(MainActivity.ID_ACTION_NEW_WALLET).isVisible());
+                assertTrue(menu.findItem(MainActivity.ID_ACTION_MANAGE_WALLET).isVisible());
+                assertEquals(View.GONE, activity.findViewById(R.id.first_wallet_image_view).getVisibility());
+            });
+        }
+    }
+
+    @Test
+    public void aReloadRebuildsTheWalletRowsInsteadOfStackingThem() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                Menu menu = drawer(activity).getMenu();
+                assertEquals(3, walletRows(menu));
+                // a restore from backup asks the drawer to load the wallets again
+                Intent restored = new Intent(LocalAction.ACTION_BACKUP_SERVICE_FINISHED)
+                        .putExtra(BackupHandlerIntentService.ACTION, BackupHandlerIntentService.ACTION_RESTORE);
+                LocalBroadcastManager.getInstance(activity).sendBroadcast(restored);
+                ((TextView) activity.findViewById(R.id.wallet_name_text_view)).setText("");
+                awaitWallets(activity);
+                assertEquals(3, walletRows(menu));
+                assertFalse(menu.findItem(walletItem(mFirstWallet)).isVisible());
+                assertEquals("Cash", headerName(activity));
+            });
+        }
+    }
+
+    @Test
+    public void aPreferenceNamingNoListedWalletShowsTheFirstAndIsLeftAlone() {
+        PreferenceManager.setCurrentWallet(ApplicationProvider.getApplicationContext(), 999L);
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                assertEquals("Cash", headerName(activity));
+                assertEquals(999L, PreferenceManager.getCurrentWallet());
+            });
+        }
+    }
+
+    @Test
+    public void aSectionTapLoadsItsFragmentAndBackReturnsToTransactions() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                Menu menu = drawer(activity).getMenu();
+                assertTrue(menu.performIdentifierAction(MainActivity.ID_SECTION_CATEGORIES, 0));
+                runPending(activity);
+                assertTrue(section(activity) instanceof CategoryMultiPanelViewPagerFragment);
+                activity.onBackPressed();
+                runPending(activity);
+                assertTrue(section(activity) instanceof TransactionMultiPanelViewPagerFragment);
+                assertEquals(MainActivity.ID_SECTION_TRANSACTIONS, drawer(activity).getCheckedItem().getItemId());
+                assertFalse(activity.isFinishing());
+                activity.onBackPressed();
+                assertTrue(activity.isFinishing());
+            });
+        }
+    }
+
+    @Test
+    public void backClosesAnOpenDrawerAndLeavesTheSectionAlone() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                Menu menu = drawer(activity).getMenu();
+                activity.onNavigationItemSelected(menu.findItem(MainActivity.ID_SECTION_CATEGORIES));
+                runPending(activity);
+                DrawerLayout layout = activity.findViewById(R.id.drawer_layout);
+                layout.openDrawer(GravityCompat.START, false);
+                assertTrue(layout.isDrawerOpen(GravityCompat.START));
+                // the close animates, and the JVM never draws a frame; what back must not do
+                // is move the section or finish the activity while the drawer had it
+                activity.onBackPressed();
+                runPending(activity);
+                assertTrue(section(activity) instanceof CategoryMultiPanelViewPagerFragment);
+                assertEquals(MainActivity.ID_SECTION_CATEGORIES, drawer(activity).getCheckedItem().getItemId());
+                assertFalse(activity.isFinishing());
+            });
+        }
+    }
+
+    @Test
+    public void theSectionSurvivesARecreate() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                activity.onNavigationItemSelected(drawer(activity).getMenu().findItem(MainActivity.ID_SECTION_CATEGORIES));
+                runPending(activity);
+            });
+            scenario.recreate();
+            scenario.onActivity(activity -> {
+                runPending(activity);
+                assertTrue(section(activity) instanceof CategoryMultiPanelViewPagerFragment);
+                assertEquals(MainActivity.ID_SECTION_CATEGORIES, drawer(activity).getCheckedItem().getItemId());
+            });
+        }
+    }
+
+    @Test
+    public void aToolTapOpensItsScreenAndLeavesTheSectionAlone() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                Menu menu = drawer(activity).getMenu();
+                assertFalse(activity.onNavigationItemSelected(menu.findItem(MainActivity.ID_SECTION_CALCULATOR)));
+                Intent next = shadowOf(activity).getNextStartedActivity();
+                assertEquals(CalculatorActivity.class.getName(), next.getComponent().getClassName());
+                runPending(activity);
+                assertTrue(section(activity) instanceof TransactionMultiPanelViewPagerFragment);
+                assertEquals(MainActivity.ID_SECTION_TRANSACTIONS, drawer(activity).getCheckedItem().getItemId());
+            });
+        }
+    }
+
+    @Test
+    public void pickingAWalletFromTheListMovesTheHeaderAndThePreference() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                Menu menu = drawer(activity).getMenu();
+                activity.findViewById(R.id.navigation_drawer_header).performClick();
+                assertFalse(menu.findItem(MainActivity.ID_SECTION_TRANSACTIONS).isVisible());
+                assertFalse(menu.findItem(MainActivity.ID_SECTION_CALCULATOR).isVisible());
+                assertFalse(menu.findItem(MainActivity.ID_SECTION_SETTING).isVisible());
+                MenuItem bank = menu.findItem(walletItem(mSecondWallet));
+                assertEquals("Bank", bank.getTitle().toString());
+                assertTrue(bank.isVisible());
+                assertEquals(walletItem(mFirstWallet), drawer(activity).getCheckedItem().getItemId());
+                assertFalse(activity.onNavigationItemSelected(bank));
+                assertEquals(mSecondWallet, PreferenceManager.getCurrentWallet());
+                assertEquals("Bank", headerName(activity));
+                assertTrue(menu.findItem(MainActivity.ID_SECTION_TRANSACTIONS).isVisible());
+                assertTrue(menu.findItem(MainActivity.ID_SECTION_CALCULATOR).isVisible());
+                assertTrue(menu.findItem(MainActivity.ID_SECTION_SETTING).isVisible());
+                assertFalse(menu.findItem(walletItem(mSecondWallet)).isVisible());
+                assertEquals(MainActivity.ID_SECTION_TRANSACTIONS, drawer(activity).getCheckedItem().getItemId());
+                activity.findViewById(R.id.navigation_drawer_header).performClick();
+                assertEquals(walletItem(mSecondWallet), drawer(activity).getCheckedItem().getItemId());
+            });
+        }
+    }
+
+    @Test
+    public void aRowNamingAWalletThatIsGoneIsIgnored() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                Menu menu = drawer(activity).getMenu();
+                activity.findViewById(R.id.navigation_drawer_header).performClick();
+                // a row bound before a reload carries the id of a wallet the list no longer has
+                MenuItem stale = menu.add(4, MainActivity.ID_WALLET_FIRST + 999, Menu.NONE, "Gone");
+                assertFalse(activity.onNavigationItemSelected(stale));
+                assertEquals(mFirstWallet, PreferenceManager.getCurrentWallet());
+                assertEquals("Cash", headerName(activity));
+                assertTrue(menu.findItem(MainActivity.ID_SECTION_TRANSACTIONS).isVisible());
+            });
+        }
+    }
+
+    @Test
+    public void theTotalEntryComesAfterTheWalletsAndIsItsOwnCurrentWallet() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                MenuItem total = drawer(activity).getMenu().findItem(TOTAL_ITEM);
+                assertEquals(activity.getString(R.string.total_wallet_name), total.getTitle().toString());
+                activity.onNavigationItemSelected(total);
+                assertEquals(PreferenceManager.TOTAL_WALLET_ID, PreferenceManager.getCurrentWallet());
+                assertEquals(activity.getString(R.string.total_wallet_name), headerName(activity));
+            });
+        }
+    }
+
+    @Test
+    public void anArchivedWalletStaysOutOfTheListAndInTheTotalAndAnExcludedOneStaysOut() {
+        insertWallet("Old", 2, 50000L, true, true);
+        insertWallet("Side", 3, 70000L, false, false);
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                Menu menu = drawer(activity).getMenu();
+                activity.findViewById(R.id.navigation_drawer_header).performClick();
+                assertNull(findByTitle(menu, "Old"));
+                assertTrue(findByTitle(menu, "Side").isVisible());
+                String expected = MoneyFormatter.getInstance().getNotTintedString(new Money("EUR", 50000L));
+                assertEquals(expected, ((TextView) menu.findItem(TOTAL_ITEM).getActionView()).getText().toString());
+                activity.onNavigationItemSelected(menu.findItem(TOTAL_ITEM));
+                assertEquals(expected, ((TextView) activity.findViewById(R.id.wallet_money_text_view)).getText().toString());
+            });
+        }
+    }
+
+    @Test
+    public void theQuickSwitchIconsHoldTheNextTwoWalletsAndSwitchToThem() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                View first = activity.findViewById(R.id.first_wallet_image_view);
+                View second = activity.findViewById(R.id.second_wallet_image_view);
+                assertEquals(mSecondWallet, quickWallet(first).getId());
+                assertEquals(PreferenceManager.TOTAL_WALLET_ID, quickWallet(second).getId());
+                assertEquals(View.VISIBLE, second.getVisibility());
+                assertNotNull(((ImageView) first).getDrawable());
+                assertEquals("Bank", first.getContentDescription().toString());
+                first.performClick();
+                assertEquals(mSecondWallet, PreferenceManager.getCurrentWallet());
+                assertEquals("Bank", headerName(activity));
+                assertEquals(mFirstWallet, quickWallet(first).getId());
+                assertEquals("Cash", first.getContentDescription().toString());
+                assertEquals(PreferenceManager.TOTAL_WALLET_ID, quickWallet(second).getId());
+                second.performClick();
+                assertEquals(PreferenceManager.TOTAL_WALLET_ID, PreferenceManager.getCurrentWallet());
+                assertEquals(mFirstWallet, quickWallet(first).getId());
+                assertEquals(mSecondWallet, quickWallet(second).getId());
+            });
+        }
+    }
+
+    @Test
+    public void aQuickSwitchWalletWithAPickerIconLoadsWithoutACrash() {
+        ContentValues values = new ContentValues();
+        values.put(Contract.Wallet.ICON, VECTOR_ICON);
+        mResolver.update(ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, mSecondWallet), values, null, null);
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                ImageView first = activity.findViewById(R.id.first_wallet_image_view);
+                assertEquals(mSecondWallet, quickWallet(first).getId());
+                assertEquals(View.VISIBLE, first.getVisibility());
+                // the picker icon comes through Glide, which lands on the main looper later
+                for (int i = 0; i < 80 && first.getDrawable() == null; i++) {
+                    shadowOf(Looper.getMainLooper()).idle();
+                    try {
+                        Thread.sleep(25);
+                    } catch (InterruptedException e) {
+                        throw new AssertionError(e);
+                    }
+                }
+                assertNotNull(first.getDrawable());
+            });
+        }
+    }
+
+    @Test
+    public void noWalletCountingInTheTotalMeansNoTotalEntry() {
+        ContentValues values = new ContentValues();
+        values.put(Contract.Wallet.COUNT_IN_TOTAL, false);
+        for (long id : new long[] {mFirstWallet, mSecondWallet}) {
+            mResolver.update(ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, id), values, null, null);
+        }
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                assertNull(drawer(activity).getMenu().findItem(TOTAL_ITEM));
+                assertEquals(mSecondWallet, quickWallet(activity.findViewById(R.id.first_wallet_image_view)).getId());
+                assertEquals(View.GONE, activity.findViewById(R.id.second_wallet_image_view).getVisibility());
+            });
+        }
+    }
+
+    @Test
+    public void newWalletOpensTheEditorAndPutsTheSectionsBack() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                Menu menu = drawer(activity).getMenu();
+                activity.findViewById(R.id.navigation_drawer_header).performClick();
+                assertFalse(activity.onNavigationItemSelected(menu.findItem(MainActivity.ID_ACTION_NEW_WALLET)));
+                Intent next = shadowOf(activity).getNextStartedActivity();
+                assertEquals(NewEditWalletActivity.class.getName(), next.getComponent().getClassName());
+                assertTrue(menu.findItem(MainActivity.ID_SECTION_TRANSACTIONS).isVisible());
+                assertEquals(MainActivity.ID_SECTION_TRANSACTIONS, drawer(activity).getCheckedItem().getItemId());
+            });
+        }
+    }
+
+    private static int walletItem(long walletId) {
+        return MainActivity.ID_WALLET_FIRST + (int) walletId;
+    }
+
+    private static WalletAccount quickWallet(View icon) {
+        return (WalletAccount) icon.getTag(icon.getId());
+    }
+
+    private static int walletRows(Menu menu) {
+        int rows = 0;
+        for (int i = 0; i < menu.size(); i++) {
+            if (menu.getItem(i).getItemId() >= MainActivity.ID_WALLET_FIRST) {
+                rows++;
+            }
+        }
+        return rows;
+    }
+
+    private static MenuItem findByTitle(Menu menu, String title) {
+        for (int i = 0; i < menu.size(); i++) {
+            if (title.contentEquals(menu.getItem(i).getTitle())) {
+                return menu.getItem(i);
+            }
+        }
+        return null;
+    }
+
+    private static NavigationView drawer(MainActivity activity) {
+        return activity.findViewById(R.id.navigation_view);
+    }
+
+    private static Fragment section(MainActivity activity) {
+        return activity.getSupportFragmentManager().findFragmentById(R.id.fragment_container);
+    }
+
+    private static String headerName(MainActivity activity) {
+        return ((TextView) activity.findViewById(R.id.wallet_name_text_view)).getText().toString();
+    }
+
+    private static void runPending(MainActivity activity) {
+        activity.getSupportFragmentManager().executePendingTransactions();
+    }
+
+    /**
+     * The wallets arrive through a cursor loader on a background thread and land on the main
+     * looper, which the test drives by hand.
+     */
+    private static void awaitWallets(MainActivity activity) {
+        for (int i = 0; i < 200 && headerName(activity).isEmpty(); i++) {
+            shadowOf(Looper.getMainLooper()).idle();
+            try {
+                Thread.sleep(25);
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+        }
+        assertFalse("the wallets never loaded", headerName(activity).isEmpty());
+    }
+
+    private long insertWallet(String name, int index, long startMoney, boolean countInTotal, boolean archived) {
+        ContentValues values = new ContentValues();
+        values.put(Contract.Wallet.NAME, name);
+        values.put(Contract.Wallet.ICON, ICON);
+        values.put(Contract.Wallet.CURRENCY, "EUR");
+        values.put(Contract.Wallet.START_MONEY, startMoney);
+        values.put(Contract.Wallet.COUNT_IN_TOTAL, countInTotal);
+        values.put(Contract.Wallet.ARCHIVED, archived);
+        values.put(Contract.Wallet.INDEX, index);
+        return ContentUris.parseId(mResolver.insert(DataContentProvider.CONTENT_WALLETS, values));
+    }
+}


### PR DESCRIPTION
The navigation drawer on the main screen came from a third party drawer library last released in 2018. It brought three more libraries with it, owned the parent of the app theme, and reached into the app's own model. The architecture plan takes it out before the material library can move.

The drawer is now built from the drawer and navigation views that Android's material library already ships. Every section, tool and settings entry is where it was, and the highlighted entry still follows the section on screen, including on the way back to Transactions. The header still shows the current wallet with its icon, name and balance, the two small icons at its top end still switch to another wallet in one tap, and the arrow still swaps the sections for the wallet list with New wallet and Manage wallets under it. The chosen theme colors and the three dark modes reach the drawer through the same color tables as before.

What looks different: the wallet rows are standard rows with the balance at the end instead of taller rows with the balance under the name; on Android 15 and later the header loses a blank band the old library added for a status bar it was not under; the drawer icon animates into an arrow while the drawer slides; the dropdown triangle is now the app's own chevron; and the two small icons always show the first two other wallets in list order, where the old library kept a recently used order.

Tested on an Android 16 emulator over a seeded ledger against a build of master: every destination and back from each, the wallet switch from the list and from the small icons, both wallet actions, rotation with the drawer open and with the list shown, the three modes and RTL, plus the status bar band on Android 9 with both builds. 347 unit tests including a new class that drives the drawer on the JVM, 138 instrumented tests, two clean release builds byte identical, and the only classes gone are the four libraries' own.
