### PR TITLE
Move the material library to current and the app theme onto its bridge parent

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -13081,51 +13081,7 @@
 
     <issue
         id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
-        errorLine1="            floatingActionButton.setVisibility(View.GONE);"
-        errorLine2="                                 ~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java"
-            line="238"
-            column="34"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
-        errorLine1="            floatingActionButton.setVisibility(View.GONE);"
-        errorLine2="                                               ~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java"
-            line="238"
-            column="48"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
-        errorLine1="                mFloatingActionButton.setVisibility(View.GONE);"
-        errorLine2="                                      ~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java"
-            line="145"
-            column="39"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
-        errorLine1="                mFloatingActionButton.setVisibility(View.GONE);"
-        errorLine2="                                                    ~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java"
-            line="145"
-            column="53"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
+        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10b`)"
         errorLine1="        return dependency instanceof AppBarLayout || dependency instanceof Snackbar.SnackbarLayout;"
         errorLine2="                                                                           ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -13136,7 +13092,7 @@
 
     <issue
         id="RestrictedApi"
-        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
+        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10b`)"
         errorLine1="        } else if (dependency instanceof Snackbar.SnackbarLayout) {"
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
@@ -13147,57 +13103,13 @@
 
     <issue
         id="RestrictedApi"
-        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
+        message="SnackbarLayout can only be accessed from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10b`)"
         errorLine1="            if (view instanceof Snackbar.SnackbarLayout &amp;&amp; parent.doViewsOverlap(fab, view)) {"
         errorLine2="                                ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/java/com/oriondev/moneywallet/ui/behavior/ScrollingFloatingActionButtonBehavior.java"
             line="78"
             column="33"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
-        errorLine1="                floatingActionButton.setVisibility(View.GONE);"
-        errorLine2="                                     ~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/base/SinglePanelActivity.java"
-            line="114"
-            column="38"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
-        errorLine1="                floatingActionButton.setVisibility(View.GONE);"
-        errorLine2="                                                   ~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/base/SinglePanelActivity.java"
-            line="114"
-            column="52"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
-        errorLine1="                floatingActionButton.setVisibility(View.GONE);"
-        errorLine2="                                     ~~~~~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/fragment/base/SinglePanelFragment.java"
-            line="125"
-            column="38"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="VisibilityAwareImageButton.setVisibility can only be called from within the same library group (referenced groupId=`com.google.android.material` from groupId=`moneywallet-fix10a`)"
-        errorLine1="                floatingActionButton.setVisibility(View.GONE);"
-        errorLine2="                                                   ~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/fragment/base/SinglePanelFragment.java"
-            line="125"
-            column="52"/>
     </issue>
 
     <issue

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
@@ -59,6 +59,7 @@ import android.widget.TextView;
 
 import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.navigation.NavigationView;
+import com.google.android.material.shape.MaterialShapeDrawable;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.ColorIcon;
@@ -715,7 +716,14 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
     }
 
     private void applyNavigationDrawerBodyTheme(ITheme theme) {
-        mNavigationView.setBackgroundColor(theme.getDrawerBackgroundColor());
+        // the library gives the drawer its outline, and with it its shadow, only while the background
+        // is still the shape drawable it built, so that drawable is recolored and not replaced
+        Drawable background = mNavigationView.getBackground();
+        if (background instanceof MaterialShapeDrawable) {
+            ((MaterialShapeDrawable) background).setFillColor(ColorStateList.valueOf(theme.getDrawerBackgroundColor()));
+        } else {
+            mNavigationView.setBackgroundColor(theme.getDrawerBackgroundColor());
+        }
         mNavigationView.setItemTextColor(checkedStates(theme.getDrawerSelectedTextColor(), theme.getDrawerTextColor()));
         // the row's own foreground is the theme's ripple, so the background only marks the open entry
         StateListDrawable checkedBackground = new StateListDrawable();

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,13 +19,12 @@
 
 <resources>
 
-    <!-- Base application theme. The screens carry their own toolbar, so the window's action bar
-         and title stay off, which is what the drawer library's theme used to set on top of this
-         same AppCompat parent. -->
-    <style name="MoneyWalletAppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <!-- Base application theme. The Bridge parent keeps AppCompat's own widget styles and adds the
+         theme attributes material's widgets check for when they inflate. It is a Light theme and not
+         DayNight because ThemeEngine paints the dark modes itself. The screens carry their own
+         toolbar, so the parent's window action bar and title stay off. -->
+    <style name="MoneyWalletAppTheme" parent="Theme.MaterialComponents.Light.NoActionBar.Bridge">
         <!-- Customize your theme here. -->
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/MainActivityTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/MainActivityTest.java
@@ -19,7 +19,10 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 
+import com.google.android.material.elevation.ElevationOverlayProvider;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.navigation.NavigationView;
+import com.google.android.material.shape.MaterialShapeDrawable;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.Money;
@@ -31,6 +34,7 @@ import com.oriondev.moneywallet.storage.database.TestDatabases;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.fragment.multipanel.CategoryMultiPanelViewPagerFragment;
 import com.oriondev.moneywallet.ui.fragment.multipanel.TransactionMultiPanelViewPagerFragment;
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 import com.oriondev.moneywallet.utils.MoneyFormatter;
 
 import org.junit.Before;
@@ -85,6 +89,21 @@ public class MainActivityTest {
                 assertNotNull(icon.getBackground());
                 assertNotNull(drawer(activity).getItemBackground());
                 assertNull(drawer(activity).getItemIconTintList());
+                assertTrue(drawer(activity).getClipToOutline());
+                assertTrue(drawer(activity).getBackground() instanceof MaterialShapeDrawable);
+                assertEquals(ThemeEngine.getTheme().getDrawerBackgroundColor(), ((MaterialShapeDrawable) drawer(activity).getBackground()).getFillColor().getDefaultColor());
+                assertFalse(new ElevationOverlayProvider(activity).isThemeElevationOverlayEnabled());
+            });
+        }
+    }
+
+    @Test
+    public void theMainScreenInflatesItsFloatingActionButton() {
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            scenario.onActivity(activity -> {
+                awaitWallets(activity);
+                View fab = activity.findViewById(R.id.floating_action_button);
+                assertTrue(fab instanceof FloatingActionButton);
             });
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -42,16 +42,11 @@ allprojects {
 
 ext {
     supportDependencies = [
-            // Held with material. appcompat-resources 1.6.0 replaced the DrawableWrapper that
-            // material 1.0.0's ShadowDrawableWrapper extends. Past 1.5.1 the JVM cannot load
-            // material's floating action button implementation, so Robolectric cannot inflate a
-            // screen that holds one, and a device would load that class the first time a button
-            // asked for useCompatPadding. Both move together.
-            appcompat : 'androidx.appcompat:appcompat:1.5.1',
+            appcompat : 'androidx.appcompat:appcompat:1.8.0',
             recyclerview : 'androidx.recyclerview:recyclerview:1.4.0',
             cardview: 'androidx.cardview:cardview:1.0.0',
             annotations : 'androidx.annotation:annotation:1.10.0',
-            design : 'com.google.android.material:material:1.0.0',
+            design : 'com.google.android.material:material:1.14.0',
             preference: 'androidx.preference:preference:1.2.1',
             constraintlayout : 'androidx.constraintlayout:constraintlayout:2.2.2'
     ]


### PR DESCRIPTION
The material components library was held at its first release from 2018, and the main compatibility library with it, because that old material release built on a class the newer compatibility library had dropped. Both move to current in one change, and the hold ends.

The app theme now descends from the material library's bridge theme instead of the plain compatibility theme. The bridge keeps every widget looking as it does today and adds the attributes the newer material widgets check for when a screen is built. It stays a light theme, because the app paints its own three dark modes from a setting and a theme that followed the phone's dark mode would fight that.

One screen needed a change. The new library draws the navigation drawer's shadow from a background it builds for the drawer, and the app used to replace that background with a plain color, which left the open drawer without its edge shadow. The color now goes onto the library's background, and a test pins that.

The rest is the library's own defaults. A list under a toolbar that slides away is no longer denied the over scroll at its bottom edge. A two line message bar at the bottom of a screen is a little shorter. Keyboard users tab into the toolbar tabs before the list.

Eight entries leave the build's issue baseline because the round add button no longer calls a restricted method. The release build grows by about two megabytes, mostly the new library's translations.

Tested: 348 unit tests, including one that proves a screen with the round add button opens on the desktop test harness; two clean release builds byte identical; and on an emulator over a seeded ledger against a build of master, 138 device tests, 45 screens across the three modes, right to left and landscape matching to the pixel apart from a one pixel taller toolbar, the drawer shadow back, the PIN lock set and cleared, the ledger untouched, and a cold start about a tenth slower.
