### PR TITLE
Take the old dialog library out and rebuild its dialogs in the app

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -117,8 +117,6 @@ dependencies {
     implementation supportDependencies.annotations
     implementation supportDependencies.design
     implementation supportDependencies.preference
-    implementation 'com.afollestad.material-dialogs:core:0.9.6.0'
-    implementation 'com.afollestad.material-dialogs:commons:0.9.6.0'
     implementation 'com.pnikosis:materialish-progress:1.7'
     // jcenter-orphaned. No 1.6.1 git tag ever existed (Bintray-only publish); rubensousa's repo only
     // has buildable tags up to 1.5.1 on JitPack. kizitonwose/BottomSheetBuilder is a direct fork at

--- a/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendService.java
@@ -21,10 +21,9 @@ package com.oriondev.moneywallet.api.disk;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.AbstractBackendServiceDelegate;
 import com.oriondev.moneywallet.api.BackendException;
@@ -93,8 +92,8 @@ public class DiskBackendService extends AbstractBackendServiceDelegate {
                         if (!isGranted) {
                             setBackendServiceEnabled(false);
                             ThemedDialog.buildMaterialDialog(activity)
-                                    .title(R.string.title_warning)
-                                    .content(R.string.message_permission_required_not_granted)
+                                    .setTitle(R.string.title_warning)
+                                    .setMessage(R.string.message_permission_required_not_granted)
                                     .show();
                         }
                     }
@@ -102,18 +101,18 @@ public class DiskBackendService extends AbstractBackendServiceDelegate {
         );
         if (ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             ThemedDialog.buildMaterialDialog(activity)
-                    .title(R.string.title_request_permission)
-                    .content(R.string.message_permission_required_external_storage)
-                    .positiveText(android.R.string.ok)
-                    .negativeText(android.R.string.cancel)
-                    .onPositive(new MaterialDialog.SingleButtonCallback() {
+                    .setTitle(R.string.title_request_permission)
+                    .setMessage(R.string.message_permission_required_external_storage)
+                    .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                         @Override
-                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        public void onClick(DialogInterface dialog, int which) {
                             launcher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                         }
 
-                    }).show();
+                    })
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .show();
         } else {
             launcher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }

--- a/app/src/main/java/com/oriondev/moneywallet/api/saf/SAFBackendService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/saf/SAFBackendService.java
@@ -1,12 +1,11 @@
 package com.oriondev.moneywallet.api.saf;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.AbstractBackendServiceDelegate;
 import com.oriondev.moneywallet.api.BackendServiceFactory;
@@ -108,14 +107,12 @@ public class SAFBackendService extends AbstractBackendServiceDelegate {
             return;
         }
         ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.title_warning)
-                .content(R.string.message_backup_service_storage_access_framework_disconnect)
-                .positiveText(android.R.string.yes)
-                .negativeText(android.R.string.no)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_backup_service_storage_access_framework_disconnect)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         activity.getContentResolver()
                                 .releasePersistableUriPermission(uri, FLAG_URI_READ_WRITE);
                         clearUri(activity);
@@ -123,6 +120,7 @@ public class SAFBackendService extends AbstractBackendServiceDelegate {
                     }
 
                 })
+                .setNegativeButton(android.R.string.no, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/api/webdav/WebDAVBackendService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/webdav/WebDAVBackendService.java
@@ -20,6 +20,7 @@
 package com.oriondev.moneywallet.api.webdav;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.util.Log;
 import android.view.View;
@@ -27,12 +28,10 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import androidx.activity.ComponentActivity;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.appcompat.app.AlertDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.AbstractBackendServiceDelegate;
 import com.oriondev.moneywallet.api.BackendServiceFactory;
@@ -117,32 +116,25 @@ public class WebDAVBackendService extends AbstractBackendServiceDelegate {
     }
 
     private void showSetupDialog(final ComponentActivity activity, @Nullable String url, @Nullable String username) {
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.service_backup_webdav)
-                .customView(R.layout.dialog_webdav_setup, true)
-                .positiveText(R.string.action_connect)
-                .negativeText(android.R.string.cancel)
-                .autoDismiss(false)
-                .onNegative(new MaterialDialog.SingleButtonCallback() {
+        View view = ThemedDialog.inflateScrollableView(activity, R.layout.dialog_webdav_setup);
+        final AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.service_backup_webdav)
+                .setView(view)
+                .setPositiveButton(R.string.action_connect, null)
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
 
-                    @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                        dialog.dismiss();
-                    }
-                })
-                .build();
-
-        View view = dialog.getCustomView();
-        if (view == null) {
-            return;
-        }
         final EditText urlField = view.findViewById(R.id.webdav_url_edit_text);
         final EditText usernameField = view.findViewById(R.id.webdav_username_edit_text);
         final EditText passwordField = view.findViewById(R.id.webdav_password_edit_text);
         urlField.setText(url);
         usernameField.setText(username);
 
-        dialog.getActionButton(DialogAction.POSITIVE).setOnClickListener(new View.OnClickListener() {
+        dialog.show();
+        // Replacing the listener on the button itself is what keeps Connect from closing the form,
+        // so a rejected url can be corrected without typing everything again. The button only
+        // exists once the dialog has been shown.
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
 
             @Override
             public void onClick(View v) {
@@ -160,17 +152,15 @@ public class WebDAVBackendService extends AbstractBackendServiceDelegate {
                 verifyAndStore(activity, dialog, typedUrl, typedUsername, typedPassword);
             }
         });
-
-        dialog.show();
     }
 
     /**
      * Credentials are checked against the server before they are saved, so a typo is reported while
      * the form is still open rather than surfacing later as an empty folder listing.
      */
-    private void verifyAndStore(final ComponentActivity activity, final MaterialDialog dialog,
+    private void verifyAndStore(final ComponentActivity activity, final AlertDialog dialog,
                                 final String url, final String username, final String password) {
-        dialog.getActionButton(DialogAction.POSITIVE).setEnabled(false);
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(false);
         new Thread(new Runnable() {
 
             @Override
@@ -190,7 +180,7 @@ public class WebDAVBackendService extends AbstractBackendServiceDelegate {
 
                     @Override
                     public void run() {
-                        dialog.getActionButton(DialogAction.POSITIVE).setEnabled(true);
+                        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setEnabled(true);
                         if (result != null) {
                             Toast.makeText(activity, result, Toast.LENGTH_LONG).show();
                             return;
@@ -207,18 +197,17 @@ public class WebDAVBackendService extends AbstractBackendServiceDelegate {
     @Override
     public void teardown(final ComponentActivity activity) {
         ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.title_warning)
-                .content(R.string.message_backup_service_webdav_disconnect)
-                .positiveText(android.R.string.yes)
-                .negativeText(android.R.string.no)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_backup_service_webdav_disconnect)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         clearCredentials(activity);
                         setBackendServiceEnabled(false);
                     }
                 })
+                .setNegativeButton(android.R.string.no, null)
                 .show();
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/model/Attachment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/model/Attachment.java
@@ -179,9 +179,9 @@ public class Attachment implements Parcelable, Identifiable {
             context.startActivity(attachment.getActionViewIntent(context));
         } catch (ActivityNotFoundException e) {
             ThemedDialog.buildMaterialDialog(context)
-                    .title(R.string.title_error)
-                    .content(R.string.message_error_activity_not_found)
-                    .positiveText(android.R.string.ok)
+                    .setTitle(R.string.title_error)
+                    .setMessage(R.string.message_error_activity_not_found)
+                    .setPositiveButton(android.R.string.ok, null)
                     .show();
         }
     }

--- a/app/src/main/java/com/oriondev/moneywallet/picker/ColorPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/ColorPicker.java
@@ -19,7 +19,6 @@
 
 package com.oriondev.moneywallet.picker;
 
-import android.app.Activity;
 import android.content.Context;
 import android.graphics.Color;
 import android.os.Bundle;
@@ -28,14 +27,13 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
-import com.afollestad.materialdialogs.color.ColorChooserDialog;
 import com.oriondev.moneywallet.R;
-import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+import com.oriondev.moneywallet.ui.fragment.dialog.ColorChooserDialog;
 
 /**
  * Created by andrea on 15/04/18.
  */
-public class ColorPicker extends Fragment implements ColorChooserDialog.ColorCallback {
+public class ColorPicker extends Fragment implements ColorChooserDialog.Callback {
 
     private static final String SS_CURRENT_COLOR = "ColorPicker::SavedState::CurrentColor";
     private static final String SS_ACCENT_PALETTE = "ColorPicker::SavedState::AccentPalette";
@@ -61,8 +59,6 @@ public class ColorPicker extends Fragment implements ColorChooserDialog.ColorCal
     private int mCurrentColor;
     private boolean mAccentPalette;
 
-    private ColorChooserDialog mColorChooserDialog;
-
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
@@ -87,16 +83,6 @@ public class ColorPicker extends Fragment implements ColorChooserDialog.ColorCal
                 mAccentPalette = false;
             }
         }
-        createColorChooserDialog(getActivity());
-    }
-
-    private void createColorChooserDialog(Activity activity) {
-        mColorChooserDialog = ThemedDialog.buildColorChooserDialog(activity, R.string.dialog_color_picker_title)
-                .accentMode(mAccentPalette)
-                .preselect(mCurrentColor)
-                .dynamicButtonColor(true)
-                .tag(getDialogTag())
-                .build();
     }
 
     @Override
@@ -127,7 +113,13 @@ public class ColorPicker extends Fragment implements ColorChooserDialog.ColorCal
     }
 
     public void showPicker() {
-        mColorChooserDialog.show(getChildFragmentManager());
+        FragmentManager fragmentManager = getChildFragmentManager();
+        String tag = getDialogTag();
+        // showNow adds the dialog before it returns, so a second tap in the same frame finds it.
+        if (fragmentManager.findFragmentByTag(tag) == null) {
+            ColorChooserDialog.newInstance(R.string.dialog_color_picker_title, mAccentPalette, mCurrentColor)
+                    .showNow(fragmentManager, tag);
+        }
     }
 
     @Override
@@ -137,14 +129,14 @@ public class ColorPicker extends Fragment implements ColorChooserDialog.ColorCal
     }
 
     @Override
-    public void onColorSelection(@NonNull ColorChooserDialog dialog, int selectedColor) {
+    public void onColorSelection(ColorChooserDialog dialog, int selectedColor) {
         mCurrentColor = selectedColor;
         fireCallbackSafely(false);
     }
 
     @Override
-    public void onColorChooserDismissed(@NonNull ColorChooserDialog dialog) {
-        createColorChooserDialog(getActivity());
+    public void onColorChooserDismissed(ColorChooserDialog dialog) {
+        // nothing to do: the dialog is built fresh on every showPicker
     }
 
     public interface Controller {

--- a/app/src/main/java/com/oriondev/moneywallet/picker/IconPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/IconPicker.java
@@ -33,7 +33,6 @@ import android.text.TextWatcher;
 import android.view.MenuItem;
 import android.widget.EditText;
 
-import com.afollestad.materialdialogs.color.ColorChooserDialog;
 import com.github.rubensousa.bottomsheetbuilder.BottomSheetBuilder;
 import com.github.rubensousa.bottomsheetbuilder.adapter.BottomSheetItemClickListener;
 import com.oriondev.moneywallet.R;
@@ -41,6 +40,7 @@ import com.oriondev.moneywallet.model.ColorIcon;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.model.VectorIcon;
 import com.oriondev.moneywallet.ui.activity.IconListActivity;
+import com.oriondev.moneywallet.ui.fragment.dialog.ColorChooserDialog;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.Utils;
@@ -48,7 +48,7 @@ import com.oriondev.moneywallet.utils.Utils;
 /**
  * Created by andrea on 01/02/18.
  */
-public class IconPicker extends Fragment implements ColorChooserDialog.ColorCallback {
+public class IconPicker extends Fragment implements ColorChooserDialog.Callback {
 
     private static final String SS_CURRENT_ICON = "IconPicker::SavedState::CurrentIcon";
     private static final String SS_LAST_BG_COLOR = "IconPicker::SavedState::LastBackgroundColor";
@@ -57,6 +57,8 @@ public class IconPicker extends Fragment implements ColorChooserDialog.ColorCall
     private static final int REQUEST_ICON_PICKER = 57;
 
     private static final String DEFAULT_BACKGROUND_COLOR = "#000000";
+
+    private static final String TAG_COLOR_CHOOSER = "IconPicker::Tag::ColorChooserDialog";
 
     private Controller mController;
 
@@ -236,13 +238,15 @@ public class IconPicker extends Fragment implements ColorChooserDialog.ColorCall
     }
 
     private void openColorPicker() {
-        Activity activity = getActivity();
-        if (activity != null) {
-            ThemedDialog.buildColorChooserDialog(activity, R.string.dialog_color_picker_title_icon_picker_background_color)
-                    .accentMode(true)
-                    .preselect(Color.parseColor(mLastBackgroundColor))
-                    .dynamicButtonColor(false)
-                    .show(getChildFragmentManager());
+        if (!isAdded()) {
+            return;
+        }
+        FragmentManager fragmentManager = getChildFragmentManager();
+        // showNow adds the dialog before it returns, so a second tap in the same frame finds it.
+        if (fragmentManager.findFragmentByTag(TAG_COLOR_CHOOSER) == null) {
+            ColorChooserDialog.newInstance(R.string.dialog_color_picker_title_icon_picker_background_color,
+                            true, Color.parseColor(mLastBackgroundColor))
+                    .showNow(fragmentManager, TAG_COLOR_CHOOSER);
         }
     }
 
@@ -262,7 +266,7 @@ public class IconPicker extends Fragment implements ColorChooserDialog.ColorCall
     }
 
     @Override
-    public void onColorSelection(@NonNull ColorChooserDialog dialog, int selectedColor) {
+    public void onColorSelection(ColorChooserDialog dialog, int selectedColor) {
         mLastBackgroundColor = Utils.getHexColor(selectedColor);
         if (mCurrentIcon instanceof ColorIcon) {
             String text = IconLoader.getColorIconString(mBindEditText != null ? mBindEditText.getText().toString() : null);
@@ -272,7 +276,7 @@ public class IconPicker extends Fragment implements ColorChooserDialog.ColorCall
     }
 
     @Override
-    public void onColorChooserDismissed(@NonNull ColorChooserDialog dialog) {
+    public void onColorChooserDismissed(ColorChooserDialog dialog) {
         // do nothing here: if the user dismiss the picker, it means that he don't want to change
         // the color at the moment.
     }

--- a/app/src/main/java/com/oriondev/moneywallet/picker/MoneyPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/MoneyPicker.java
@@ -151,26 +151,6 @@ public class MoneyPicker extends Fragment {
 
     public void showPicker() {
         // TODO let the user choice in preferences if start the calculator or the bottom sheet keypad
-        /*
-        Activity activity = getActivity();
-        if (activity != null) {
-            new MaterialDialog.Builder(activity)
-                    .title("Enter money")
-                    .inputType(InputType.TYPE_CLASS_NUMBER)
-                    .input("money", null, new MaterialDialog.InputCallback() {
-
-                        @Override
-                        public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
-                            try {
-                                mCurrentMoney = Long.parseLong(input.toString());
-                                fireCallbackSafely();
-                            } catch (NumberFormatException e) {
-                                e.printStackTrace();
-                            }
-                        }
-
-                    }).show();
-        }*/
         Intent intent = new Intent(getActivity(), CalculatorActivity.class);
         intent.putExtra(CalculatorActivity.ACTIVITY_MODE, CalculatorActivity.MODE_KEYPAD);
         intent.putExtra(CalculatorActivity.CURRENCY, mCurrentCurrency);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/BackendExplorerActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/BackendExplorerActivity.java
@@ -21,11 +21,13 @@ package com.oriondev.moneywallet.ui.activity;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.widget.EditText;
 import androidx.annotation.MenuRes;
-import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
@@ -39,7 +41,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.BackendServiceFactory;
 import com.oriondev.moneywallet.broadcast.LocalAction;
@@ -232,26 +233,30 @@ public class BackendExplorerActivity extends SinglePanelActivity implements Swip
 
     @Override
     protected void onFloatingActionButtonClick() {
-        ThemedDialog.buildMaterialDialog(this)
-                .title(R.string.title_backend_create_folder)
-                .content(R.string.message_backend_create_folder)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .inputType(InputType.TYPE_CLASS_TEXT)
-                .input(R.string.hint_new_folder, 0, false, new MaterialDialog.InputCallback() {
+        View inputView = LayoutInflater.from(this).inflate(R.layout.dialog_input, null);
+        final EditText inputEditText = inputView.findViewById(R.id.dialog_input_edit_text);
+        inputEditText.setHint(R.string.hint_new_folder);
+        inputEditText.setInputType(InputType.TYPE_CLASS_TEXT);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(this)
+                .setTitle(R.string.title_backend_create_folder)
+                .setMessage(R.string.message_backend_create_folder)
+                .setView(inputView)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Intent intent = new Intent(BackendExplorerActivity.this, BackendHandlerIntentService.class);
                         intent.putExtra(BackendHandlerIntentService.BACKEND_ID, mBackendId);
                         intent.putExtra(BackendHandlerIntentService.ACTION, BackendHandlerIntentService.ACTION_CREATE_FOLDER);
                         intent.putExtra(BackendHandlerIntentService.PARENT_FOLDER, getCurrentFolder());
-                        intent.putExtra(BackendHandlerIntentService.FOLDER_NAME, input.toString());
+                        intent.putExtra(BackendHandlerIntentService.FOLDER_NAME, inputEditText.getText().toString());
                         startService(intent);
                     }
 
                 })
-                .show();
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
+        ThemedDialog.showWithInput(dialog, inputEditText, false);
     }
 
     private BroadcastReceiver mLocalBroadcastReceiver = new BroadcastReceiver() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/BackupListActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/BackupListActivity.java
@@ -22,18 +22,16 @@ package com.oriondev.moneywallet.ui.activity;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.appcompat.widget.Toolbar;
 import android.view.View;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.service.BackupHandlerIntentService;
@@ -183,13 +181,12 @@ public class BackupListActivity extends BaseActivity implements ToolbarControlle
                                 return;
                         }
                         ThemedDialog.buildMaterialDialog(BackupListActivity.this)
-                                .title(titleRes)
-                                .content(messageRes)
-                                .positiveText(android.R.string.ok)
-                                .onAny(new MaterialDialog.SingleButtonCallback() {
+                                .setTitle(titleRes)
+                                .setMessage(messageRes)
+                                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                                     @Override
-                                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                                    public void onClick(DialogInterface dialog, int which) {
                                         Intent intent = getIntent();
                                         if (intent != null) {
                                             int mode = intent.getIntExtra(BACKUP_MODE, FULL);
@@ -225,9 +222,9 @@ public class BackupListActivity extends BaseActivity implements ToolbarControlle
                                 return;
                         }
                         ThemedDialog.buildMaterialDialog(BackupListActivity.this)
-                                .title(titleRes)
-                                .content(messageString)
-                                .positiveText(android.R.string.ok)
+                                .setTitle(titleRes)
+                                .setMessage(messageString)
+                                .setPositiveButton(android.R.string.ok, null)
                                 .show();
                         break;
                 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/CalculatorActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/CalculatorActivity.java
@@ -180,9 +180,9 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
             // the display so it can be corrected.
             if (money < 0 && !mAllowNegative) {
                 ThemedDialog.buildMaterialDialog(this)
-                        .title(R.string.title_error)
-                        .content(R.string.message_error_negative_amount)
-                        .positiveText(android.R.string.ok)
+                        .setTitle(R.string.title_error)
+                        .setMessage(R.string.message_error_negative_amount)
+                        .setPositiveButton(android.R.string.ok, null)
                         .show();
                 return;
             }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/ImportExportActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/ImportExportActivity.java
@@ -3,6 +3,7 @@ package com.oriondev.moneywallet.ui.activity;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
@@ -26,8 +27,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.DataFormat;
@@ -447,18 +446,17 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
         if (itemId == R.id.action_import_data) {
             if (mImportFormatEditText.validate() && mImportFileEditText.validate()) {
                 ThemedDialog.buildMaterialDialog(this)
-                        .title(R.string.title_warning)
-                        .content(R.string.message_data_import_without_backup)
-                        .positiveText(android.R.string.ok)
-                        .negativeText(android.R.string.cancel)
-                        .onPositive(new MaterialDialog.SingleButtonCallback() {
+                        .setTitle(R.string.title_warning)
+                        .setMessage(R.string.message_data_import_without_backup)
+                        .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                             @Override
-                            public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                            public void onClick(DialogInterface dialog, int which) {
                                 importData();
                             }
 
                         })
+                        .setNegativeButton(android.R.string.cancel, null)
                         .show();
             }
         } else if (itemId == R.id.action_export_data) {
@@ -523,9 +521,9 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
             mImportFile = null;
             mImportFileEditText.setText(null);
             ThemedDialog.buildMaterialDialog(this)
-                    .title(R.string.title_failed)
-                    .content(R.string.message_data_import_failed, e.getMessage())
-                    .positiveText(android.R.string.ok)
+                    .setTitle(R.string.title_failed)
+                    .setMessage(getString(R.string.message_data_import_failed, e.getMessage()))
+                    .setPositiveButton(android.R.string.ok, null)
                     .show();
         }
     }
@@ -738,11 +736,11 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                         // that too rather than leaving the user to find it in the ledger.
                         int roundedAmounts = intent.getIntExtra(ImportExportIntentService.ROUNDED_AMOUNTS, 0);
                         ThemedDialog.buildMaterialDialog(ImportExportActivity.this)
-                                .title(R.string.title_success)
-                                .content(roundedAmounts > 0
+                                .setTitle(R.string.title_success)
+                                .setMessage(roundedAmounts > 0
                                         ? getString(R.string.message_data_import_success_rounded, roundedAmounts)
                                         : getString(R.string.message_data_import_success))
-                                .positiveText(android.R.string.ok)
+                                .setPositiveButton(android.R.string.ok, null)
                                 .show();
                         break;
                     case LocalAction.ACTION_IMPORT_SERVICE_FAILED:
@@ -752,9 +750,9 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                         }
                         Exception exception = (Exception) intent.getSerializableExtra(ImportExportIntentService.EXCEPTION);
                         ThemedDialog.buildMaterialDialog(ImportExportActivity.this)
-                                .title(R.string.title_failed)
-                                .content(R.string.message_data_import_failed, exception.getMessage())
-                                .positiveText(android.R.string.ok)
+                                .setTitle(R.string.title_failed)
+                                .setMessage(getString(R.string.message_data_import_failed, exception.getMessage()))
+                                .setPositiveButton(android.R.string.ok, null)
                                 .show();
                         break;
                     case LocalAction.ACTION_EXPORT_SERVICE_STARTED:
@@ -774,21 +772,19 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                             saveExportToSelectedFolder(resultUri, resultType);
                         } catch (IOException e) {
                             ThemedDialog.buildMaterialDialog(ImportExportActivity.this)
-                                    .title(R.string.title_failed)
-                                    .content(R.string.message_data_export_failed, e.getMessage())
-                                    .positiveText(android.R.string.ok)
+                                    .setTitle(R.string.title_failed)
+                                    .setMessage(getString(R.string.message_data_export_failed, e.getMessage()))
+                                    .setPositiveButton(android.R.string.ok, null)
                                     .show();
                             break;
                         }
                         ThemedDialog.buildMaterialDialog(ImportExportActivity.this)
-                                .title(R.string.title_success)
-                                .content(R.string.message_data_export_success)
-                                .positiveText(android.R.string.ok)
-                                .negativeText(android.R.string.cancel)
-                                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                                .setTitle(R.string.title_success)
+                                .setMessage(R.string.message_data_export_success)
+                                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                                     @Override
-                                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                                    public void onClick(DialogInterface dialog, int which) {
                                         if (resultUri != null) {
                                             Intent target = new Intent(Intent.ACTION_VIEW);
                                             target.setDataAndType(resultUri, resultType);
@@ -804,6 +800,7 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                                     }
 
                                 })
+                                .setNegativeButton(android.R.string.cancel, null)
                                 .show();
                         break;
                     case LocalAction.ACTION_EXPORT_SERVICE_FAILED:
@@ -813,9 +810,9 @@ public class ImportExportActivity extends SinglePanelActivity implements ImportE
                         }
                         exception = (Exception) intent.getSerializableExtra(ImportExportIntentService.EXCEPTION);
                         ThemedDialog.buildMaterialDialog(ImportExportActivity.this)
-                                .title(R.string.title_failed)
-                                .content(R.string.message_data_export_failed, exception.getMessage())
-                                .positiveText(android.R.string.ok)
+                                .setTitle(R.string.title_failed)
+                                .setMessage(getString(R.string.message_data_export_failed, exception.getMessage()))
+                                .setPositiveButton(android.R.string.ok, null)
                                 .show();
                         break;
                 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/LauncherActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/LauncherActivity.java
@@ -21,6 +21,7 @@ package com.oriondev.moneywallet.ui.activity;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
@@ -33,8 +34,6 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.view.View;
 import android.widget.Button;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.service.UpgradeLegacyEditionIntentService;
@@ -206,19 +205,20 @@ public class LauncherActivity extends ThemedActivity {
         if (mProgressWheel != null) {
             mProgressWheel.setVisibility(View.INVISIBLE);
         }
+        // both buttons do the same thing, as the onAny callback this replaces did
+        DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                startMainActivity();
+            }
+
+        };
         ThemedDialog.buildMaterialDialog(LauncherActivity.this)
-                .title(R.string.title_failed)
-                .content(R.string.message_error_legacy_upgrade_failed, mUpgradeLegacyEditionError)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onAny(new MaterialDialog.SingleButtonCallback() {
-
-                    @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                        startMainActivity();
-                    }
-
-                })
+                .setTitle(R.string.title_failed)
+                .setMessage(getString(R.string.message_error_legacy_upgrade_failed, mUpgradeLegacyEditionError))
+                .setPositiveButton(android.R.string.ok, listener)
+                .setNegativeButton(android.R.string.cancel, listener)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
@@ -22,6 +22,7 @@ package com.oriondev.moneywallet.ui.activity;
 import android.content.ActivityNotFoundException;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.ColorStateList;
@@ -34,10 +35,13 @@ import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.StateListDrawable;
 import android.net.Uri;
 import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.widget.EditText;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBarDrawerToggle;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.GravityCompat;
@@ -57,7 +61,6 @@ import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.google.android.material.navigation.NavigationView;
 import com.google.android.material.shape.MaterialShapeDrawable;
 import com.oriondev.moneywallet.R;
@@ -428,13 +431,17 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
     }
 
     private void showAtmSearchDialog() {
-        ThemedDialog.buildMaterialDialog(this)
-                .title(R.string.title_atm_search)
-                .input(R.string.hint_atm_name, 0, false, new MaterialDialog.InputCallback() {
+        View inputView = LayoutInflater.from(this).inflate(R.layout.dialog_input, null);
+        final EditText inputEditText = inputView.findViewById(R.id.dialog_input_edit_text);
+        inputEditText.setHint(R.string.hint_atm_name);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(this)
+                .setTitle(R.string.title_atm_search)
+                .setView(inputView)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
-                        Uri mapUri = Uri.parse("geo:0,0?q=atm " + input);
+                    public void onClick(DialogInterface dialog, int which) {
+                        Uri mapUri = Uri.parse("geo:0,0?q=atm " + inputEditText.getText());
                         Intent mapIntent = new Intent(Intent.ACTION_VIEW, mapUri);
                         try {
                             startActivity(mapIntent);
@@ -443,17 +450,23 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
                         }
                     }
 
-                }).show();
+                })
+                .create();
+        ThemedDialog.showWithInput(dialog, inputEditText, false);
     }
 
     private void showBankSearchDialog() {
-        ThemedDialog.buildMaterialDialog(this)
-                .title(R.string.title_bank_search)
-                .input(R.string.hint_bank_name, 0, false, new MaterialDialog.InputCallback() {
+        View inputView = LayoutInflater.from(this).inflate(R.layout.dialog_input, null);
+        final EditText inputEditText = inputView.findViewById(R.id.dialog_input_edit_text);
+        inputEditText.setHint(R.string.hint_bank_name);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(this)
+                .setTitle(R.string.title_bank_search)
+                .setView(inputView)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
-                        Uri mapUri = Uri.parse("geo:0,0?q=bank " + input);
+                    public void onClick(DialogInterface dialog, int which) {
+                        Uri mapUri = Uri.parse("geo:0,0?q=bank " + inputEditText.getText());
                         Intent mapIntent = new Intent(Intent.ACTION_VIEW, mapUri);
                         try {
                             startActivity(mapIntent);
@@ -462,14 +475,16 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
                         }
                     }
 
-                }).show();
+                })
+                .create();
+        ThemedDialog.showWithInput(dialog, inputEditText, false);
     }
 
     private void showActivityNotFoundDialog() {
         ThemedDialog.buildMaterialDialog(this)
-                .title(R.string.title_error)
-                .content(R.string.message_error_activity_not_found)
-                .positiveText(android.R.string.ok)
+                .setTitle(R.string.title_error)
+                .setMessage(R.string.message_error_activity_not_found)
+                .setPositiveButton(android.R.string.ok, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivity.java
@@ -858,9 +858,9 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
                 // budget is history now. Writing a schedule onto it would put a second one on the
                 // chain, and every period after this would open twice.
                 ThemedDialog.buildMaterialDialog(this)
-                        .title(R.string.title_warning)
-                        .content(R.string.message_budget_period_superseded)
-                        .positiveText(android.R.string.ok)
+                        .setTitle(R.string.title_warning)
+                        .setMessage(R.string.message_budget_period_superseded)
+                        .setPositiveButton(android.R.string.ok, null)
                         .show();
                 return;
             }
@@ -903,9 +903,9 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
                 }
                 if (contentRes != 0) {
                     ThemedDialog.buildMaterialDialog(this)
-                            .title(R.string.title_error)
-                            .content(contentRes)
-                            .positiveText(android.R.string.ok)
+                            .setTitle(R.string.title_error)
+                            .setMessage(contentRes)
+                            .setPositiveButton(android.R.string.ok, null)
                             .show();
                 }
             }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditCategoryActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditCategoryActivity.java
@@ -276,9 +276,9 @@ public class NewEditCategoryActivity extends NewEditItemActivity implements Icon
                         }
                         if (contentRes != 0) {
                             ThemedDialog.buildMaterialDialog(this)
-                                    .title(R.string.title_error)
-                                    .content(contentRes)
-                                    .positiveText(android.R.string.ok)
+                                    .setTitle(R.string.title_error)
+                                    .setMessage(contentRes)
+                                    .setPositiveButton(android.R.string.ok, null)
                                     .show();
                         }
                     }
@@ -301,9 +301,9 @@ public class NewEditCategoryActivity extends NewEditItemActivity implements Icon
                         }
                         if (contentRes != 0) {
                             ThemedDialog.buildMaterialDialog(this)
-                                    .title(R.string.title_error)
-                                    .content(contentRes)
-                                    .positiveText(android.R.string.ok)
+                                    .setTitle(R.string.title_error)
+                                    .setMessage(contentRes)
+                                    .setPositiveButton(android.R.string.ok, null)
                                     .show();
                         }
                     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditCurrencyActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditCurrencyActivity.java
@@ -3,6 +3,7 @@ package com.oriondev.moneywallet.ui.activity;
 import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentValues;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -18,8 +19,7 @@ import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.MoneyScale;
@@ -201,18 +201,17 @@ public class NewEditCurrencyActivity extends SinglePanelScrollActivity {
             onSaveChanges();
         } else if (itemId == R.id.action_delete_item) {
             ThemedDialog.buildMaterialDialog(this)
-                    .title(R.string.title_warning)
-                    .content(R.string.message_delete_currency)
-                    .positiveText(android.R.string.ok)
-                    .negativeText(android.R.string.cancel)
-                    .onPositive(new MaterialDialog.SingleButtonCallback() {
+                    .setTitle(R.string.title_warning)
+                    .setMessage(R.string.message_delete_currency)
+                    .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                         @Override
-                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        public void onClick(DialogInterface dialog, int which) {
                             onDelete();
                         }
 
                     })
+                    .setNegativeButton(android.R.string.cancel, null)
                     .show();
         }
         return false;
@@ -242,15 +241,12 @@ public class NewEditCurrencyActivity extends SinglePanelScrollActivity {
                     if (currencyUnit != null) {
                         final Uri uri = Uri.withAppendedPath(DataContentProvider.CONTENT_CURRENCIES, mIso);
                         if (currencyUnit.getDecimals() != decimalCount) {
-                            MaterialDialog.Builder builder = ThemedDialog.buildMaterialDialog(this)
-                                    .title(R.string.title_warning)
-                                    .positiveText(android.R.string.ok)
-                                    .negativeText(android.R.string.cancel)
-                                    .neutralText(R.string.action_skip)
-                                    .onPositive(new MaterialDialog.SingleButtonCallback() {
+                            MaterialAlertDialogBuilder builder = ThemedDialog.buildMaterialDialog(this)
+                                    .setTitle(R.string.title_warning)
+                                    .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                                         @Override
-                                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                                        public void onClick(DialogInterface dialog, int which) {
                                             contentValues.put(Contract.Currency.FIX_MONEY_DECIMALS, true);
                                             contentResolver.update(uri, contentValues, null, null);
                                             CurrencyManager.invalidateCache(NewEditCurrencyActivity.this);
@@ -259,10 +255,11 @@ public class NewEditCurrencyActivity extends SinglePanelScrollActivity {
                                         }
 
                                     })
-                                    .onNeutral(new MaterialDialog.SingleButtonCallback() {
+                                    .setNegativeButton(android.R.string.cancel, null)
+                                    .setNeutralButton(R.string.action_skip, new DialogInterface.OnClickListener() {
 
                                         @Override
-                                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                                        public void onClick(DialogInterface dialog, int which) {
                                             contentValues.put(Contract.Currency.FIX_MONEY_DECIMALS, false);
                                             contentResolver.update(uri, contentValues, null, null);
                                             CurrencyManager.invalidateCache(NewEditCurrencyActivity.this);
@@ -275,12 +272,12 @@ public class NewEditCurrencyActivity extends SinglePanelScrollActivity {
                                 // in this case we have to multiply the current values
                                 int exponent = decimalCount - currencyUnit.getDecimals();
                                 int multiplier = (int) MoneyScale.rescale(1L, exponent);
-                                builder.content(R.string.message_multiply_currency_decimals, multiplier);
+                                builder.setMessage(getString(R.string.message_multiply_currency_decimals, multiplier));
                             } else {
                                 // in this case we have to divide the current values
                                 int exponent = currencyUnit.getDecimals() - decimalCount;
                                 int divider = (int) MoneyScale.rescale(1L, exponent);
-                                builder.content(R.string.message_divide_currency_decimals, divider);
+                                builder.setMessage(getString(R.string.message_divide_currency_decimals, divider));
                             }
                             builder.show();
                             return;
@@ -309,9 +306,9 @@ public class NewEditCurrencyActivity extends SinglePanelScrollActivity {
             } catch (SQLiteDataException e) {
                 if (e.getErrorCode() == Contract.ErrorCode.CURRENCY_IN_USE) {
                     ThemedDialog.buildMaterialDialog(this)
-                            .title(R.string.title_error)
-                            .content(R.string.message_error_delete_currency)
-                            .positiveText(android.R.string.ok)
+                            .setTitle(R.string.title_error)
+                            .setMessage(R.string.message_error_delete_currency)
+                            .setPositiveButton(android.R.string.ok, null)
                             .show();
                 }
             }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditDebtActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditDebtActivity.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
+import android.content.DialogInterface;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -34,8 +35,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
@@ -425,21 +424,23 @@ public class NewEditDebtActivity extends NewEditItemActivity implements IconPick
     protected void onSaveChanges(final Mode mode) {
         if (validate()) {
             if (mode == Mode.NEW_ITEM) {
+                // yes and no both save, and the answer only decides whether a master transaction
+                // comes with it, as the onAny callback this replaces did
+                DialogInterface.OnClickListener listener = new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        updateDatabase(mode, which == DialogInterface.BUTTON_POSITIVE);
+                        setResult(Activity.RESULT_OK);
+                        finish();
+                    }
+
+                };
                 ThemedDialog.buildMaterialDialog(this)
-                        .title(R.string.title_debt_insert_master_transaction)
-                        .content(R.string.message_debt_insert_master_transaction)
-                        .positiveText(android.R.string.yes)
-                        .negativeText(android.R.string.no)
-                        .onAny(new MaterialDialog.SingleButtonCallback() {
-
-                            @Override
-                            public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                                updateDatabase(mode, which == DialogAction.POSITIVE);
-                                setResult(Activity.RESULT_OK);
-                                finish();
-                            }
-
-                        })
+                        .setTitle(R.string.title_debt_insert_master_transaction)
+                        .setMessage(R.string.message_debt_insert_master_transaction)
+                        .setPositiveButton(android.R.string.yes, listener)
+                        .setNegativeButton(android.R.string.no, listener)
                         .show();
             } else {
                 updateDatabase(mode, false);
@@ -478,9 +479,9 @@ public class NewEditDebtActivity extends NewEditItemActivity implements IconPick
                 throw e;
             }
             ThemedDialog.buildMaterialDialog(this)
-                    .title(R.string.title_error)
-                    .content(R.string.error_wallet_currency_not_consistent)
-                    .positiveText(android.R.string.ok)
+                    .setTitle(R.string.title_error)
+                    .setMessage(R.string.error_wallet_currency_not_consistent)
+                    .setPositiveButton(android.R.string.ok, null)
                     .show();
             return;
         }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditSavingActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditSavingActivity.java
@@ -317,9 +317,9 @@ public class NewEditSavingActivity extends NewEditItemActivity implements IconPi
                     throw e;
                 }
                 ThemedDialog.buildMaterialDialog(this)
-                        .title(R.string.title_error)
-                        .content(R.string.error_wallet_currency_not_consistent)
-                        .positiveText(android.R.string.ok)
+                        .setTitle(R.string.title_error)
+                        .setMessage(R.string.error_wallet_currency_not_consistent)
+                        .setPositiveButton(android.R.string.ok, null)
                         .show();
                 return;
             }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivity.java
@@ -1140,9 +1140,9 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
         String message = getString(R.string.error_saving_withdraw_over_balance,
                 mMoneyFormatter.getNotTintedString(currency, limit));
         ThemedDialog.buildMaterialDialog(this)
-                .title(R.string.title_error)
-                .content(message)
-                .positiveText(android.R.string.ok)
+                .setTitle(R.string.title_error)
+                .setMessage(message)
+                .setPositiveButton(android.R.string.ok, null)
                 .show();
         return false;
     }
@@ -1187,9 +1187,9 @@ public class NewEditTransactionActivity extends NewEditItemActivity implements M
                     throw e;
                 }
                 ThemedDialog.buildMaterialDialog(this)
-                        .title(R.string.title_error)
-                        .content(R.string.error_debt_wallet_currency_not_consistent)
-                        .positiveText(android.R.string.ok)
+                        .setTitle(R.string.title_error)
+                        .setMessage(R.string.error_debt_wallet_currency_not_consistent)
+                        .setPositiveButton(android.R.string.ok, null)
                         .show();
                 return;
             }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditTransferActivity.java
@@ -839,9 +839,9 @@ public class NewEditTransferActivity extends NewEditItemActivity  implements Cur
             startActivity(attachment.getActionViewIntent(this));
         } catch (ActivityNotFoundException e) {
             ThemedDialog.buildMaterialDialog(this)
-                    .title(R.string.title_error)
-                    .content(R.string.message_error_activity_not_found)
-                    .positiveText(android.R.string.ok)
+                    .setTitle(R.string.title_error)
+                    .setMessage(R.string.message_error_activity_not_found)
+                    .setPositiveButton(android.R.string.ok, null)
                     .show();
         }
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/AutoBackupSettingDialog.java
@@ -25,6 +25,7 @@ import android.app.Dialog;
 import android.content.Intent;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.core.app.ActivityCompat;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
@@ -37,8 +38,6 @@ import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.BackendServiceFactory;
 import com.oriondev.moneywallet.broadcast.AutoBackupBroadcastReceiver;
@@ -89,99 +88,98 @@ public class AutoBackupSettingDialog extends DialogFragment {
             mBackendId = savedInstanceState.getString(SS_BACKEND_ID);
             mFolder = savedInstanceState.getParcelable(SS_FOLDER);
         }
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_auto_backup_title)
-                .customView(R.layout.dialog_auto_backup_setting, true)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                // OK does not close the dialog by itself, so a setting it refuses to save leaves
-                // the rest of what was typed on screen. Tapping outside and the back button are
-                // not affected and still cancel.
-                .autoDismiss(false)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = ThemedDialog.inflateScrollableView(activity, R.layout.dialog_auto_backup_setting);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_auto_backup_title)
+                .setView(view)
+                .setPositiveButton(android.R.string.ok, null)
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
+        mServiceEnabledSwitchCompat = view.findViewById(R.id.auto_backup_enable_switch);
+        mOnlyWiFiCheckBox = view.findViewById(R.id.auto_backup_wifi_check_box);
+        mOnlyDataChangedCheckBox = view.findViewById(R.id.auto_backup_data_change_check_box);
+        mOffsetTextView = view.findViewById(R.id.auto_backup_offset_text_view);
+        mOffsetSeekBar = view.findViewById(R.id.auto_backup_offset_seek_bar);
+        mFolderTextView = view.findViewById(R.id.auto_backup_folder_text_view);
+        mFailureTextView = view.findViewById(R.id.auto_backup_failure_text_view);
+        mPasswordEditText = view.findViewById(R.id.auto_backup_password_edit_text);
+        // set listeners
+        mOffsetSeekBar.setMax((OFFSET_MAX_HOURS - OFFSET_MIN_HOURS) / OFFSET_BETWEEN_HOURS);
+        mOffsetSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
 
-                    @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                        if (onSaveSetting()) {
-                            dialog.dismiss();
-                        }
-                    }
-
-                })
-                .onNegative(new MaterialDialog.SingleButtonCallback() {
-
-                    @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
-                        dialog.dismiss();
-                    }
-
-                })
-                .build();
-        View view = dialog.getCustomView();
-        if (view != null) {
-            mServiceEnabledSwitchCompat = view.findViewById(R.id.auto_backup_enable_switch);
-            mOnlyWiFiCheckBox = view.findViewById(R.id.auto_backup_wifi_check_box);
-            mOnlyDataChangedCheckBox = view.findViewById(R.id.auto_backup_data_change_check_box);
-            mOffsetTextView = view.findViewById(R.id.auto_backup_offset_text_view);
-            mOffsetSeekBar = view.findViewById(R.id.auto_backup_offset_seek_bar);
-            mFolderTextView = view.findViewById(R.id.auto_backup_folder_text_view);
-            mFailureTextView = view.findViewById(R.id.auto_backup_failure_text_view);
-            mPasswordEditText = view.findViewById(R.id.auto_backup_password_edit_text);
-            // set listeners
-            mOffsetSeekBar.setMax((OFFSET_MAX_HOURS - OFFSET_MIN_HOURS) / OFFSET_BETWEEN_HOURS);
-            mOffsetSeekBar.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
-
-                @Override
-                public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-                    AutoBackupSettingDialog.this.onProgressChanged(progress);
-                }
-
-                @Override
-                public void onStartTrackingTouch(SeekBar seekBar) {
-                    // not used
-                }
-
-                @Override
-                public void onStopTrackingTouch(SeekBar seekBar) {
-                    // not used
-                }
-
-            });
-            mServiceEnabledSwitchCompat.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-
-                @Override
-                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                    AutoBackupSettingDialog.this.onServiceEnabledChanged();
-                }
-
-            });
-            mFolderTextView.setOnClickListener(new View.OnClickListener() {
-
-                @Override
-                public void onClick(View v) {
-                    Activity activity = getActivity();
-                    if (activity != null) {
-                        Intent intent = new Intent(activity, BackendExplorerActivity.class);
-                        intent.putExtra(BackendExplorerActivity.BACKEND_ID, mBackendId);
-                        intent.putExtra(BackendExplorerActivity.MODE, BackendExplorerActivity.MODE_FOLDER_PICKER);
-                        startActivityForResult(intent, REQUEST_CODE_FOLDER_PICKER);
-                    }
-                }
-
-            });
-            if (savedInstanceState == null) {
-                mServiceEnabledSwitchCompat.setChecked(BackendManager.isAutoBackupEnabled(mBackendId));
-                mOnlyWiFiCheckBox.setChecked(BackendManager.isAutoBackupOnWiFiOnly(mBackendId));
-                mOnlyDataChangedCheckBox.setChecked(BackendManager.isAutoBackupWhenDataIsChangedOnly(mBackendId));
-                mOffsetSeekBar.setProgress((BackendManager.getAutoBackupHoursOffset(mBackendId) - OFFSET_MIN_HOURS) / OFFSET_BETWEEN_HOURS);
-                mFolder = BackendServiceFactory.getFile(mBackendId, BackendManager.getAutoBackupFolder(mBackendId));
-                mPasswordEditText.setText(BackendManager.getAutoBackupPassword(mBackendId));
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                AutoBackupSettingDialog.this.onProgressChanged(progress);
             }
-            onProgressChanged(mOffsetSeekBar.getProgress());
-            onFolderChanged();
-            onServiceEnabledChanged();
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {
+                // not used
+            }
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {
+                // not used
+            }
+
+        });
+        mServiceEnabledSwitchCompat.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                AutoBackupSettingDialog.this.onServiceEnabledChanged();
+            }
+
+        });
+        mFolderTextView.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                Activity activity = getActivity();
+                if (activity != null) {
+                    Intent intent = new Intent(activity, BackendExplorerActivity.class);
+                    intent.putExtra(BackendExplorerActivity.BACKEND_ID, mBackendId);
+                    intent.putExtra(BackendExplorerActivity.MODE, BackendExplorerActivity.MODE_FOLDER_PICKER);
+                    startActivityForResult(intent, REQUEST_CODE_FOLDER_PICKER);
+                }
+            }
+
+        });
+        if (savedInstanceState == null) {
+            mServiceEnabledSwitchCompat.setChecked(BackendManager.isAutoBackupEnabled(mBackendId));
+            mOnlyWiFiCheckBox.setChecked(BackendManager.isAutoBackupOnWiFiOnly(mBackendId));
+            mOnlyDataChangedCheckBox.setChecked(BackendManager.isAutoBackupWhenDataIsChangedOnly(mBackendId));
+            mOffsetSeekBar.setProgress((BackendManager.getAutoBackupHoursOffset(mBackendId) - OFFSET_MIN_HOURS) / OFFSET_BETWEEN_HOURS);
+            mFolder = BackendServiceFactory.getFile(mBackendId, BackendManager.getAutoBackupFolder(mBackendId));
+            mPasswordEditText.setText(BackendManager.getAutoBackupPassword(mBackendId));
         }
+        onProgressChanged(mOffsetSeekBar.getProgress());
+        onFolderChanged();
+        onServiceEnabledChanged();
         return dialog;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        final AlertDialog dialog = (AlertDialog) getDialog();
+        if (dialog == null) {
+            return;
+        }
+        // OK does not close the dialog by itself, so a setting it refuses to save leaves the rest
+        // of what was typed on screen. Replacing the listener on the button is what drops the
+        // dismiss that comes with it, and the button only exists once the dialog has been shown.
+        // Tapping outside and the back button are not affected and still cancel.
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                if (onSaveSetting()) {
+                    dialog.dismiss();
+                }
+            }
+
+        });
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/BudgetTypePickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/BudgetTypePickerDialog.java
@@ -26,6 +26,8 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.ui.adapter.recycler.BudgetTypeSelectorAdapter;
@@ -55,9 +57,12 @@ public class BudgetTypePickerDialog extends DialogFragment implements BudgetType
         if (savedInstanceState != null) {
             mBudgetType = (Contract.BudgetType) savedInstanceState.getSerializable(SS_SELECTED_BUDGET_TYPE);
         }
+        RecyclerView recyclerView = (RecyclerView) getLayoutInflater().inflate(R.layout.dialog_recycler_view, null);
+        recyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        recyclerView.setAdapter(new BudgetTypeSelectorAdapter(this));
         return ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_budget_type_picker_title)
-                .adapter(new BudgetTypeSelectorAdapter(this), null)
+                .setTitle(R.string.dialog_budget_type_picker_title)
+                .setView(recyclerView)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ChangeLogDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ChangeLogDialog.java
@@ -29,7 +29,8 @@ import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.background.ChangeLogLoader;
 import com.oriondev.moneywallet.model.ChangeLog;
@@ -65,12 +66,15 @@ public class ChangeLogDialog extends DialogFragment implements LoaderManager.Loa
             return super.onCreateDialog(savedInstanceState);
         }
         mAdapter = new ChangeLogAdapter();
-        MaterialDialog.Builder builder = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_change_log_title)
-                .positiveText(android.R.string.ok)
-                .adapter(mAdapter, new LinearLayoutManager(activity));
+        RecyclerView recyclerView = (RecyclerView) getLayoutInflater().inflate(R.layout.dialog_recycler_view, null);
+        recyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        recyclerView.setAdapter(mAdapter);
+        MaterialAlertDialogBuilder builder = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_change_log_title)
+                .setPositiveButton(android.R.string.ok, null)
+                .setView(recyclerView);
         LoaderManager.getInstance(this).restartLoader(LOADER_ID, null, this);
-        return builder.build();
+        return builder.create();
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorChooserDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorChooserDialog.java
@@ -1,0 +1,344 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.fragment.dialog;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.TextWatcher;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.EditText;
+import android.widget.GridView;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.view.ColorSwatchView;
+import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+
+import java.util.Locale;
+
+/**
+ * The app's color chooser, replacing the one material-dialogs provided. The palette is the same
+ * one, in ColorPalette; the two levels and the drill in are the same behavior. What it drops is
+ * the alpha channel, the RGB sliders and the Custom/Presets toggle, and in their place the hex
+ * field is on both levels and is the only way to reach a color the palette does not carry.
+ */
+public class ColorChooserDialog extends DialogFragment {
+
+    private static final String ARG_TITLE = "ColorChooserDialog::Arguments::Title";
+    private static final String ARG_ACCENT_PALETTE = "ColorChooserDialog::Arguments::AccentPalette";
+    private static final String ARG_PRESELECT_COLOR = "ColorChooserDialog::Arguments::PreselectColor";
+
+    private static final String SS_IN_SHADE_LEVEL = "ColorChooserDialog::SavedState::InShadeLevel";
+    private static final String SS_HUE_INDEX = "ColorChooserDialog::SavedState::HueIndex";
+    private static final String SS_SHADE_INDEX = "ColorChooserDialog::SavedState::ShadeIndex";
+    private static final String SS_SELECTED_COLOR = "ColorChooserDialog::SavedState::SelectedColor";
+
+    private static final int HEX_DIGITS = 6;
+
+    public static ColorChooserDialog newInstance(@StringRes int title, boolean accentPalette, @ColorInt int preselectColor) {
+        ColorChooserDialog dialog = new ColorChooserDialog();
+        Bundle arguments = new Bundle();
+        arguments.putInt(ARG_TITLE, title);
+        arguments.putBoolean(ARG_ACCENT_PALETTE, accentPalette);
+        arguments.putInt(ARG_PRESELECT_COLOR, preselectColor);
+        dialog.setArguments(arguments);
+        return dialog;
+    }
+
+    private Callback mCallback;
+
+    private int[] mHues;
+    private int[][] mShades;
+
+    private boolean mInShadeLevel;
+    private int mHueIndex;
+    private int mShadeIndex;
+    private int mSelectedColor;
+
+    private GridView mGridView;
+    private EditText mHexEditText;
+    private ColorSwatchView mPreviewView;
+
+    @Override
+    public void onAttach(@NonNull Context context) {
+        super.onAttach(context);
+        Fragment parent = getParentFragment();
+        if (!(parent instanceof Callback)) {
+            throw new IllegalStateException("ColorChooserDialog must be shown from a parent fragment implementing Callback");
+        }
+        mCallback = (Callback) parent;
+    }
+
+    @Override
+    @NonNull
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        Bundle arguments = getArguments();
+        boolean accentPalette = arguments != null && arguments.getBoolean(ARG_ACCENT_PALETTE);
+        mHues = accentPalette ? ColorPalette.ACCENT_COLORS : ColorPalette.PRIMARY_COLORS;
+        mShades = accentPalette ? ColorPalette.ACCENT_COLORS_SUB : ColorPalette.PRIMARY_COLORS_SUB;
+        if (savedInstanceState != null) {
+            mInShadeLevel = savedInstanceState.getBoolean(SS_IN_SHADE_LEVEL);
+            mHueIndex = savedInstanceState.getInt(SS_HUE_INDEX);
+            mShadeIndex = savedInstanceState.getInt(SS_SHADE_INDEX);
+            mSelectedColor = savedInstanceState.getInt(SS_SELECTED_COLOR);
+        } else {
+            mSelectedColor = 0xFF000000 | (arguments != null ? arguments.getInt(ARG_PRESELECT_COLOR) : Color.BLACK);
+            findPreselect(mSelectedColor);
+        }
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(requireActivity())
+                .setTitle(arguments != null ? arguments.getInt(ARG_TITLE) : R.string.dialog_color_picker_title)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface unused, int which) {
+                        mCallback.onColorSelection(ColorChooserDialog.this, mSelectedColor);
+                        dismiss();
+                    }
+
+                })
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
+        // The dialog's own context carries the light or dark dialog theme the factory picked, so
+        // the layout's theme attributes have to resolve against it and not against the activity.
+        // This is the same clone DialogFragment makes for a dialog it inflates a content view for,
+        // and it has to be made by hand here because getLayoutInflater() hands back the plain
+        // activity inflater while onCreateDialog is still running.
+        View view = getLayoutInflater().cloneInContext(dialog.getContext())
+                .inflate(R.layout.dialog_color_chooser, null);
+        mGridView = view.findViewById(R.id.color_chooser_grid_view);
+        mHexEditText = view.findViewById(R.id.color_chooser_hex_edit_text);
+        mPreviewView = view.findViewById(R.id.color_chooser_preview_view);
+        mGridView.setAdapter(new SwatchAdapter());
+        mHexEditText.setFilters(new InputFilter[] {new InputFilter.LengthFilter(HEX_DIGITS)});
+        ThemedDialog.tintInput(mHexEditText);
+        mHexEditText.addTextChangedListener(new TextWatcher() {
+
+            @Override
+            public void beforeTextChanged(CharSequence text, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence text, int start, int before, int count) {
+                onHexTyped(text.toString());
+            }
+
+            @Override
+            public void afterTextChanged(Editable text) {}
+
+        });
+        writeHex(mSelectedColor);
+        mPreviewView.setColor(mSelectedColor);
+        dialog.setView(view);
+        return dialog;
+    }
+
+    @Override
+    public void onStart() {
+        super.onStart();
+        final AlertDialog dialog = (AlertDialog) getDialog();
+        if (dialog == null) {
+            return;
+        }
+        // Negative is Back on the shade level, and back has to leave the dialog up, so the click
+        // that comes with the button is replaced. The button only exists once the dialog has been
+        // shown. Tapping outside and the back button still cancel.
+        dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                if (mInShadeLevel) {
+                    mInShadeLevel = false;
+                    findPreselect(mSelectedColor);
+                    invalidate();
+                } else {
+                    dialog.cancel();
+                }
+            }
+
+        });
+        invalidateNegativeButton();
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(SS_IN_SHADE_LEVEL, mInShadeLevel);
+        outState.putInt(SS_HUE_INDEX, mHueIndex);
+        outState.putInt(SS_SHADE_INDEX, mShadeIndex);
+        outState.putInt(SS_SELECTED_COLOR, mSelectedColor);
+    }
+
+    @Override
+    public void onDismiss(@NonNull DialogInterface dialog) {
+        super.onDismiss(dialog);
+        if (mCallback != null) {
+            mCallback.onColorChooserDismissed(this);
+        }
+    }
+
+    /**
+     * Points the two indices at the preselect if the palette carries it, as a hue or as one of a
+     * hue's shades, and clears them if it does not. Either way the dialog opens on the hue level,
+     * which is what the material-dialogs one did; the shade index only decides where drilling in
+     * lands.
+     */
+    private void findPreselect(@ColorInt int color) {
+        for (int hue = 0; hue < mHues.length; hue++) {
+            if (mHues[hue] == color) {
+                mHueIndex = hue;
+                mShadeIndex = findShade(hue, color);
+                return;
+            }
+            int shade = findShade(hue, color);
+            if (shade >= 0) {
+                mHueIndex = hue;
+                mShadeIndex = shade;
+                return;
+            }
+        }
+        mHueIndex = -1;
+        mShadeIndex = -1;
+    }
+
+    private int findShade(int hue, @ColorInt int color) {
+        for (int shade = 0; shade < mShades[hue].length; shade++) {
+            if (mShades[hue][shade] == color) {
+                return shade;
+            }
+        }
+        return -1;
+    }
+
+    private void onHexTyped(String text) {
+        if (text.length() != HEX_DIGITS) {
+            return;
+        }
+        try {
+            mSelectedColor = Color.parseColor("#" + text);
+        } catch (IllegalArgumentException e) {
+            return;
+        }
+        mPreviewView.setColor(mSelectedColor);
+        if (mInShadeLevel) {
+            mShadeIndex = mHueIndex >= 0 ? findShade(mHueIndex, mSelectedColor) : -1;
+        } else {
+            findPreselect(mSelectedColor);
+        }
+        ((BaseAdapter) mGridView.getAdapter()).notifyDataSetChanged();
+    }
+
+    private void writeHex(@ColorInt int color) {
+        mHexEditText.setText(String.format(Locale.US, "%06X", 0xFFFFFF & color));
+    }
+
+    private void onSwatchClicked(int position) {
+        if (mInShadeLevel) {
+            mShadeIndex = position;
+            mSelectedColor = mShades[mHueIndex][position];
+        } else {
+            // The ring on the hue level marks the family of the selected color, which may be one of
+            // that family's shades, so tapping the ringed hue drills in and keeps the color.
+            if (mHueIndex != position) {
+                mSelectedColor = mHues[position];
+                mShadeIndex = findShade(position, mSelectedColor);
+            }
+            mHueIndex = position;
+            mInShadeLevel = true;
+        }
+        writeHex(mSelectedColor);
+        mPreviewView.setColor(mSelectedColor);
+        invalidate();
+    }
+
+    private void invalidate() {
+        ((BaseAdapter) mGridView.getAdapter()).notifyDataSetChanged();
+        invalidateNegativeButton();
+    }
+
+    private void invalidateNegativeButton() {
+        AlertDialog dialog = (AlertDialog) getDialog();
+        if (dialog != null) {
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setText(mInShadeLevel ? R.string.action_back : android.R.string.cancel);
+        }
+    }
+
+    public interface Callback {
+
+        void onColorSelection(ColorChooserDialog dialog, @ColorInt int color);
+
+        void onColorChooserDismissed(ColorChooserDialog dialog);
+    }
+
+    private class SwatchAdapter extends BaseAdapter {
+
+        @Override
+        public int getCount() {
+            return mInShadeLevel ? mShades[mHueIndex].length : mHues.length;
+        }
+
+        @Override
+        public Object getItem(int position) {
+            return colorAt(position);
+        }
+
+        @Override
+        public long getItemId(int position) {
+            return position;
+        }
+
+        @ColorInt
+        private int colorAt(int position) {
+            return mInShadeLevel ? mShades[mHueIndex][position] : mHues[position];
+        }
+
+        @Override
+        public View getView(final int position, View convertView, ViewGroup parent) {
+            if (convertView == null) {
+                int size = getResources().getDimensionPixelSize(R.dimen.color_chooser_swatch_size);
+                convertView = new ColorSwatchView(parent.getContext());
+                convertView.setLayoutParams(new GridView.LayoutParams(size, size));
+            }
+            ColorSwatchView swatch = (ColorSwatchView) convertView;
+            swatch.setColor(colorAt(position));
+            swatch.setSwatchSelected(position == (mInShadeLevel ? mShadeIndex : mHueIndex));
+            swatch.setOnClickListener(new View.OnClickListener() {
+
+                @Override
+                public void onClick(View v) {
+                    onSwatchClicked(position);
+                }
+
+            });
+            return convertView;
+        }
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorPalette.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorPalette.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.fragment.dialog;
+
+import android.graphics.Color;
+
+/**
+ * The palette arrays are from material-dialogs 0.9.6.0, under the MIT license.
+ */
+class ColorPalette {
+
+    static final int[] PRIMARY_COLORS =
+        new int[] {
+          Color.parseColor("#F44336"),
+          Color.parseColor("#E91E63"),
+          Color.parseColor("#9C27B0"),
+          Color.parseColor("#673AB7"),
+          Color.parseColor("#3F51B5"),
+          Color.parseColor("#2196F3"),
+          Color.parseColor("#03A9F4"),
+          Color.parseColor("#00BCD4"),
+          Color.parseColor("#009688"),
+          Color.parseColor("#4CAF50"),
+          Color.parseColor("#8BC34A"),
+          Color.parseColor("#CDDC39"),
+          Color.parseColor("#FFEB3B"),
+          Color.parseColor("#FFC107"),
+          Color.parseColor("#FF9800"),
+          Color.parseColor("#FF5722"),
+          Color.parseColor("#795548"),
+          Color.parseColor("#9E9E9E"),
+          Color.parseColor("#607D8B")
+        };
+
+    static final int[][] PRIMARY_COLORS_SUB =
+        new int[][] {
+          new int[] {
+            Color.parseColor("#FFEBEE"),
+            Color.parseColor("#FFCDD2"),
+            Color.parseColor("#EF9A9A"),
+            Color.parseColor("#E57373"),
+            Color.parseColor("#EF5350"),
+            Color.parseColor("#F44336"),
+            Color.parseColor("#E53935"),
+            Color.parseColor("#D32F2F"),
+            Color.parseColor("#C62828"),
+            Color.parseColor("#B71C1C")
+          },
+          new int[] {
+            Color.parseColor("#FCE4EC"),
+            Color.parseColor("#F8BBD0"),
+            Color.parseColor("#F48FB1"),
+            Color.parseColor("#F06292"),
+            Color.parseColor("#EC407A"),
+            Color.parseColor("#E91E63"),
+            Color.parseColor("#D81B60"),
+            Color.parseColor("#C2185B"),
+            Color.parseColor("#AD1457"),
+            Color.parseColor("#880E4F")
+          },
+          new int[] {
+            Color.parseColor("#F3E5F5"),
+            Color.parseColor("#E1BEE7"),
+            Color.parseColor("#CE93D8"),
+            Color.parseColor("#BA68C8"),
+            Color.parseColor("#AB47BC"),
+            Color.parseColor("#9C27B0"),
+            Color.parseColor("#8E24AA"),
+            Color.parseColor("#7B1FA2"),
+            Color.parseColor("#6A1B9A"),
+            Color.parseColor("#4A148C")
+          },
+          new int[] {
+            Color.parseColor("#EDE7F6"),
+            Color.parseColor("#D1C4E9"),
+            Color.parseColor("#B39DDB"),
+            Color.parseColor("#9575CD"),
+            Color.parseColor("#7E57C2"),
+            Color.parseColor("#673AB7"),
+            Color.parseColor("#5E35B1"),
+            Color.parseColor("#512DA8"),
+            Color.parseColor("#4527A0"),
+            Color.parseColor("#311B92")
+          },
+          new int[] {
+            Color.parseColor("#E8EAF6"),
+            Color.parseColor("#C5CAE9"),
+            Color.parseColor("#9FA8DA"),
+            Color.parseColor("#7986CB"),
+            Color.parseColor("#5C6BC0"),
+            Color.parseColor("#3F51B5"),
+            Color.parseColor("#3949AB"),
+            Color.parseColor("#303F9F"),
+            Color.parseColor("#283593"),
+            Color.parseColor("#1A237E")
+          },
+          new int[] {
+            Color.parseColor("#E3F2FD"),
+            Color.parseColor("#BBDEFB"),
+            Color.parseColor("#90CAF9"),
+            Color.parseColor("#64B5F6"),
+            Color.parseColor("#42A5F5"),
+            Color.parseColor("#2196F3"),
+            Color.parseColor("#1E88E5"),
+            Color.parseColor("#1976D2"),
+            Color.parseColor("#1565C0"),
+            Color.parseColor("#0D47A1")
+          },
+          new int[] {
+            Color.parseColor("#E1F5FE"),
+            Color.parseColor("#B3E5FC"),
+            Color.parseColor("#81D4FA"),
+            Color.parseColor("#4FC3F7"),
+            Color.parseColor("#29B6F6"),
+            Color.parseColor("#03A9F4"),
+            Color.parseColor("#039BE5"),
+            Color.parseColor("#0288D1"),
+            Color.parseColor("#0277BD"),
+            Color.parseColor("#01579B")
+          },
+          new int[] {
+            Color.parseColor("#E0F7FA"),
+            Color.parseColor("#B2EBF2"),
+            Color.parseColor("#80DEEA"),
+            Color.parseColor("#4DD0E1"),
+            Color.parseColor("#26C6DA"),
+            Color.parseColor("#00BCD4"),
+            Color.parseColor("#00ACC1"),
+            Color.parseColor("#0097A7"),
+            Color.parseColor("#00838F"),
+            Color.parseColor("#006064")
+          },
+          new int[] {
+            Color.parseColor("#E0F2F1"),
+            Color.parseColor("#B2DFDB"),
+            Color.parseColor("#80CBC4"),
+            Color.parseColor("#4DB6AC"),
+            Color.parseColor("#26A69A"),
+            Color.parseColor("#009688"),
+            Color.parseColor("#00897B"),
+            Color.parseColor("#00796B"),
+            Color.parseColor("#00695C"),
+            Color.parseColor("#004D40")
+          },
+          new int[] {
+            Color.parseColor("#E8F5E9"),
+            Color.parseColor("#C8E6C9"),
+            Color.parseColor("#A5D6A7"),
+            Color.parseColor("#81C784"),
+            Color.parseColor("#66BB6A"),
+            Color.parseColor("#4CAF50"),
+            Color.parseColor("#43A047"),
+            Color.parseColor("#388E3C"),
+            Color.parseColor("#2E7D32"),
+            Color.parseColor("#1B5E20")
+          },
+          new int[] {
+            Color.parseColor("#F1F8E9"),
+            Color.parseColor("#DCEDC8"),
+            Color.parseColor("#C5E1A5"),
+            Color.parseColor("#AED581"),
+            Color.parseColor("#9CCC65"),
+            Color.parseColor("#8BC34A"),
+            Color.parseColor("#7CB342"),
+            Color.parseColor("#689F38"),
+            Color.parseColor("#558B2F"),
+            Color.parseColor("#33691E")
+          },
+          new int[] {
+            Color.parseColor("#F9FBE7"),
+            Color.parseColor("#F0F4C3"),
+            Color.parseColor("#E6EE9C"),
+            Color.parseColor("#DCE775"),
+            Color.parseColor("#D4E157"),
+            Color.parseColor("#CDDC39"),
+            Color.parseColor("#C0CA33"),
+            Color.parseColor("#AFB42B"),
+            Color.parseColor("#9E9D24"),
+            Color.parseColor("#827717")
+          },
+          new int[] {
+            Color.parseColor("#FFFDE7"),
+            Color.parseColor("#FFF9C4"),
+            Color.parseColor("#FFF59D"),
+            Color.parseColor("#FFF176"),
+            Color.parseColor("#FFEE58"),
+            Color.parseColor("#FFEB3B"),
+            Color.parseColor("#FDD835"),
+            Color.parseColor("#FBC02D"),
+            Color.parseColor("#F9A825"),
+            Color.parseColor("#F57F17")
+          },
+          new int[] {
+            Color.parseColor("#FFF8E1"),
+            Color.parseColor("#FFECB3"),
+            Color.parseColor("#FFE082"),
+            Color.parseColor("#FFD54F"),
+            Color.parseColor("#FFCA28"),
+            Color.parseColor("#FFC107"),
+            Color.parseColor("#FFB300"),
+            Color.parseColor("#FFA000"),
+            Color.parseColor("#FF8F00"),
+            Color.parseColor("#FF6F00")
+          },
+          new int[] {
+            Color.parseColor("#FFF3E0"),
+            Color.parseColor("#FFE0B2"),
+            Color.parseColor("#FFCC80"),
+            Color.parseColor("#FFB74D"),
+            Color.parseColor("#FFA726"),
+            Color.parseColor("#FF9800"),
+            Color.parseColor("#FB8C00"),
+            Color.parseColor("#F57C00"),
+            Color.parseColor("#EF6C00"),
+            Color.parseColor("#E65100")
+          },
+          new int[] {
+            Color.parseColor("#FBE9E7"),
+            Color.parseColor("#FFCCBC"),
+            Color.parseColor("#FFAB91"),
+            Color.parseColor("#FF8A65"),
+            Color.parseColor("#FF7043"),
+            Color.parseColor("#FF5722"),
+            Color.parseColor("#F4511E"),
+            Color.parseColor("#E64A19"),
+            Color.parseColor("#D84315"),
+            Color.parseColor("#BF360C")
+          },
+          new int[] {
+            Color.parseColor("#EFEBE9"),
+            Color.parseColor("#D7CCC8"),
+            Color.parseColor("#BCAAA4"),
+            Color.parseColor("#A1887F"),
+            Color.parseColor("#8D6E63"),
+            Color.parseColor("#795548"),
+            Color.parseColor("#6D4C41"),
+            Color.parseColor("#5D4037"),
+            Color.parseColor("#4E342E"),
+            Color.parseColor("#3E2723")
+          },
+          new int[] {
+            Color.parseColor("#FAFAFA"),
+            Color.parseColor("#F5F5F5"),
+            Color.parseColor("#EEEEEE"),
+            Color.parseColor("#E0E0E0"),
+            Color.parseColor("#BDBDBD"),
+            Color.parseColor("#9E9E9E"),
+            Color.parseColor("#757575"),
+            Color.parseColor("#616161"),
+            Color.parseColor("#424242"),
+            Color.parseColor("#212121")
+          },
+          new int[] {
+            Color.parseColor("#ECEFF1"),
+            Color.parseColor("#CFD8DC"),
+            Color.parseColor("#B0BEC5"),
+            Color.parseColor("#90A4AE"),
+            Color.parseColor("#78909C"),
+            Color.parseColor("#607D8B"),
+            Color.parseColor("#546E7A"),
+            Color.parseColor("#455A64"),
+            Color.parseColor("#37474F"),
+            Color.parseColor("#263238")
+          }
+        };
+
+    static final int[] ACCENT_COLORS =
+        new int[] {
+          Color.parseColor("#FF1744"),
+          Color.parseColor("#F50057"),
+          Color.parseColor("#D500F9"),
+          Color.parseColor("#651FFF"),
+          Color.parseColor("#3D5AFE"),
+          Color.parseColor("#2979FF"),
+          Color.parseColor("#00B0FF"),
+          Color.parseColor("#00E5FF"),
+          Color.parseColor("#1DE9B6"),
+          Color.parseColor("#00E676"),
+          Color.parseColor("#76FF03"),
+          Color.parseColor("#C6FF00"),
+          Color.parseColor("#FFEA00"),
+          Color.parseColor("#FFC400"),
+          Color.parseColor("#FF9100"),
+          Color.parseColor("#FF3D00")
+        };
+
+    static final int[][] ACCENT_COLORS_SUB =
+        new int[][] {
+          new int[] {
+            Color.parseColor("#FF8A80"),
+            Color.parseColor("#FF5252"),
+            Color.parseColor("#FF1744"),
+            Color.parseColor("#D50000")
+          },
+          new int[] {
+            Color.parseColor("#FF80AB"),
+            Color.parseColor("#FF4081"),
+            Color.parseColor("#F50057"),
+            Color.parseColor("#C51162")
+          },
+          new int[] {
+            Color.parseColor("#EA80FC"),
+            Color.parseColor("#E040FB"),
+            Color.parseColor("#D500F9"),
+            Color.parseColor("#AA00FF")
+          },
+          new int[] {
+            Color.parseColor("#B388FF"),
+            Color.parseColor("#7C4DFF"),
+            Color.parseColor("#651FFF"),
+            Color.parseColor("#6200EA")
+          },
+          new int[] {
+            Color.parseColor("#8C9EFF"),
+            Color.parseColor("#536DFE"),
+            Color.parseColor("#3D5AFE"),
+            Color.parseColor("#304FFE")
+          },
+          new int[] {
+            Color.parseColor("#82B1FF"),
+            Color.parseColor("#448AFF"),
+            Color.parseColor("#2979FF"),
+            Color.parseColor("#2962FF")
+          },
+          new int[] {
+            Color.parseColor("#80D8FF"),
+            Color.parseColor("#40C4FF"),
+            Color.parseColor("#00B0FF"),
+            Color.parseColor("#0091EA")
+          },
+          new int[] {
+            Color.parseColor("#84FFFF"),
+            Color.parseColor("#18FFFF"),
+            Color.parseColor("#00E5FF"),
+            Color.parseColor("#00B8D4")
+          },
+          new int[] {
+            Color.parseColor("#A7FFEB"),
+            Color.parseColor("#64FFDA"),
+            Color.parseColor("#1DE9B6"),
+            Color.parseColor("#00BFA5")
+          },
+          new int[] {
+            Color.parseColor("#B9F6CA"),
+            Color.parseColor("#69F0AE"),
+            Color.parseColor("#00E676"),
+            Color.parseColor("#00C853")
+          },
+          new int[] {
+            Color.parseColor("#CCFF90"),
+            Color.parseColor("#B2FF59"),
+            Color.parseColor("#76FF03"),
+            Color.parseColor("#64DD17")
+          },
+          new int[] {
+            Color.parseColor("#F4FF81"),
+            Color.parseColor("#EEFF41"),
+            Color.parseColor("#C6FF00"),
+            Color.parseColor("#AEEA00")
+          },
+          new int[] {
+            Color.parseColor("#FFFF8D"),
+            Color.parseColor("#FFFF00"),
+            Color.parseColor("#FFEA00"),
+            Color.parseColor("#FFD600")
+          },
+          new int[] {
+            Color.parseColor("#FFE57F"),
+            Color.parseColor("#FFD740"),
+            Color.parseColor("#FFC400"),
+            Color.parseColor("#FFAB00")
+          },
+          new int[] {
+            Color.parseColor("#FFD180"),
+            Color.parseColor("#FFAB40"),
+            Color.parseColor("#FF9100"),
+            Color.parseColor("#FF6D00")
+          },
+          new int[] {
+            Color.parseColor("#FF9E80"),
+            Color.parseColor("#FF6E40"),
+            Color.parseColor("#FF3D00"),
+            Color.parseColor("#DD2C00")
+          }
+        };
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/CurrencyConverterDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/CurrencyConverterDialog.java
@@ -23,10 +23,12 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -34,8 +36,6 @@ import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.CurrencyUnit;
@@ -112,15 +112,14 @@ public class CurrencyConverterDialog extends DialogFragment {
             mCurrency2 = savedInstanceState.getParcelable(SS_CURRENCY_2);
             mExchangeRate = savedInstanceState.getDouble(SS_RATE);
         }
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.title_currency_exchange_rate)
-                .customView(R.layout.dialog_currency_exchange_rate, true)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View customView = ThemedDialog.inflateScrollableView(activity, R.layout.dialog_currency_exchange_rate);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.title_currency_exchange_rate)
+                .setView(customView)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         try {
                             mExchangeRate = Double.parseDouble(mExchangeRateEditText.getText().toString());
                         } catch (NumberFormatException ignore) {}
@@ -130,26 +129,24 @@ public class CurrencyConverterDialog extends DialogFragment {
                     }
 
                 })
-                .build();
-        View customView = dialog.getCustomView();
-        if (customView != null) {
-            mExchangeRateEditText = customView.findViewById(R.id.exchange_rate_edit_text);
-            mRefreshButton = customView.findViewById(R.id.refresh_button);
-            updateDisplay();
-            mRefreshButton.setOnClickListener(new View.OnClickListener() {
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
+        mExchangeRateEditText = customView.findViewById(R.id.exchange_rate_edit_text);
+        mRefreshButton = customView.findViewById(R.id.refresh_button);
+        updateDisplay();
+        mRefreshButton.setOnClickListener(new View.OnClickListener() {
 
-                @Override
-                public void onClick(View v) {
-                    Activity activity = getActivity();
-                    Intent intent = AbstractCurrencyRateDownloadIntentService.buildIntent(activity);
-                    activity.startService(intent);
-                    // temporary disable the refresh button until the load is completed
-                    // to avoid launching multiple serial services
-                    mRefreshButton.setClickable(false);
-                }
+            @Override
+            public void onClick(View v) {
+                Activity activity = getActivity();
+                Intent intent = AbstractCurrencyRateDownloadIntentService.buildIntent(activity);
+                activity.startService(intent);
+                // temporary disable the refresh button until the load is completed
+                // to avoid launching multiple serial services
+                mRefreshButton.setClickable(false);
+            }
 
-            });
-        }
+        });
         return dialog;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/CustomDigitSetupDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/CustomDigitSetupDialog.java
@@ -21,16 +21,16 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.appcompat.widget.SwitchCompat;
 import android.view.View;
 import android.widget.CompoundButton;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
@@ -64,23 +64,19 @@ public class CustomDigitSetupDialog extends DialogFragment {
         if (activity == null) {
             return super.onCreateDialog(savedInstanceState);
         }
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .customView(R.layout.layout_dialog_custom_digit_setup, false)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = getLayoutInflater().inflate(R.layout.layout_dialog_custom_digit_setup, null);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setView(view)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         onSaveChanges();
                     }
 
                 })
-                .build();
-        View view = dialog.getCustomView();
-        if (view == null) {
-            throw new IllegalStateException("Custom view has been inflated but the returned view is null");
-        }
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
         mDisplayTextView = view.findViewById(R.id.display_text_view);
         SwitchCompat currencyEnabledSwitch = view.findViewById(R.id.show_currency_switch);
         SwitchCompat groupingEnabledSwitch = view.findViewById(R.id.group_digits_switch);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/DataFormatPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/DataFormatPickerDialog.java
@@ -7,6 +7,8 @@ import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.DataFormat;
 import com.oriondev.moneywallet.ui.adapter.recycler.DataFormatSelectorAdapter;
@@ -40,9 +42,12 @@ public class DataFormatPickerDialog extends DialogFragment implements DataFormat
             mDataFormats = (DataFormat[]) savedInstanceState.getSerializable(SS_DATA_FORMATS);
             mIndex = savedInstanceState.getInt(SS_CURRENT_INDEX, -1);
         }
+        RecyclerView recyclerView = (RecyclerView) getLayoutInflater().inflate(R.layout.dialog_recycler_view, null);
+        recyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        recyclerView.setAdapter(new DataFormatSelectorAdapter(mDataFormats, this));
         return ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_data_format_picker_title)
-                .adapter(new DataFormatSelectorAdapter(mDataFormats, this), null)
+                .setTitle(R.string.dialog_data_format_picker_title)
+                .setView(recyclerView)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/EventPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/EventPickerDialog.java
@@ -21,11 +21,13 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.loader.app.LoaderManager;
@@ -36,8 +38,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Event;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -84,29 +84,26 @@ public class EventPickerDialog extends DialogFragment implements EventSelectorCu
             mEvent = savedInstanceState.getParcelable(SS_SELECTED_EVENT);
             mFilterDate = (Date) savedInstanceState.getSerializable(SS_FILTER_DATE);
         }
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_event_picker_title)
-                .positiveText(R.string.action_new)
-                .negativeText(android.R.string.cancel)
-                .customView(R.layout.dialog_advanced_list, false)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = getLayoutInflater().inflate(R.layout.dialog_advanced_list, null);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_event_picker_title)
+                .setPositiveButton(R.string.action_new, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         startActivity(new Intent(getActivity(), NewEditEventActivity.class));
                     }
 
                 })
-                .build();
+                .setNegativeButton(android.R.string.cancel, null)
+                .setView(view)
+                .create();
         mCursorAdapter = new EventSelectorCursorAdapter(this);
-        View view = dialog.getCustomView();
-        if (view != null) {
-            mRecyclerView = view.findViewById(R.id.recycler_view);
-            mMessageTextView = view.findViewById(R.id.message_text_view);
-            mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
-            mRecyclerView.setAdapter(mCursorAdapter);
-            mMessageTextView.setText(R.string.message_no_event_found);
-        }
+        mRecyclerView = view.findViewById(R.id.recycler_view);
+        mMessageTextView = view.findViewById(R.id.message_text_view);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        mRecyclerView.setAdapter(mCursorAdapter);
+        mMessageTextView.setText(R.string.message_no_event_found);
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
         LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ExportColumnsDialogFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ExportColumnsDialogFragment.java
@@ -3,15 +3,17 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.storage.database.data.AbstractDataExporter;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by andrea on 21/12/18.
@@ -55,21 +57,38 @@ public class ExportColumnsDialogFragment extends DialogFragment {
         for (int i = 0; i < COLUMN_NAMES.length; i++) {
             items[i] = getString(COLUMN_NAMES[i]);
         }
+        final boolean[] checked = new boolean[items.length];
+        if (mIndices != null) {
+            for (Integer index : mIndices) {
+                checked[index] = true;
+            }
+        }
         return ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_export_optional_columns_title)
-                .items(items)
-                .itemsCallbackMultiChoice(mIndices, new MaterialDialog.ListCallbackMultiChoice() {
+                .setTitle(R.string.dialog_export_optional_columns_title)
+                .setMultiChoiceItems(items, checked, new DialogInterface.OnMultiChoiceClickListener() {
 
                     @Override
-                    public boolean onSelection(MaterialDialog dialog, Integer[] indices, CharSequence[] text) {
-                        mIndices = indices;
-                        mCallback.onExportColumnsSelected(mIndices);
-                        return false;
+                    public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+                        checked[which] = isChecked;
                     }
 
                 })
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        List<Integer> indices = new ArrayList<>();
+                        for (int i = 0; i < checked.length; i++) {
+                            if (checked[i]) {
+                                indices.add(i);
+                            }
+                        }
+                        mIndices = indices.toArray(new Integer[0]);
+                        mCallback.onExportColumnsSelected(mIndices);
+                    }
+
+                })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/GenericProgressDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/GenericProgressDialog.java
@@ -22,11 +22,19 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 import android.app.Activity;
 import android.app.Dialog;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.progressindicator.BaseProgressIndicator;
+import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+
+import java.text.NumberFormat;
 
 /**
  * Created by andre on 22/03/2018.
@@ -36,6 +44,10 @@ public class GenericProgressDialog extends DialogFragment {
     private static final String ARG_TITLE_RES = "GenericProgressDialog::Arguments::TitleRes";
     private static final String ARG_CONTENT_RES = "GenericProgressDialog::Arguments::ContentRes";
     private static final String ARG_INDETERMINATE = "GenericProgressDialog::Arguments::Indeterminate";
+
+    private BaseProgressIndicator<?> mProgressIndicator;
+    private TextView mMessageTextView;
+    private TextView mPercentageTextView;
 
     public static GenericProgressDialog newInstance(int title, int content, boolean indeterminate) {
         GenericProgressDialog dialog = new GenericProgressDialog();
@@ -59,28 +71,67 @@ public class GenericProgressDialog extends DialogFragment {
         int titleRes = arguments != null ? arguments.getInt(ARG_TITLE_RES) : 0;
         int contentRes = arguments != null ? arguments.getInt(ARG_CONTENT_RES) : 0;
         boolean indeterminate = arguments != null && arguments.getBoolean(ARG_INDETERMINATE);
-        MaterialDialog.Builder builder = ThemedDialog.buildMaterialDialog(activity);
-                if (titleRes != 0) {
-                    builder.title(titleRes);
-                }
-                if (contentRes != 0) {
-                    builder.content(contentRes);
-                }
-        return builder.progress(indeterminate, 100)
-                .cancelable(false)
-                .build();
+        int layoutRes = indeterminate ? R.layout.dialog_progress_indeterminate
+                : R.layout.dialog_progress_determinate;
+        MaterialAlertDialogBuilder builder = ThemedDialog.buildMaterialDialog(activity);
+        if (titleRes != 0) {
+            builder.setTitle(titleRes);
+        }
+        AlertDialog dialog = builder.setCancelable(false).create();
+        // The dialog's own context carries the light or dark dialog theme the factory picked, so
+        // the layout's theme attributes have to resolve against it and not against the activity.
+        // This is the same clone DialogFragment makes for a dialog it inflates a content view for,
+        // and it has to be made by hand here because getLayoutInflater() hands back the plain
+        // activity inflater while onCreateDialog is still running.
+        View view = getLayoutInflater().cloneInContext(dialog.getContext()).inflate(layoutRes, null);
+        mProgressIndicator = view.findViewById(R.id.dialog_progress_indicator);
+        mProgressIndicator.setMax(100);
+        // The widget defaults to colorPrimary, which neither dialog style sets, so it sinks into
+        // the dark dialog surface.
+        mProgressIndicator.setIndicatorColor(ThemedDialog.getAccentColor());
+        if (!indeterminate) {
+            // setIndicatorColor leaves the track alone, and the linear style declares no track
+            // color, so the widget derived one at inflation by fading colorPrimary to the theme's
+            // disabledAlpha, which all but erases it on the dark dialog. The circular style
+            // declares a transparent track and keeps it.
+            mProgressIndicator.setTrackColor(ThemedDialog.getIdleColor());
+        }
+        mMessageTextView = view.findViewById(R.id.dialog_progress_message);
+        // Only the determinate layout carries a percentage label.
+        mPercentageTextView = view.findViewById(R.id.dialog_progress_percentage);
+        setMessage(contentRes);
+        setProgress(0);
+        dialog.setView(view);
+        return dialog;
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        mProgressIndicator = null;
+        mMessageTextView = null;
+        mPercentageTextView = null;
     }
 
     public void updateProgress(int contentRes, int progress) {
-        MaterialDialog dialog = (MaterialDialog) getDialog();
-        if (dialog != null) {
-            dialog.setCancelable(false);
-            if (contentRes != 0) {
-                dialog.setContent(contentRes);
-            } else {
-                dialog.setContent(null);
-            }
-            dialog.setProgress(progress);
+        if (mProgressIndicator == null) {
+            return;
+        }
+        setMessage(contentRes);
+        setProgress(progress);
+    }
+
+    private void setMessage(int contentRes) {
+        mMessageTextView.setText(contentRes != 0 ? getText(contentRes) : null);
+    }
+
+    private void setProgress(int progress) {
+        mProgressIndicator.setProgress(progress);
+        if (mPercentageTextView != null) {
+            // material-dialogs wrote this label through its default progressPercentFormat, which
+            // is NumberFormat.getPercentInstance().
+            NumberFormat format = NumberFormat.getPercentInstance();
+            mPercentageTextView.setText(format.format(progress / (float) mProgressIndicator.getMax()));
         }
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/LicenseDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/LicenseDialog.java
@@ -29,7 +29,8 @@ import androidx.loader.app.LoaderManager;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
-import com.afollestad.materialdialogs.MaterialDialog;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.background.LicenseLoader;
 import com.oriondev.moneywallet.model.License;
@@ -68,12 +69,15 @@ public class LicenseDialog extends DialogFragment implements LoaderManager.Loade
             return super.onCreateDialog(savedInstanceState);
         }
         mAdapter = new LicenseAdapter(this);
-        MaterialDialog.Builder builder = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.title_licenses)
-                .adapter(mAdapter, new LinearLayoutManager(activity))
-                .positiveText(android.R.string.ok);
+        RecyclerView recyclerView = (RecyclerView) getLayoutInflater().inflate(R.layout.dialog_recycler_view, null);
+        recyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        recyclerView.setAdapter(mAdapter);
+        MaterialAlertDialogBuilder builder = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.title_licenses)
+                .setView(recyclerView)
+                .setPositiveButton(android.R.string.ok, null);
         LoaderManager.getInstance(this).restartLoader(LOADER_ID, null, this);
-        return builder.build();
+        return builder.create();
     }
 
     public void setCallback(Callback callback) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/MultiCategoryPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/MultiCategoryPickerDialog.java
@@ -21,6 +21,7 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -29,6 +30,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.collection.LongSparseArray;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
@@ -38,8 +40,6 @@ import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Category;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -92,31 +92,28 @@ public class MultiCategoryPickerDialog extends DialogFragment implements ParentC
                 }
             }
         }
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_category_picker_title)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .customView(R.layout.dialog_advanced_list, false)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = getLayoutInflater().inflate(R.layout.dialog_advanced_list, null);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_category_picker_title)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         if (mCallback != null) {
                             mCallback.onCategoriesSelected(selectedCategories());
                         }
                     }
 
                 })
-                .build();
+                .setNegativeButton(android.R.string.cancel, null)
+                .setView(view)
+                .create();
         mCursorAdapter = new ParentCategorySelectorCursorAdapter(this);
-        View view = dialog.getCustomView();
-        if (view != null) {
-            mRecyclerView = view.findViewById(R.id.recycler_view);
-            mMessageTextView = view.findViewById(R.id.message_text_view);
-            mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
-            mRecyclerView.setAdapter(mCursorAdapter);
-            mMessageTextView.setText(R.string.message_no_category_found);
-        }
+        mRecyclerView = view.findViewById(R.id.recycler_view);
+        mMessageTextView = view.findViewById(R.id.message_text_view);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        mRecyclerView.setAdapter(mCursorAdapter);
+        mMessageTextView.setText(R.string.message_no_category_found);
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
         LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/OverviewSettingDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/OverviewSettingDialog.java
@@ -23,16 +23,16 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import android.view.View;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.jaredrummler.materialspinner.MaterialSpinner;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Category;
@@ -94,15 +94,14 @@ public class OverviewSettingDialog extends DialogFragment implements DateTimePic
         mEndDatePicker = DateTimePicker.createPicker(fragmentManager, TAG_END_DATE_PICKER, mOverviewSetting.getEndDate());
         mCategoryPicker = CategoryPicker.createPicker(fragmentManager, TAG_CATEGORY_PICKER, getFirstAvailableCategory(activity));
         // create the dialog
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_overview_setting_title)
-                .customView(R.layout.dialog_overview_setting_picker, true)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = ThemedDialog.inflateScrollableView(activity, R.layout.dialog_overview_setting_picker);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_overview_setting_title)
+                .setView(view)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         mOverviewSetting = getCurrentOverviewSetting();
                         if (mCallback != null) {
                             mCallback.onOverviewSettingChanged(mOverviewSetting);
@@ -110,114 +109,112 @@ public class OverviewSettingDialog extends DialogFragment implements DateTimePic
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
-        View view = dialog.getCustomView();
-        if (view != null) {
-            // obtain the references of all the spinners
-            mStartDateSpinner = view.findViewById(R.id.start_date_spinner);
-            mEndDateSpinner = view.findViewById(R.id.end_date_spinner);
-            mGroupTypeSpinner = view.findViewById(R.id.group_type_spinner);
-            mOverviewTypeSpinner = view.findViewById(R.id.overview_type_spinner);
-            mCashFlowSpinner = view.findViewById(R.id.cash_flow_spinner);
-            mCategorySpinner = view.findViewById(R.id.category_spinner);
-            // adjust padding for each spinner
-            mStartDateSpinner.setPadding(0, mStartDateSpinner.getPaddingTop(), 0, mStartDateSpinner.getPaddingBottom());
-            mEndDateSpinner.setPadding(0, mEndDateSpinner.getPaddingTop(), 0, mEndDateSpinner.getPaddingBottom());
-            mGroupTypeSpinner.setPadding(0, mGroupTypeSpinner.getPaddingTop(), 0, mGroupTypeSpinner.getPaddingBottom());
-            mOverviewTypeSpinner.setPadding(0, mOverviewTypeSpinner.getPaddingTop(), 0, mOverviewTypeSpinner.getPaddingBottom());
-            mCashFlowSpinner.setPadding(0, mCashFlowSpinner.getPaddingTop(), 0, mCashFlowSpinner.getPaddingBottom());
-            mCategorySpinner.setPadding(0, mCategorySpinner.getPaddingTop(), 0, mCategorySpinner.getPaddingBottom());
-            // setup the standard spinners
-            mGroupTypeSpinner.setItems(
-                    getString(R.string.spinner_item_group_type_daily),
-                    getString(R.string.spinner_item_group_type_weekly),
-                    getString(R.string.spinner_item_group_type_monthly),
-                    getString(R.string.spinner_item_group_type_yearly)
-            );
-            mOverviewTypeSpinner.setItems(
-                    getString(R.string.spinner_item_type_cash_flow),
-                    getString(R.string.spinner_item_type_category)
-            );
-            mCashFlowSpinner.setItems(
-                    getString(R.string.spinner_item_cash_flow_incomes),
-                    getString(R.string.spinner_item_cash_flow_expenses),
-                    getString(R.string.spinner_item_cash_flow_net_incomes)
-            );
-            // now we can attach the listeners to all the spinners
-            mStartDateSpinner.setOnClickListener(new View.OnClickListener() {
+        // obtain the references of all the spinners
+        mStartDateSpinner = view.findViewById(R.id.start_date_spinner);
+        mEndDateSpinner = view.findViewById(R.id.end_date_spinner);
+        mGroupTypeSpinner = view.findViewById(R.id.group_type_spinner);
+        mOverviewTypeSpinner = view.findViewById(R.id.overview_type_spinner);
+        mCashFlowSpinner = view.findViewById(R.id.cash_flow_spinner);
+        mCategorySpinner = view.findViewById(R.id.category_spinner);
+        // adjust padding for each spinner
+        mStartDateSpinner.setPadding(0, mStartDateSpinner.getPaddingTop(), 0, mStartDateSpinner.getPaddingBottom());
+        mEndDateSpinner.setPadding(0, mEndDateSpinner.getPaddingTop(), 0, mEndDateSpinner.getPaddingBottom());
+        mGroupTypeSpinner.setPadding(0, mGroupTypeSpinner.getPaddingTop(), 0, mGroupTypeSpinner.getPaddingBottom());
+        mOverviewTypeSpinner.setPadding(0, mOverviewTypeSpinner.getPaddingTop(), 0, mOverviewTypeSpinner.getPaddingBottom());
+        mCashFlowSpinner.setPadding(0, mCashFlowSpinner.getPaddingTop(), 0, mCashFlowSpinner.getPaddingBottom());
+        mCategorySpinner.setPadding(0, mCategorySpinner.getPaddingTop(), 0, mCategorySpinner.getPaddingBottom());
+        // setup the standard spinners
+        mGroupTypeSpinner.setItems(
+                getString(R.string.spinner_item_group_type_daily),
+                getString(R.string.spinner_item_group_type_weekly),
+                getString(R.string.spinner_item_group_type_monthly),
+                getString(R.string.spinner_item_group_type_yearly)
+        );
+        mOverviewTypeSpinner.setItems(
+                getString(R.string.spinner_item_type_cash_flow),
+                getString(R.string.spinner_item_type_category)
+        );
+        mCashFlowSpinner.setItems(
+                getString(R.string.spinner_item_cash_flow_incomes),
+                getString(R.string.spinner_item_cash_flow_expenses),
+                getString(R.string.spinner_item_cash_flow_net_incomes)
+        );
+        // now we can attach the listeners to all the spinners
+        mStartDateSpinner.setOnClickListener(new View.OnClickListener() {
 
-                @Override
-                public void onClick(View v) {
-                    mStartDatePicker.showDatePicker();
-                    mStartDateSpinner.collapse();
-                }
-
-            });
-            mEndDateSpinner.setOnClickListener(new View.OnClickListener() {
-
-                @Override
-                public void onClick(View v) {
-                    mEndDatePicker.showDatePicker();
-                    mEndDateSpinner.collapse();
-                }
-
-            });
-            mOverviewTypeSpinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener() {
-
-                @Override
-                public void onItemSelected(MaterialSpinner view, int position, long id, Object item) {
-                    mCashFlowSpinner.setVisibility(position == 0 ? View.VISIBLE : View.GONE);
-                    mCategorySpinner.setVisibility(position == 1 ? View.VISIBLE : View.GONE);
-                }
-
-            });
-            mCategorySpinner.setOnClickListener(new View.OnClickListener() {
-
-                @Override
-                public void onClick(View v) {
-                    mCategoryPicker.showPicker(true, true);
-                    mCategorySpinner.collapse();
-                }
-
-            });
-            // now use the current data to update all the views
-            switch (mOverviewSetting.getGroupType()) {
-                case DAILY:
-                    mGroupTypeSpinner.setSelectedIndex(0);
-                    break;
-                case WEEKLY:
-                    mGroupTypeSpinner.setSelectedIndex(1);
-                    break;
-                case MONTHLY:
-                    mGroupTypeSpinner.setSelectedIndex(2);
-                    break;
-                case YEARLY:
-                    mGroupTypeSpinner.setSelectedIndex(3);
-                    break;
+            @Override
+            public void onClick(View v) {
+                mStartDatePicker.showDatePicker();
+                mStartDateSpinner.collapse();
             }
-            switch (mOverviewSetting.getType()) {
-                case CASH_FLOW:
-                    mOverviewTypeSpinner.setSelectedIndex(0);
-                    mCashFlowSpinner.setVisibility(View.VISIBLE);
-                    mCategorySpinner.setVisibility(View.GONE);
-                    break;
-                case CATEGORY:
-                    mOverviewTypeSpinner.setSelectedIndex(1);
-                    mCashFlowSpinner.setVisibility(View.GONE);
-                    mCategorySpinner.setVisibility(View.VISIBLE);
-                    break;
+
+        });
+        mEndDateSpinner.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                mEndDatePicker.showDatePicker();
+                mEndDateSpinner.collapse();
             }
-            switch (mOverviewSetting.getCashFlow()) {
-                case INCOMES:
-                    mCashFlowSpinner.setSelectedIndex(0);
-                    break;
-                case EXPENSES:
-                    mCashFlowSpinner.setSelectedIndex(1);
-                    break;
-                case NET_INCOMES:
-                    mCashFlowSpinner.setSelectedIndex(2);
-                    break;
+
+        });
+        mOverviewTypeSpinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener() {
+
+            @Override
+            public void onItemSelected(MaterialSpinner view, int position, long id, Object item) {
+                mCashFlowSpinner.setVisibility(position == 0 ? View.VISIBLE : View.GONE);
+                mCategorySpinner.setVisibility(position == 1 ? View.VISIBLE : View.GONE);
             }
+
+        });
+        mCategorySpinner.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View v) {
+                mCategoryPicker.showPicker(true, true);
+                mCategorySpinner.collapse();
+            }
+
+        });
+        // now use the current data to update all the views
+        switch (mOverviewSetting.getGroupType()) {
+            case DAILY:
+                mGroupTypeSpinner.setSelectedIndex(0);
+                break;
+            case WEEKLY:
+                mGroupTypeSpinner.setSelectedIndex(1);
+                break;
+            case MONTHLY:
+                mGroupTypeSpinner.setSelectedIndex(2);
+                break;
+            case YEARLY:
+                mGroupTypeSpinner.setSelectedIndex(3);
+                break;
+        }
+        switch (mOverviewSetting.getType()) {
+            case CASH_FLOW:
+                mOverviewTypeSpinner.setSelectedIndex(0);
+                mCashFlowSpinner.setVisibility(View.VISIBLE);
+                mCategorySpinner.setVisibility(View.GONE);
+                break;
+            case CATEGORY:
+                mOverviewTypeSpinner.setSelectedIndex(1);
+                mCashFlowSpinner.setVisibility(View.GONE);
+                mCategorySpinner.setVisibility(View.VISIBLE);
+                break;
+        }
+        switch (mOverviewSetting.getCashFlow()) {
+            case INCOMES:
+                mCashFlowSpinner.setSelectedIndex(0);
+                break;
+            case EXPENSES:
+                mCashFlowSpinner.setSelectedIndex(1);
+                break;
+            case NET_INCOMES:
+                mCashFlowSpinner.setSelectedIndex(2);
+                break;
         }
         return dialog;
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ParentCategoryPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ParentCategoryPickerDialog.java
@@ -21,11 +21,13 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.loader.app.LoaderManager;
@@ -36,8 +38,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Category;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -84,29 +84,26 @@ public class ParentCategoryPickerDialog extends DialogFragment implements Parent
             mCallerId = savedInstanceState.getLong(SS_CALLER_ID);
             mCategoryType = (Contract.CategoryType) savedInstanceState.getSerializable(SS_CATEGORY_TYPE);
         }
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_category_picker_title)
-                .positiveText(R.string.action_new)
-                .negativeText(android.R.string.cancel)
-                .customView(R.layout.dialog_advanced_list, false)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = getLayoutInflater().inflate(R.layout.dialog_advanced_list, null);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_category_picker_title)
+                .setPositiveButton(R.string.action_new, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         startActivity(new Intent(getActivity(), NewEditCategoryActivity.class));
                     }
 
                 })
-                .build();
+                .setNegativeButton(android.R.string.cancel, null)
+                .setView(view)
+                .create();
         mCursorAdapter = new ParentCategorySelectorCursorAdapter(this);
-        View view = dialog.getCustomView();
-        if (view != null) {
-            mRecyclerView = view.findViewById(R.id.recycler_view);
-            mMessageTextView = view.findViewById(R.id.message_text_view);
-            mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
-            mRecyclerView.setAdapter(mCursorAdapter);
-            mMessageTextView.setText(R.string.message_no_category_found);
-        }
+        mRecyclerView = view.findViewById(R.id.recycler_view);
+        mMessageTextView = view.findViewById(R.id.message_text_view);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        mRecyclerView.setAdapter(mCursorAdapter);
+        mMessageTextView.setText(R.string.message_no_category_found);
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
         LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/PeoplePickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/PeoplePickerDialog.java
@@ -21,11 +21,13 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.loader.app.LoaderManager;
@@ -37,8 +39,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Person;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -85,15 +85,13 @@ public class PeoplePickerDialog extends DialogFragment implements PeopleSelector
                 }
             }
         }
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_people_picker_title)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .neutralText(R.string.action_new)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = getLayoutInflater().inflate(R.layout.dialog_advanced_list, null);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_people_picker_title)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         if (mCallback != null) {
                             Person[] people = new Person[mSelectedPeople.size()];
                             for (int i = 0; i < mSelectedPeople.size(); i++) {
@@ -104,25 +102,23 @@ public class PeoplePickerDialog extends DialogFragment implements PeopleSelector
                     }
 
                 })
-                .onNeutral(new MaterialDialog.SingleButtonCallback() {
+                .setNegativeButton(android.R.string.cancel, null)
+                .setNeutralButton(R.string.action_new, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         startActivity(new Intent(getActivity(), NewEditPersonActivity.class));
                     }
 
                 })
-                .customView(R.layout.dialog_advanced_list, false)
-                .build();
+                .setView(view)
+                .create();
         mCursorAdapter = new PeopleSelectorCursorAdapter(this);
-        View view = dialog.getCustomView();
-        if (view != null) {
-            mRecyclerView = view.findViewById(R.id.recycler_view);
-            mMessageTextView = view.findViewById(R.id.message_text_view);
-            mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
-            mRecyclerView.setAdapter(mCursorAdapter);
-            mMessageTextView.setText(R.string.message_no_person_found);
-        }
+        mRecyclerView = view.findViewById(R.id.recycler_view);
+        mMessageTextView = view.findViewById(R.id.message_text_view);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        mRecyclerView.setAdapter(mCursorAdapter);
+        mMessageTextView.setText(R.string.message_no_person_found);
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
         LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/PlacePickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/PlacePickerDialog.java
@@ -21,11 +21,13 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.loader.app.LoaderManager;
@@ -36,8 +38,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Place;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -78,29 +78,26 @@ public class PlacePickerDialog extends DialogFragment implements PlaceSelectorCu
         if (savedInstanceState != null) {
             mPlace = savedInstanceState.getParcelable(SS_SELECTED_PLACE);
         }
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_place_picker_title)
-                .positiveText(R.string.action_new)
-                .negativeText(android.R.string.cancel)
-                .customView(R.layout.dialog_advanced_list, false)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = getLayoutInflater().inflate(R.layout.dialog_advanced_list, null);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_place_picker_title)
+                .setPositiveButton(R.string.action_new, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         startActivity(new Intent(getActivity(), NewEditPlaceActivity.class));
                     }
 
                 })
-                .build();
+                .setNegativeButton(android.R.string.cancel, null)
+                .setView(view)
+                .create();
         mCursorAdapter = new PlaceSelectorCursorAdapter(this);
-        View view = dialog.getCustomView();
-        if (view != null) {
-            mRecyclerView = view.findViewById(R.id.recycler_view);
-            mMessageTextView = view.findViewById(R.id.message_text_view);
-            mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
-            mRecyclerView.setAdapter(mCursorAdapter);
-            mMessageTextView.setText(R.string.message_no_place_found);
-        }
+        mRecyclerView = view.findViewById(R.id.recycler_view);
+        mMessageTextView = view.findViewById(R.id.message_text_view);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        mRecyclerView.setAdapter(mCursorAdapter);
+        mMessageTextView.setText(R.string.message_no_place_found);
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
         LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/RecurrencePickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/RecurrencePickerDialog.java
@@ -21,8 +21,10 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import android.view.View;
@@ -33,8 +35,6 @@ import android.widget.LinearLayout;
 import android.widget.RadioButton;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.jaredrummler.materialspinner.MaterialSpinner;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.RecurrenceSetting;
@@ -103,15 +103,14 @@ public class RecurrencePickerDialog extends DialogFragment implements DateTimePi
             mOnceAPeriod = savedInstanceState.getBoolean(SS_ONCE_A_PERIOD, false);
         }
         // create the dialog
-        MaterialDialog dialog = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_recurrence_title)
-                .customView(R.layout.dialog_recurrence_setting_picker, true)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+        View view = ThemedDialog.inflateScrollableView(activity, R.layout.dialog_recurrence_setting_picker);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_recurrence_title)
+                .setView(view)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         mRecurrenceSetting = getCurrentRecurrenceSetting();
                         if (mCallback != null) {
                             mCallback.onRecurrenceSettingChanged(mRecurrenceSetting);
@@ -119,109 +118,107 @@ public class RecurrencePickerDialog extends DialogFragment implements DateTimePi
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
-        View view = dialog.getCustomView();
-        if (view != null) {
-            mRecurrenceTypeSpinner = view.findViewById(R.id.type_spinner);
-            mRecurrenceStartDateSpinner = view.findViewById(R.id.start_date_spinner);
-            mRecurrenceEveryNumberEditText = view.findViewById(R.id.every_number_edit_text);
-            mRecurrenceEveryItemTextView = view.findViewById(R.id.every_item_text_view);
-            mRecurrenceTypeWeeklyLayout = view.findViewById(R.id.type_weekly_layout);
-            mRecurrenceTypeWeeklySundayRadioButton = view.findViewById(R.id.type_weekly_sunday);
-            mRecurrenceTypeWeeklyMondayRadioButton = view.findViewById(R.id.type_weekly_monday);
-            mRecurrenceTypeWeeklyTuesdayRadioButton = view.findViewById(R.id.type_weekly_tuesday);
-            mRecurrenceTypeWeeklyWednesdayRadioButton = view.findViewById(R.id.type_weekly_wednesday);
-            mRecurrenceTypeWeeklyThursdayRadioButton = view.findViewById(R.id.type_weekly_thursday);
-            mRecurrenceTypeWeeklyFridayRadioButton = view.findViewById(R.id.type_weekly_friday);
-            mRecurrenceTypeWeeklySaturdayRadioButton = view.findViewById(R.id.type_weekly_saturday);
-            mRecurrenceTypeMonthlyLayout = view.findViewById(R.id.type_monthly_layout);
-            mRecurrenceTypeMonthlySameDayRadioButton = view.findViewById(R.id.type_monthly_repeat_same_day);
-            mRecurrenceEndTypeSpinner = view.findViewById(R.id.end_type_spinner);
-            mRecurrenceTimesLayout = view.findViewById(R.id.end_type_for_layout);
-            mRecurrenceTimesNumberEditText = view.findViewById(R.id.end_type_for_edit_text);
-            mRecurrenceEndDateSpinner = view.findViewById(R.id.end_date_spinner);
-            // setup margins
-            mRecurrenceTypeSpinner.setPadding(0, mRecurrenceTypeSpinner.getPaddingTop(), 0, mRecurrenceTypeSpinner.getPaddingBottom());
-            mRecurrenceStartDateSpinner.setPadding(0, mRecurrenceStartDateSpinner.getPaddingTop(), 0, mRecurrenceStartDateSpinner.getPaddingBottom());
-            mRecurrenceEndTypeSpinner.setPadding(0, mRecurrenceEndTypeSpinner.getPaddingTop(), 0, mRecurrenceEndTypeSpinner.getPaddingBottom());
-            mRecurrenceEndDateSpinner.setPadding(0, mRecurrenceEndDateSpinner.getPaddingTop(), 0, mRecurrenceEndDateSpinner.getPaddingBottom());
-            // configure spinners
-            mRecurrenceTypeSpinner.setItems(
-                    getString(R.string.recurrence_type_daily),
-                    getString(R.string.recurrence_type_weekly),
-                    getString(R.string.recurrence_type_monthly),
-                    getString(R.string.recurrence_type_yearly)
-            );
-            mRecurrenceEndTypeSpinner.setItems(
-                    getString(R.string.recurrence_end_type_forever),
-                    getString(R.string.recurrence_end_type_until),
-                    getString(R.string.recurrence_end_type_for)
-            );
-            mRecurrenceTypeSpinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener() {
+        mRecurrenceTypeSpinner = view.findViewById(R.id.type_spinner);
+        mRecurrenceStartDateSpinner = view.findViewById(R.id.start_date_spinner);
+        mRecurrenceEveryNumberEditText = view.findViewById(R.id.every_number_edit_text);
+        mRecurrenceEveryItemTextView = view.findViewById(R.id.every_item_text_view);
+        mRecurrenceTypeWeeklyLayout = view.findViewById(R.id.type_weekly_layout);
+        mRecurrenceTypeWeeklySundayRadioButton = view.findViewById(R.id.type_weekly_sunday);
+        mRecurrenceTypeWeeklyMondayRadioButton = view.findViewById(R.id.type_weekly_monday);
+        mRecurrenceTypeWeeklyTuesdayRadioButton = view.findViewById(R.id.type_weekly_tuesday);
+        mRecurrenceTypeWeeklyWednesdayRadioButton = view.findViewById(R.id.type_weekly_wednesday);
+        mRecurrenceTypeWeeklyThursdayRadioButton = view.findViewById(R.id.type_weekly_thursday);
+        mRecurrenceTypeWeeklyFridayRadioButton = view.findViewById(R.id.type_weekly_friday);
+        mRecurrenceTypeWeeklySaturdayRadioButton = view.findViewById(R.id.type_weekly_saturday);
+        mRecurrenceTypeMonthlyLayout = view.findViewById(R.id.type_monthly_layout);
+        mRecurrenceTypeMonthlySameDayRadioButton = view.findViewById(R.id.type_monthly_repeat_same_day);
+        mRecurrenceEndTypeSpinner = view.findViewById(R.id.end_type_spinner);
+        mRecurrenceTimesLayout = view.findViewById(R.id.end_type_for_layout);
+        mRecurrenceTimesNumberEditText = view.findViewById(R.id.end_type_for_edit_text);
+        mRecurrenceEndDateSpinner = view.findViewById(R.id.end_date_spinner);
+        // setup margins
+        mRecurrenceTypeSpinner.setPadding(0, mRecurrenceTypeSpinner.getPaddingTop(), 0, mRecurrenceTypeSpinner.getPaddingBottom());
+        mRecurrenceStartDateSpinner.setPadding(0, mRecurrenceStartDateSpinner.getPaddingTop(), 0, mRecurrenceStartDateSpinner.getPaddingBottom());
+        mRecurrenceEndTypeSpinner.setPadding(0, mRecurrenceEndTypeSpinner.getPaddingTop(), 0, mRecurrenceEndTypeSpinner.getPaddingBottom());
+        mRecurrenceEndDateSpinner.setPadding(0, mRecurrenceEndDateSpinner.getPaddingTop(), 0, mRecurrenceEndDateSpinner.getPaddingBottom());
+        // configure spinners
+        mRecurrenceTypeSpinner.setItems(
+                getString(R.string.recurrence_type_daily),
+                getString(R.string.recurrence_type_weekly),
+                getString(R.string.recurrence_type_monthly),
+                getString(R.string.recurrence_type_yearly)
+        );
+        mRecurrenceEndTypeSpinner.setItems(
+                getString(R.string.recurrence_end_type_forever),
+                getString(R.string.recurrence_end_type_until),
+                getString(R.string.recurrence_end_type_for)
+        );
+        mRecurrenceTypeSpinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener() {
 
-                @Override
-                public void onItemSelected(MaterialSpinner view, int position, long id, Object item) {
-                    switch (position) {
-                        case 0:
-                            updateRecurrenceType(RecurrenceSetting.TYPE_DAILY, true);
-                            break;
-                        case 1:
-                            updateRecurrenceType(RecurrenceSetting.TYPE_WEEKLY, true);
-                            break;
-                        case 2:
-                            updateRecurrenceType(RecurrenceSetting.TYPE_MONTHLY, true);
-                            break;
-                        case 3:
-                            updateRecurrenceType(RecurrenceSetting.TYPE_YEARLY, true);
-                            break;
-                    }
+            @Override
+            public void onItemSelected(MaterialSpinner view, int position, long id, Object item) {
+                switch (position) {
+                    case 0:
+                        updateRecurrenceType(RecurrenceSetting.TYPE_DAILY, true);
+                        break;
+                    case 1:
+                        updateRecurrenceType(RecurrenceSetting.TYPE_WEEKLY, true);
+                        break;
+                    case 2:
+                        updateRecurrenceType(RecurrenceSetting.TYPE_MONTHLY, true);
+                        break;
+                    case 3:
+                        updateRecurrenceType(RecurrenceSetting.TYPE_YEARLY, true);
+                        break;
                 }
+            }
 
-            });
-            mRecurrenceStartDateSpinner.setOnClickListener(new View.OnClickListener() {
+        });
+        mRecurrenceStartDateSpinner.setOnClickListener(new View.OnClickListener() {
 
-                @Override
-                public void onClick(View v) {
-                    mStartDatePicker.showDatePicker();
-                    mRecurrenceStartDateSpinner.collapse();
+            @Override
+            public void onClick(View v) {
+                mStartDatePicker.showDatePicker();
+                mRecurrenceStartDateSpinner.collapse();
+            }
+
+        });
+        mRecurrenceTypeWeeklySundayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
+        mRecurrenceTypeWeeklyMondayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
+        mRecurrenceTypeWeeklyTuesdayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
+        mRecurrenceTypeWeeklyWednesdayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
+        mRecurrenceTypeWeeklyThursdayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
+        mRecurrenceTypeWeeklyFridayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
+        mRecurrenceTypeWeeklySaturdayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
+        mRecurrenceEndTypeSpinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener() {
+
+            @Override
+            public void onItemSelected(MaterialSpinner view, int position, long id, Object item) {
+                switch (position) {
+                    case 0:
+                        updateRecurrenceEndType(RecurrenceSetting.END_FOREVER, true);
+                        break;
+                    case 1:
+                        updateRecurrenceEndType(RecurrenceSetting.END_UNTIL, true);
+                        break;
+                    case 2:
+                        updateRecurrenceEndType(RecurrenceSetting.END_FOR, true);
+                        break;
                 }
+            }
 
-            });
-            mRecurrenceTypeWeeklySundayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
-            mRecurrenceTypeWeeklyMondayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
-            mRecurrenceTypeWeeklyTuesdayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
-            mRecurrenceTypeWeeklyWednesdayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
-            mRecurrenceTypeWeeklyThursdayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
-            mRecurrenceTypeWeeklyFridayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
-            mRecurrenceTypeWeeklySaturdayRadioButton.setOnCheckedChangeListener(mWeekdayChangeListener);
-            mRecurrenceEndTypeSpinner.setOnItemSelectedListener(new MaterialSpinner.OnItemSelectedListener() {
+        });
+        mRecurrenceEndDateSpinner.setOnClickListener(new View.OnClickListener() {
 
-                @Override
-                public void onItemSelected(MaterialSpinner view, int position, long id, Object item) {
-                    switch (position) {
-                        case 0:
-                            updateRecurrenceEndType(RecurrenceSetting.END_FOREVER, true);
-                            break;
-                        case 1:
-                            updateRecurrenceEndType(RecurrenceSetting.END_UNTIL, true);
-                            break;
-                        case 2:
-                            updateRecurrenceEndType(RecurrenceSetting.END_FOR, true);
-                            break;
-                    }
-                }
+            @Override
+            public void onClick(View v) {
+                mEndDatePicker.showDatePicker();
+                mRecurrenceEndDateSpinner.collapse();
+            }
 
-            });
-            mRecurrenceEndDateSpinner.setOnClickListener(new View.OnClickListener() {
-
-                @Override
-                public void onClick(View v) {
-                    mEndDatePicker.showDatePicker();
-                    mRecurrenceEndDateSpinner.collapse();
-                }
-
-            });
-        }
+        });
         // create sub-pickers
         FragmentManager fragmentManager = getChildFragmentManager();
         mStartDatePicker = DateTimePicker.createPicker(fragmentManager, TAG_START_DATE_PICKER, mRecurrenceSetting.getStartDate());

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/WalletPickerDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/WalletPickerDialog.java
@@ -21,11 +21,13 @@ package com.oriondev.moneywallet.ui.fragment.dialog;
 
 import android.app.Activity;
 import android.app.Dialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.loader.app.LoaderManager;
@@ -37,8 +39,7 @@ import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Wallet;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -88,28 +89,25 @@ public class WalletPickerDialog extends DialogFragment implements LoaderManager.
                 }
             }
         }
-        MaterialDialog.Builder builder = ThemedDialog.buildMaterialDialog(activity)
-                .title(R.string.dialog_wallet_picker_title)
-                .customView(R.layout.dialog_advanced_list, false);
+        View view = getLayoutInflater().inflate(R.layout.dialog_advanced_list, null);
+        MaterialAlertDialogBuilder builder = ThemedDialog.buildMaterialDialog(activity)
+                .setTitle(R.string.dialog_wallet_picker_title)
+                .setView(view);
         if (mSinglePicker) {
-            builder.positiveText(R.string.action_new)
-                    .negativeText(android.R.string.cancel)
-                    .onPositive(new MaterialDialog.SingleButtonCallback() {
+            builder.setPositiveButton(R.string.action_new, new DialogInterface.OnClickListener() {
 
                         @Override
-                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        public void onClick(DialogInterface dialog, int which) {
                             startActivity(new Intent(getActivity(), NewEditWalletActivity.class));
                         }
 
-                    });
+                    })
+                    .setNegativeButton(android.R.string.cancel, null);
         } else {
-            builder.positiveText(android.R.string.ok)
-                    .negativeText(android.R.string.cancel)
-                    .neutralText(R.string.action_new)
-                    .onPositive(new MaterialDialog.SingleButtonCallback() {
+            builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                         @Override
-                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        public void onClick(DialogInterface dialog, int which) {
                             if (mCallback != null) {
                                 Wallet[] wallets = new Wallet[mSelectedWallets.size()];
                                 for (int i = 0; i < mSelectedWallets.size(); i++) {
@@ -120,25 +118,23 @@ public class WalletPickerDialog extends DialogFragment implements LoaderManager.
                         }
 
                     })
-                    .onNeutral(new MaterialDialog.SingleButtonCallback() {
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .setNeutralButton(R.string.action_new, new DialogInterface.OnClickListener() {
 
                         @Override
-                        public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                        public void onClick(DialogInterface dialog, int which) {
                             startActivity(new Intent(getActivity(), NewEditWalletActivity.class));
                         }
 
                     });
         }
-        MaterialDialog dialog = builder.build();
+        AlertDialog dialog = builder.create();
         mCursorAdapter = new WalletSelectorCursorAdapter(this);
-        View view = dialog.getCustomView();
-        if (view != null) {
-            mRecyclerView = view.findViewById(R.id.recycler_view);
-            mMessageTextView = view.findViewById(R.id.message_text_view);
-            mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
-            mRecyclerView.setAdapter(mCursorAdapter);
-            mMessageTextView.setText(R.string.message_no_wallet_found);
-        }
+        mRecyclerView = view.findViewById(R.id.recycler_view);
+        mMessageTextView = view.findViewById(R.id.message_text_view);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(activity));
+        mRecyclerView.setAdapter(mCursorAdapter);
+        mMessageTextView.setText(R.string.message_no_wallet_found);
         mRecyclerView.setVisibility(View.GONE);
         mMessageTextView.setVisibility(View.GONE);
         LoaderManager.getInstance(this).restartLoader(DEFAULT_LOADER_ID, null, this);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/SearchMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/SearchMultiPanelFragment.java
@@ -20,6 +20,7 @@
 package com.oriondev.moneywallet.ui.fragment.multipanel;
 
 import android.app.Activity;
+import android.content.DialogInterface;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Bundle;
@@ -36,7 +37,6 @@ import androidx.loader.content.CursorLoader;
 import androidx.loader.content.Loader;
 import androidx.recyclerview.widget.LinearLayoutManager;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
@@ -173,49 +173,28 @@ public class SearchMultiPanelFragment extends MultiPanelCursorListItemFragment i
                 getString(R.string.hint_event),
                 getString(R.string.hint_place)
         };
+        final boolean[] checked = mSearchFlags.clone();
         ThemedDialog.buildMaterialDialog(getActivity())
-                .title(R.string.dialog_filter_search_title)
-                .items(items)
-                .itemsCallbackMultiChoice(getSelectedIndices(), new MaterialDialog.ListCallbackMultiChoice() {
+                .setTitle(R.string.dialog_filter_search_title)
+                .setMultiChoiceItems(items, checked, new DialogInterface.OnMultiChoiceClickListener() {
 
                     @Override
-                    public boolean onSelection(MaterialDialog dialog, Integer[] which, CharSequence[] text) {
-                        mSearchFlags = new boolean[] {
-                                isChecked(0, which),
-                                isChecked(1, which),
-                                isChecked(2, which),
-                                isChecked(3, which),
-                                isChecked(4, which),
-                                isChecked(5, which),
-                                isChecked(6, which)
-                        };
-                        recreateLoader();
-                        return true;
+                    public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+                        checked[which] = isChecked;
                     }
 
                 })
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        mSearchFlags = checked;
+                        recreateLoader();
+                    }
+
+                })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
-    }
-
-    private Integer[] getSelectedIndices() {
-        List<Integer> indices = new ArrayList<>();
-        for (int i = 0; i < mSearchFlags.length; i++) {
-            if (mSearchFlags[i]) {
-                indices.add(i);
-            }
-        }
-        return indices.toArray(new Integer[indices.size()]);
-    }
-
-    private boolean isChecked(int index, Integer[] which) {
-        for (Integer integer : which) {
-            if (integer == index) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @NonNull

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
@@ -22,12 +22,15 @@ package com.oriondev.moneywallet.ui.fragment.secondary;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
+import android.widget.EditText;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import androidx.fragment.app.Fragment;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
@@ -44,8 +47,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.BackendException;
 import com.oriondev.moneywallet.api.AbstractBackendServiceDelegate;
@@ -205,17 +206,21 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
 
                 @Override
                 public void onClick(View v) {
-                    ThemedDialog.buildMaterialDialog(v.getContext())
-                            .title(R.string.title_backup_create)
-                            .content(R.string.message_backup_create)
-                            .negativeText(android.R.string.cancel)
-                            .inputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD)
-                            .input(R.string.hint_password, 0, new MaterialDialog.InputCallback() {
+                    View inputView = LayoutInflater.from(v.getContext()).inflate(R.layout.dialog_input, null);
+                    final EditText inputEditText = inputView.findViewById(R.id.dialog_input_edit_text);
+                    inputEditText.setHint(R.string.hint_password);
+                    inputEditText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+                    AlertDialog dialog = ThemedDialog.buildMaterialDialog(v.getContext())
+                            .setTitle(R.string.title_backup_create)
+                            .setMessage(R.string.message_backup_create)
+                            .setView(inputView)
+                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                                 @Override
-                                public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
+                                public void onClick(DialogInterface dialog, int which) {
                                     Activity activity = getActivity();
                                     if (activity != null) {
+                                        CharSequence input = inputEditText.getText();
                                         IFile folder = mFileStack.isEmpty() ? ROOT_FOLDER : mFileStack.get(mFileStack.size() - 1);
                                         Intent intent = new Intent(activity, BackupHandlerIntentService.class);
                                         intent.putExtra(BackupHandlerIntentService.BACKEND_ID, mBackendService.getId());
@@ -230,7 +235,10 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
                                 }
 
                             })
-                            .show();
+                            .setNegativeButton(android.R.string.cancel, null)
+                            .create();
+                    // the three argument input() allowed an empty value, so an empty password is valid here
+                    ThemedDialog.showWithInput(dialog, inputEditText, true);
                 }
 
             });
@@ -351,14 +359,12 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
             if (mAllowRestore && activity != null) {
                 if (file.getName().endsWith(BackupManager.BACKUP_EXTENSION_STANDARD)) {
                     ThemedDialog.buildMaterialDialog(activity)
-                            .title(R.string.title_backup_restore)
-                            .content(R.string.message_backup_restore_standard)
-                            .positiveText(android.R.string.ok)
-                            .negativeText(android.R.string.cancel)
-                            .onPositive(new MaterialDialog.SingleButtonCallback() {
+                            .setTitle(R.string.title_backup_restore)
+                            .setMessage(R.string.message_backup_restore_standard)
+                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                                 @Override
-                                public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                                public void onClick(DialogInterface dialog, int which) {
                                     Intent intent = new Intent(getActivity(), BackupHandlerIntentService.class);
                                     intent.putExtra(BackupHandlerIntentService.BACKEND_ID, mBackendService.getId());
                                     intent.putExtra(BackupHandlerIntentService.ACTION, BackupHandlerIntentService.ACTION_RESTORE);
@@ -368,38 +374,41 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
                                 }
 
                             })
+                            .setNegativeButton(android.R.string.cancel, null)
                             .show();
                 } else if (file.getName().endsWith(BackupManager.BACKUP_EXTENSION_PROTECTED)) {
-                    ThemedDialog.buildMaterialDialog(activity)
-                            .title(R.string.title_backup_restore)
-                            .content(R.string.message_backup_restore_protected)
-                            .positiveText(android.R.string.ok)
-                            .inputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD)
-                            .input(R.string.hint_password, 0, false, new MaterialDialog.InputCallback() {
+                    View inputView = LayoutInflater.from(activity).inflate(R.layout.dialog_input, null);
+                    final EditText inputEditText = inputView.findViewById(R.id.dialog_input_edit_text);
+                    inputEditText.setHint(R.string.hint_password);
+                    inputEditText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+                    AlertDialog dialog = ThemedDialog.buildMaterialDialog(activity)
+                            .setTitle(R.string.title_backup_restore)
+                            .setMessage(R.string.message_backup_restore_protected)
+                            .setView(inputView)
+                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                                 @Override
-                                public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
+                                public void onClick(DialogInterface dialog, int which) {
                                     Intent intent = new Intent(getActivity(), BackupHandlerIntentService.class);
                                     intent.putExtra(BackupHandlerIntentService.BACKEND_ID, mBackendService.getId());
                                     intent.putExtra(BackupHandlerIntentService.ACTION, BackupHandlerIntentService.ACTION_RESTORE);
                                     intent.putExtra(BackupHandlerIntentService.BACKUP_FILE, file);
-                                    intent.putExtra(BackupHandlerIntentService.PASSWORD, input.toString());
+                                    intent.putExtra(BackupHandlerIntentService.PASSWORD, inputEditText.getText().toString());
                                     intent.putExtra(BackupHandlerIntentService.CALLER_ID, BACKUP_SERVICE_CALLER_ID);
                                     getActivity().startService(intent);
                                 }
 
                             })
-                            .show();
+                            .create();
+                    ThemedDialog.showWithInput(dialog, inputEditText, false);
                 } else if (file.getName().endsWith(BackupManager.BACKUP_EXTENSION_LEGACY)) {
                     ThemedDialog.buildMaterialDialog(activity)
-                            .title(R.string.title_backup_restore)
-                            .content(R.string.message_backup_restore_legacy)
-                            .positiveText(android.R.string.ok)
-                            .negativeText(android.R.string.cancel)
-                            .onPositive(new MaterialDialog.SingleButtonCallback() {
+                            .setTitle(R.string.title_backup_restore)
+                            .setMessage(R.string.message_backup_restore_legacy)
+                            .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                                 @Override
-                                public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                                public void onClick(DialogInterface dialog, int which) {
                                     Intent intent = new Intent(getActivity(), BackupHandlerIntentService.class);
                                     intent.putExtra(BackupHandlerIntentService.BACKEND_ID, mBackendService.getId());
                                     intent.putExtra(BackupHandlerIntentService.ACTION, BackupHandlerIntentService.ACTION_RESTORE);
@@ -409,6 +418,7 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
                                 }
 
                             })
+                            .setNegativeButton(android.R.string.cancel, null)
                             .show();
                 }
             }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BudgetItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BudgetItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -38,8 +39,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.RecurrenceSetting;
@@ -131,14 +130,12 @@ public class BudgetItemFragment extends SecondaryPanelFragment implements Loader
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_budget)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_budget)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_BUDGETS, getItemId());
@@ -150,6 +147,7 @@ public class BudgetItemFragment extends SecondaryPanelFragment implements Loader
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/CategoryItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/CategoryItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -42,8 +43,6 @@ import android.widget.RadioButton;
 import android.widget.RadioGroup;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -123,14 +122,12 @@ public class CategoryItemFragment extends SecondaryPanelFragment implements Load
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_category)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_category)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             try {
@@ -154,9 +151,9 @@ public class CategoryItemFragment extends SecondaryPanelFragment implements Load
                                 }
                                 if (contentRes != 0) {
                                     ThemedDialog.buildMaterialDialog(activity)
-                                            .title(R.string.title_error)
-                                            .content(contentRes)
-                                            .positiveText(android.R.string.ok)
+                                            .setTitle(R.string.title_error)
+                                            .setMessage(contentRes)
+                                            .setPositiveButton(android.R.string.ok, null)
                                             .show();
                                 }
                             }
@@ -164,6 +161,7 @@ public class CategoryItemFragment extends SecondaryPanelFragment implements Load
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/DebtItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/DebtItemFragment.java
@@ -24,6 +24,7 @@ import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -41,8 +42,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
@@ -142,14 +141,12 @@ public class DebtItemFragment extends SecondaryPanelFragment implements LoaderMa
 
     private void showArchiveDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_action_archive_debt)
-                .positiveText(android.R.string.yes)
-                .negativeText(android.R.string.no)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_action_archive_debt)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, getItemId());
@@ -164,19 +161,18 @@ public class DebtItemFragment extends SecondaryPanelFragment implements LoaderMa
                     }
 
                 })
+                .setNegativeButton(android.R.string.no, null)
                 .show();
     }
 
     private void showUnarchiveDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_action_unarchive_debt)
-                .positiveText(android.R.string.yes)
-                .negativeText(android.R.string.no)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_action_unarchive_debt)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, getItemId());
@@ -191,19 +187,18 @@ public class DebtItemFragment extends SecondaryPanelFragment implements LoaderMa
                     }
 
                 })
+                .setNegativeButton(android.R.string.no, null)
                 .show();
     }
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_debt)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_debt)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_DEBTS, getItemId());
@@ -215,6 +210,7 @@ public class DebtItemFragment extends SecondaryPanelFragment implements LoaderMa
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/EventItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/EventItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -40,8 +41,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -118,14 +117,12 @@ public class EventItemFragment extends SecondaryPanelFragment implements LoaderM
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_event)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_event)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_EVENTS, getItemId());
@@ -137,6 +134,7 @@ public class EventItemFragment extends SecondaryPanelFragment implements LoaderM
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PersonItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PersonItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -40,8 +41,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -118,14 +117,12 @@ public class PersonItemFragment extends SecondaryPanelFragment implements Loader
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_person)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_person)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_PEOPLE, getItemId());
@@ -137,6 +134,7 @@ public class PersonItemFragment extends SecondaryPanelFragment implements Loader
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PlaceItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/PlaceItemFragment.java
@@ -24,6 +24,7 @@ import android.content.ActivityNotFoundException;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -42,8 +43,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Coordinates;
 import com.oriondev.moneywallet.model.Icon;
@@ -105,9 +104,9 @@ public class PlaceItemFragment extends SecondaryPanelFragment implements LoaderM
                         Activity activity = getActivity();
                         if (activity != null) {
                             ThemedDialog.buildMaterialDialog(activity)
-                                    .title(R.string.title_error)
-                                    .content(R.string.message_error_activity_not_found)
-                                    .positiveText(android.R.string.ok)
+                                    .setTitle(R.string.title_error)
+                                    .setMessage(R.string.message_error_activity_not_found)
+                                    .setPositiveButton(android.R.string.ok, null)
                                     .show();
                         }
                     }
@@ -191,14 +190,12 @@ public class PlaceItemFragment extends SecondaryPanelFragment implements LoaderM
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_place)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_place)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_PLACES, getItemId());
@@ -210,6 +207,7 @@ public class PlaceItemFragment extends SecondaryPanelFragment implements LoaderM
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransactionItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransactionItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -40,8 +41,6 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.RecurrenceBroadcastReceiver;
 import com.oriondev.moneywallet.model.CurrencyUnit;
@@ -134,14 +133,12 @@ public class RecurrentTransactionItemFragment extends SecondaryPanelFragment imp
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_transaction_model)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_transaction_model)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_RECURRENT_TRANSACTIONS, getItemId());
@@ -154,6 +151,7 @@ public class RecurrentTransactionItemFragment extends SecondaryPanelFragment imp
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransferItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/RecurrentTransferItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -40,8 +41,6 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.broadcast.RecurrenceBroadcastReceiver;
 import com.oriondev.moneywallet.model.CurrencyUnit;
@@ -136,14 +135,12 @@ public class RecurrentTransferItemFragment extends SecondaryPanelFragment implem
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_recurrent_transfer)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_recurrent_transfer)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_RECURRENT_TRANSFERS, getItemId());
@@ -156,6 +153,7 @@ public class RecurrentTransferItemFragment extends SecondaryPanelFragment implem
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/SavingItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/SavingItemFragment.java
@@ -24,6 +24,7 @@ import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -41,8 +42,6 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
@@ -135,14 +134,12 @@ public class SavingItemFragment extends SecondaryPanelFragment implements Loader
 
     private void showArchiveDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_action_archive_saving)
-                .positiveText(android.R.string.yes)
-                .negativeText(android.R.string.no)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_action_archive_saving)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, getItemId());
@@ -157,19 +154,18 @@ public class SavingItemFragment extends SecondaryPanelFragment implements Loader
                     }
 
                 })
+                .setNegativeButton(android.R.string.no, null)
                 .show();
     }
 
     private void showUnarchiveDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_action_unarchive_saving)
-                .positiveText(android.R.string.yes)
-                .negativeText(android.R.string.no)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_action_unarchive_saving)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, getItemId());
@@ -184,19 +180,18 @@ public class SavingItemFragment extends SecondaryPanelFragment implements Loader
                     }
 
                 })
+                .setNegativeButton(android.R.string.no, null)
                 .show();
     }
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_saving)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_saving)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_SAVINGS, getItemId());
@@ -208,6 +203,7 @@ public class SavingItemFragment extends SecondaryPanelFragment implements Loader
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -40,8 +41,6 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Attachment;
 import com.oriondev.moneywallet.model.CurrencyUnit;
@@ -149,14 +148,12 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_transaction)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_transaction)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             try {
@@ -168,9 +165,9 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
                             } catch (SQLiteDataException e) {
                                 if (e.getErrorCode() == Contract.ErrorCode.TRANSACTION_USED_IN_TRANSFER) {
                                     ThemedDialog.buildMaterialDialog(activity)
-                                            .title(R.string.title_error)
-                                            .content(R.string.message_error_delete_transaction_of_transfer)
-                                            .positiveText(android.R.string.ok)
+                                            .setTitle(R.string.title_error)
+                                            .setMessage(R.string.message_error_delete_transaction_of_transfer)
+                                            .setPositiveButton(android.R.string.ok, null)
                                             .show();
                                 }
                             }
@@ -178,6 +175,7 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionModelItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionModelItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -40,8 +41,6 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -125,14 +124,12 @@ public class TransactionModelItemFragment extends SecondaryPanelFragment impleme
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_transaction_model)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_transaction_model)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTION_MODELS, getItemId());
@@ -144,6 +141,7 @@ public class TransactionModelItemFragment extends SecondaryPanelFragment impleme
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -40,8 +41,6 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Attachment;
 import com.oriondev.moneywallet.model.CurrencyUnit;
@@ -145,14 +144,12 @@ public class TransferItemFragment extends SecondaryPanelFragment implements Atta
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_transfer)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_transfer)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSFERS, getItemId());
@@ -164,6 +161,7 @@ public class TransferItemFragment extends SecondaryPanelFragment implements Atta
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferModelItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferModelItemFragment.java
@@ -23,6 +23,7 @@ import android.app.Activity;
 import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -40,8 +41,6 @@ import android.view.ViewGroup;
 import android.widget.CheckBox;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -127,14 +126,12 @@ public class TransferModelItemFragment extends SecondaryPanelFragment implements
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_transfer_model)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_transfer_model)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSFER_MODELS, getItemId());
@@ -146,6 +143,7 @@ public class TransferModelItemFragment extends SecondaryPanelFragment implements
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UserInterfaceSettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UserInterfaceSettingFragment.java
@@ -225,9 +225,9 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
                     Activity activity = getActivity();
                     if (activity != null) {
                         ThemedDialog.buildMaterialDialog(activity)
-                                .title(R.string.title_error)
-                                .content(R.string.message_error_activity_not_found)
-                                .positiveText(android.R.string.ok)
+                                .setTitle(R.string.title_error)
+                                .setMessage(R.string.message_error_activity_not_found)
+                                .setPositiveButton(android.R.string.ok, null)
                                 .show();
                     }
                 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/WalletItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/WalletItemFragment.java
@@ -24,6 +24,7 @@ import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
@@ -42,8 +43,6 @@ import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.afollestad.materialdialogs.DialogAction;
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
@@ -125,14 +124,12 @@ public class WalletItemFragment extends SecondaryPanelFragment implements Loader
 
     private void showArchiveDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_action_archive_wallet)
-                .positiveText(android.R.string.yes)
-                .negativeText(android.R.string.no)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_action_archive_wallet)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, getItemId());
@@ -147,19 +144,18 @@ public class WalletItemFragment extends SecondaryPanelFragment implements Loader
                     }
 
                 })
+                .setNegativeButton(android.R.string.no, null)
                 .show();
     }
 
     private void showUnarchiveDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_action_unarchive_wallet)
-                .positiveText(android.R.string.yes)
-                .negativeText(android.R.string.no)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_action_unarchive_wallet)
+                .setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, getItemId());
@@ -174,19 +170,18 @@ public class WalletItemFragment extends SecondaryPanelFragment implements Loader
                     }
 
                 })
+                .setNegativeButton(android.R.string.no, null)
                 .show();
     }
 
     private void showDeleteDialog(Context context) {
         ThemedDialog.buildMaterialDialog(context)
-                .title(R.string.title_warning)
-                .content(R.string.message_delete_wallet)
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .onPositive(new MaterialDialog.SingleButtonCallback() {
+                .setTitle(R.string.title_warning)
+                .setMessage(R.string.message_delete_wallet)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onClick(@NonNull MaterialDialog dialog, @NonNull DialogAction which) {
+                    public void onClick(DialogInterface dialog, int which) {
                         Activity activity = getActivity();
                         if (activity != null) {
                             try {
@@ -198,9 +193,9 @@ public class WalletItemFragment extends SecondaryPanelFragment implements Loader
                             } catch (SQLiteDataException e) {
                                 if (e.getErrorCode() == Contract.ErrorCode.WALLET_USED_IN_TRANSFER) {
                                     ThemedDialog.buildMaterialDialog(activity)
-                                            .title(R.string.title_error)
-                                            .content(R.string.message_error_delete_wallet_of_transfer)
-                                            .positiveText(android.R.string.ok)
+                                            .setTitle(R.string.title_error)
+                                            .setMessage(R.string.message_error_delete_wallet_of_transfer)
+                                            .setPositiveButton(android.R.string.ok, null)
                                             .show();
                                 }
                             }
@@ -208,6 +203,7 @@ public class WalletItemFragment extends SecondaryPanelFragment implements Loader
                     }
 
                 })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedInputPreference.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedInputPreference.java
@@ -20,12 +20,15 @@
 package com.oriondev.moneywallet.ui.preference;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
+import android.content.DialogInterface;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.EditText;
+import androidx.appcompat.app.AlertDialog;
 import androidx.preference.Preference;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 
@@ -96,14 +99,20 @@ public class ThemedInputPreference extends Preference {
     }
 
     private void showDialog() {
-        ThemedDialog.buildMaterialDialog(getContext())
-                .title(getTitle())
-                .content(mContent)
-                .inputType(mInputType)
-                .input(mHint, mValue, mAllowEmptyInput, new MaterialDialog.InputCallback() {
+        View inputView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_input, null);
+        final EditText inputEditText = inputView.findViewById(R.id.dialog_input_edit_text);
+        inputEditText.setHint(mHint);
+        inputEditText.setText(mValue);
+        inputEditText.setInputType(mInputType);
+        AlertDialog dialog = ThemedDialog.buildMaterialDialog(getContext())
+                .setTitle(getTitle())
+                .setMessage(mContent)
+                .setView(inputView)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public void onInput(@NonNull MaterialDialog dialog, CharSequence input) {
+                    public void onClick(DialogInterface dialog, int which) {
+                        CharSequence input = inputEditText.getText();
                         if (!TextUtils.equals(input, mValue)) {
                             mValue = input.toString();
                             callChangeListener(mValue);
@@ -111,8 +120,8 @@ public class ThemedInputPreference extends Preference {
                     }
 
                 })
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
-                .show();
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
+        ThemedDialog.showWithInput(dialog, inputEditText, mAllowEmptyInput);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedListPreference.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedListPreference.java
@@ -20,11 +20,11 @@
 package com.oriondev.moneywallet.ui.preference;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import androidx.preference.Preference;
 import android.util.AttributeSet;
 import android.view.View;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 
@@ -100,23 +100,29 @@ public class ThemedListPreference extends Preference {
     }
 
     private void showDialog() {
+        final int[] selected = new int[] {mCurrentValueIndex};
         ThemedDialog.buildMaterialDialog(getContext())
-                .title(getTitle())
-                .items(mEntries)
-                .itemsCallbackSingleChoice(mCurrentValueIndex, new MaterialDialog.ListCallbackSingleChoice() {
+                .setTitle(getTitle())
+                .setSingleChoiceItems(mEntries, mCurrentValueIndex, new DialogInterface.OnClickListener() {
 
                     @Override
-                    public boolean onSelection(MaterialDialog dialog, View itemView, int which, CharSequence text) {
-                        if (which != mCurrentValueIndex) {
-                            callChangeListener(mEntryValues[which]);
-                            mCurrentValueIndex = which;
-                        }
-                        return false;
+                    public void onClick(DialogInterface dialog, int which) {
+                        selected[0] = which;
                     }
 
                 })
-                .positiveText(android.R.string.ok)
-                .negativeText(android.R.string.cancel)
+                .setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        if (selected[0] != mCurrentValueIndex) {
+                            callChangeListener(mEntryValues[selected[0]]);
+                            mCurrentValueIndex = selected[0];
+                        }
+                    }
+
+                })
+                .setNegativeButton(android.R.string.cancel, null)
                 .show();
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/ColorSwatchView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/ColorSwatchView.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.view;
+
+import android.content.Context;
+import android.content.res.ColorStateList;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.graphics.drawable.RippleDrawable;
+import android.graphics.drawable.ShapeDrawable;
+import android.graphics.drawable.StateListDrawable;
+import android.graphics.drawable.shapes.OvalShape;
+import android.util.AttributeSet;
+import android.util.TypedValue;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.widget.FrameLayout;
+
+import androidx.annotation.ColorInt;
+
+import com.oriondev.moneywallet.utils.Utils;
+
+/**
+ * One color of the color chooser's grid, and the preview beside its hex field. Ported from the
+ * CircleView of material-dialogs 0.9.6.0, under the MIT license, minus the parts it drew nothing
+ * with.
+ */
+public class ColorSwatchView extends FrameLayout {
+
+    private static final float RING_WIDTH_DP = 5f;
+    private static final float WHITE_RING_WIDTH_DP = 3f;
+    private static final float PRESSED_ALPHA = 0.7f;
+
+    private final int mRingWidth;
+    private final int mWhiteRingWidth;
+
+    private final Paint mRingPaint;
+    private final Paint mWhitePaint;
+    private final Paint mFillPaint;
+
+    private boolean mSwatchSelected;
+
+    public ColorSwatchView(Context context) {
+        this(context, null, 0);
+    }
+
+    public ColorSwatchView(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public ColorSwatchView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        mRingWidth = dp(RING_WIDTH_DP);
+        mWhiteRingWidth = dp(WHITE_RING_WIDTH_DP);
+        mWhitePaint = new Paint();
+        mWhitePaint.setAntiAlias(true);
+        mWhitePaint.setColor(Color.WHITE);
+        mFillPaint = new Paint();
+        mFillPaint.setAntiAlias(true);
+        mRingPaint = new Paint();
+        mRingPaint.setAntiAlias(true);
+        setColor(Color.DKGRAY);
+        setWillNotDraw(false);
+    }
+
+    private int dp(float value) {
+        return (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, value,
+                getResources().getDisplayMetrics());
+    }
+
+    @ColorInt
+    private static int shiftColor(@ColorInt int color, float by) {
+        float[] hsv = new float[3];
+        Color.colorToHSV(color, hsv);
+        hsv[2] *= by;
+        return Color.HSVToColor(hsv);
+    }
+
+    @ColorInt
+    private static int translucent(@ColorInt int color) {
+        return Color.argb(Math.round(Color.alpha(color) * PRESSED_ALPHA),
+                Color.red(color), Color.green(color), Color.blue(color));
+    }
+
+    public void setColor(@ColorInt int color) {
+        mFillPaint.setColor(color);
+        mRingPaint.setColor(shiftColor(color, 0.9f));
+        ShapeDrawable pressedCircle = new ShapeDrawable(new OvalShape());
+        pressedCircle.getPaint().setColor(translucent(shiftColor(color, 1.1f)));
+        StateListDrawable pressed = new StateListDrawable();
+        pressed.addState(new int[] {android.R.attr.state_pressed}, pressedCircle);
+        ColorStateList ripple = new ColorStateList(
+                new int[][] {new int[] {android.R.attr.state_pressed}},
+                new int[] {shiftColor(color, 1.1f)}
+        );
+        setForeground(new RippleDrawable(ripple, pressed, null));
+        setContentDescription(Utils.getHexColor(color));
+        invalidate();
+    }
+
+    // The ring is the chooser's own flag, not the framework's selected flag, which GridView also
+    // writes for its own reasons.
+    public void setSwatchSelected(boolean selected) {
+        mSwatchSelected = selected;
+        invalidate();
+    }
+
+    public boolean isSwatchSelected() {
+        return mSwatchSelected;
+    }
+
+    @Override
+    public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
+        super.onInitializeAccessibilityNodeInfo(info);
+        info.setSelected(mSwatchSelected);
+    }
+
+    @Override
+    protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        super.onMeasure(widthMeasureSpec, widthMeasureSpec);
+        setMeasuredDimension(getMeasuredWidth(), getMeasuredWidth());
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        super.onDraw(canvas);
+        int centerX = getMeasuredWidth() / 2;
+        int centerY = getMeasuredHeight() / 2;
+        int outerRadius = getMeasuredWidth() / 2;
+        if (mSwatchSelected) {
+            int whiteRadius = outerRadius - mRingWidth;
+            canvas.drawCircle(centerX, centerY, outerRadius, mRingPaint);
+            canvas.drawCircle(centerX, centerY, whiteRadius, mWhitePaint);
+            canvas.drawCircle(centerX, centerY, whiteRadius - mWhiteRingWidth, mFillPaint);
+        } else {
+            canvas.drawCircle(centerX, centerY, outerRadius, mFillPaint);
+        }
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/FullHeightGridView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/FullHeightGridView.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.view;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.widget.GridView;
+
+/**
+ * A grid that measures every one of its rows, so the ScrollView above it is what scrolls and the
+ * views below it keep their own height, ported from the FillGridView of material-dialogs 0.9.6.0
+ * under the MIT license.
+ */
+public class FullHeightGridView extends GridView {
+
+    public FullHeightGridView(Context context) {
+        super(context);
+    }
+
+    public FullHeightGridView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public FullHeightGridView(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    @Override
+    public void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+        int expandSpec = MeasureSpec.makeMeasureSpec(Integer.MAX_VALUE >> 2, MeasureSpec.AT_MOST);
+        super.onMeasure(widthMeasureSpec, expandSpec);
+    }
+}

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedDialog.java
@@ -20,12 +20,27 @@
 package com.oriondev.moneywallet.ui.view.theme;
 
 import android.content.Context;
-import androidx.annotation.StringRes;
+import android.content.DialogInterface;
+import android.content.res.ColorStateList;
+import android.content.res.Resources;
+import android.os.Build;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.ContextThemeWrapper;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.EditText;
 
-import com.afollestad.materialdialogs.MaterialDialog;
-import com.afollestad.materialdialogs.Theme;
-import com.afollestad.materialdialogs.color.ColorChooserDialog;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.StyleRes;
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.view.ViewCompat;
+import androidx.core.widget.NestedScrollView;
+
 import com.github.rubensousa.bottomsheetbuilder.BottomSheetBuilder;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
 import com.oriondev.moneywallet.R;
 import com.philliphsu.bottomsheetpickers.date.DatePickerDialog;
 import com.philliphsu.bottomsheetpickers.time.BottomSheetTimePickerDialog;
@@ -36,24 +51,171 @@ import com.philliphsu.bottomsheetpickers.time.numberpad.NumberPadTimePickerDialo
  */
 public class ThemedDialog {
 
-    public static MaterialDialog.Builder buildMaterialDialog(Context context) {
-        MaterialDialog.Builder builder = new MaterialDialog.Builder(context);
-        ITheme theme = ThemeEngine.getTheme();
-        builder.theme(theme.isDark() ? Theme.DARK : Theme.LIGHT);
-        int background = theme.getColorCardBackground();
-        int accent = Util.visibleOr(theme.getColorAccent(), background, theme.getBestTextColor(background));
-        builder.positiveColor(accent);
-        builder.negativeColor(accent);
-        builder.neutralColor(accent);
-        builder.widgetColor(accent);
-        return builder;
+    // What material-dialogs faded a disabled action to.
+    private static final float DISABLED_BUTTON_ALPHA = 0.4f;
+
+    public static MaterialAlertDialogBuilder buildMaterialDialog(Context context) {
+        return new ThemedAlertDialogBuilder(context);
     }
 
-    public static ColorChooserDialog.Builder buildColorChooserDialog(Context context, @StringRes int title) {
-        ColorChooserDialog.Builder builder = new ColorChooserDialog.Builder(context, R.string.dialog_color_picker_title);
+    /**
+     * The accent as it lands on a dialog, contrast checked against the dialog surface so it falls
+     * back to readable text when the user picks an accent that disappears there. Public because a
+     * dialog outside this package tints a widget of its own with it.
+     */
+    public static int getAccentColor() {
         ITheme theme = ThemeEngine.getTheme();
-        builder.theme(theme.isDark() ? Theme.DARK : Theme.LIGHT);
-        return builder;
+        int background = theme.getColorCardBackground();
+        return Util.visibleOr(theme.getColorAccent(), background, theme.getBestTextColor(background));
+    }
+
+    /**
+     * The faded foreground for a control that is idle or disabled on a dialog, the same hint color
+     * the theme engine hands a hint on that surface. It is read off the dialog surface and not off
+     * the accent, so it stays visible whatever accent the user picks.
+     */
+    public static int getIdleColor() {
+        ITheme theme = ThemeEngine.getTheme();
+        return theme.getBestHintColor(theme.getColorCardBackground());
+    }
+
+    /**
+     * The one definition of which dialog style the app draws a dialog with. The builder and the
+     * scrollable custom view both read it here so the two cannot drift apart.
+     */
+    @StyleRes
+    private static int getDialogTheme() {
+        return ThemeEngine.getTheme().isDark() ? R.style.MoneyWalletAlertDialogDark : R.style.MoneyWalletAlertDialogLight;
+    }
+
+    /**
+     * AlertDialog.setView does not scroll what it is given, so the layouts that used to ask
+     * material-dialogs to wrap them in a scroller carry their own.
+     */
+    public static View inflateScrollableView(Context context, @LayoutRes int layoutRes) {
+        // Every caller passes an activity, whose theme is light in every mode, so a plain widget
+        // in the layout would resolve its text colors light and draw dark on a dark dialog. The
+        // wrapper puts the layout on the same dialog style the builder picks.
+        Context themedContext = new ContextThemeWrapper(context, getDialogTheme());
+        NestedScrollView scrollView = new NestedScrollView(themedContext);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            // The framework paints selectableItemBackground over the scroller's whole bounds while
+            // the scroller holds focus itself, which it takes outside touch mode once an arrow key
+            // scrolls the focused child off screen.
+            scrollView.setDefaultFocusHighlightEnabled(false);
+        }
+        View content = LayoutInflater.from(themedContext).inflate(layoutRes, scrollView, false);
+        Resources resources = context.getResources();
+        int sidePadding = resources.getDimensionPixelSize(R.dimen.material_dialog_custom_view_start_end_padding);
+        int verticalPadding = resources.getDimensionPixelSize(R.dimen.material_dialog_custom_view_top_bottom_padding);
+        // The side padding replaces what the layout declared instead of adding to it, which is
+        // what material-dialogs did with a wrapped custom view, so a layout that already carries
+        // its own 24dp keeps 24dp. The scroller does not clip it so the content can scroll
+        // through the vertical padding.
+        content.setPaddingRelative(sidePadding, 0, sidePadding, 0);
+        scrollView.setPadding(0, verticalPadding, 0, verticalPadding);
+        scrollView.setClipToPadding(false);
+        scrollView.addView(content);
+        return scrollView;
+    }
+
+    /**
+     * Raises the soft keyboard with the dialog and keeps the positive button disabled while the
+     * field is empty, which is what material-dialogs did for an input declared without allowing an
+     * empty value. The button only exists once the dialog has been shown, so this runs after show.
+     */
+    public static void showWithInput(AlertDialog dialog, final EditText editText, final boolean allowEmpty) {
+        tintInput(editText);
+        // A caller that prefills the field would otherwise leave the caret in front of that text
+        // and have the first keystroke land at the front of the stored value.
+        editText.setSelection(editText.length());
+        dialog.getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE
+                | WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN);
+        dialog.show();
+        if (allowEmpty) {
+            return;
+        }
+        final Button positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+        positiveButton.setEnabled(editText.length() > 0);
+        editText.addTextChangedListener(new TextWatcher() {
+
+            @Override
+            public void beforeTextChanged(CharSequence text, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence text, int start, int before, int count) {
+                positiveButton.setEnabled(text.length() > 0);
+            }
+
+            @Override
+            public void afterTextChanged(Editable text) {}
+        });
+    }
+
+    /**
+     * Paints the underline with the accent while the field is live and leaves it faded while the
+     * field is disabled or idle, and paints the typed text and the hint. All of it comes from the
+     * theme engine, not from colorControlNormal or textColorPrimary on the inflating context,
+     * because that context is the activity and its theme is light in every mode.
+     */
+    public static void tintInput(EditText editText) {
+        int accent = getAccentColor();
+        int idle = getIdleColor();
+        ColorStateList colors = new ColorStateList(
+                new int[][] {
+                        new int[] {-android.R.attr.state_enabled},
+                        new int[] {-android.R.attr.state_pressed, -android.R.attr.state_focused},
+                        new int[] {}
+                },
+                new int[] {idle, idle, accent}
+        );
+        ViewCompat.setBackgroundTintList(editText, colors);
+        TintHelper.setCursorTint(editText, accent);
+        ITheme theme = ThemeEngine.getTheme();
+        editText.setTextColor(theme.getBestTextColor(theme.getColorCardBackground()));
+        editText.setHintTextColor(idle);
+    }
+
+    /**
+     * The single alert dialog factory for the app. It picks the light or dark dialog theme,
+     * because ThemeEngine paints views by hand and never sets an XML theme, and puts the accent on
+     * the buttons, which only exist once the dialog is shown.
+     */
+    private static class ThemedAlertDialogBuilder extends MaterialAlertDialogBuilder {
+
+        private final ColorStateList mButtonColors;
+
+        private ThemedAlertDialogBuilder(Context context) {
+            super(context, getDialogTheme());
+            int accent = getAccentColor();
+            mButtonColors = new ColorStateList(
+                    new int[][] {new int[] {-android.R.attr.state_enabled}, new int[] {}},
+                    new int[] {Util.adjustAlpha(accent, DISABLED_BUTTON_ALPHA), accent}
+            );
+        }
+
+        @Override
+        public AlertDialog create() {
+            final AlertDialog dialog = super.create();
+            dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+
+                @Override
+                public void onShow(DialogInterface unused) {
+                    tintButton(dialog, AlertDialog.BUTTON_POSITIVE);
+                    tintButton(dialog, AlertDialog.BUTTON_NEGATIVE);
+                    tintButton(dialog, AlertDialog.BUTTON_NEUTRAL);
+                }
+            });
+            return dialog;
+        }
+
+        private void tintButton(AlertDialog dialog, int which) {
+            Button button = dialog.getButton(which);
+            if (button != null) {
+                // A state list, not a single color, so a disabled button still reads as disabled.
+                button.setTextColor(mButtonColors);
+            }
+        }
     }
 
     public static DatePickerDialog.Builder buildDatePickerDialog(DatePickerDialog.OnDateSetListener listener, int year, int monthOfYear, int dayOfMonth) {

--- a/app/src/main/res/layout/dialog_color_chooser.xml
+++ b/app/src/main/res/layout/dialog_color_chooser.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:defaultFocusHighlightEnabled="false"
+    android:fadeScrollbars="false"
+    android:scrollbars="vertical"
+    tools:targetApi="o">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <com.oriondev.moneywallet.ui.view.FullHeightGridView
+            android:id="@+id/color_chooser_grid_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="false"
+            android:columnWidth="@dimen/color_chooser_swatch_size"
+            android:gravity="center"
+            android:horizontalSpacing="8dp"
+            android:numColumns="auto_fit"
+            android:padding="16dp"
+            android:stretchMode="columnWidth"
+            android:verticalSpacing="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingLeft="?attr/dialogPreferredPadding"
+            android:paddingRight="?attr/dialogPreferredPadding"
+            android:paddingBottom="8dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="#"
+                tools:ignore="HardcodedText" />
+
+            <EditText
+                android:id="@+id/color_chooser_hex_edit_text"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:layout_marginEnd="16dp"
+                android:layout_weight="1"
+                android:digits="0123456789abcdefABCDEF"
+                android:hint="2196F3"
+                android:importantForAutofill="no"
+                android:inputType="text"
+                android:maxLines="1"
+                android:singleLine="true"
+                tools:ignore="HardcodedText" />
+
+            <com.oriondev.moneywallet.ui.view.ColorSwatchView
+                android:id="@+id/color_chooser_preview_view"
+                android:layout_width="24dp"
+                android:layout_height="24dp" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/dialog_input.xml
+++ b/app/src/main/res/layout/dialog_input.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="?attr/dialogPreferredPadding"
+    android:paddingRight="?attr/dialogPreferredPadding"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp">
+
+    <EditText
+        android:id="@+id/dialog_input_edit_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:importantForAutofill="no"
+        android:inputType="text"
+        android:maxLines="1"
+        android:singleLine="true"
+        tools:ignore="LabelFor">
+
+        <requestFocus/>
+
+    </EditText>
+
+</FrameLayout>

--- a/app/src/main/res/layout/dialog_progress_determinate.xml
+++ b/app/src/main/res/layout/dialog_progress_determinate.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingLeft="?attr/dialogPreferredPadding"
+    android:paddingRight="?attr/dialogPreferredPadding"
+    android:paddingTop="8dp"
+    android:paddingBottom="16dp">
+
+    <TextView
+        android:id="@+id/dialog_progress_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?android:attr/textColorSecondary"/>
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/dialog_progress_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:layout_marginBottom="6dp"/>
+
+    <TextView
+        android:id="@+id/dialog_progress_percentage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="36dp"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textStyle="bold"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_progress_indeterminate.xml
+++ b/app/src/main/res/layout/dialog_progress_indeterminate.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingLeft="?attr/dialogPreferredPadding"
+    android:paddingRight="?attr/dialogPreferredPadding"
+    android:paddingTop="8dp"
+    android:paddingBottom="16dp">
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/dialog_progress_indicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"/>
+
+    <TextView
+        android:id="@+id/dialog_progress_message"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:textAppearance="?attr/textAppearanceBody2"
+        android:textColor="?android:attr/textColorSecondary"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/dialog_recycler_view.xml
+++ b/app/src/main/res/layout/dialog_recycler_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/dialog_recycler_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clipToPadding="false"
+    android:defaultFocusHighlightEnabled="false"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:scrollbars="vertical"
+    tools:targetApi="o"/>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -26,4 +26,12 @@
     <color name="textSecondary">#8A000000</color>
     <color name="textPrimaryInverted">#DEFFFFFF</color>
     <color name="textSecondaryInverted">#8AFFFFFF</color>
+
+    <!-- The dark alert dialog palette. These are the values Theme.AppCompat.Dialog.Alert resolves
+         to, kept by hand because the AppCompat resources behind them are private. -->
+    <color name="dialogDarkBackground">#FF424242</color>
+    <color name="dialogDarkTextPrimary">#FFFFFFFF</color>
+    <color name="dialogDarkTextSecondary">#B3FFFFFF</color>
+    <color name="dialogDarkTextHint">#80FFFFFF</color>
+    <color name="dialogDarkControlHighlight">#33FFFFFF</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -49,6 +49,9 @@
     <dimen name="material_dialog_seek_bar_start_end_margin">6dp</dimen>
     <dimen name="material_dialog_seek_bar_top_bottom_margin">4dp</dimen>
     <dimen name="material_dialog_mtv_start_end_margin">8dp</dimen>
+    <dimen name="material_dialog_custom_view_start_end_padding">24dp</dimen>
+    <dimen name="material_dialog_custom_view_top_bottom_padding">8dp</dimen>
+    <dimen name="color_chooser_swatch_size">56dp</dimen>
 
     <dimen name="material_component_lists_padding_top">8dp</dimen>
     <dimen name="material_component_lists_padding_bottom">8dp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,6 +83,7 @@
     <string name="action_open">"Open"</string>
     <string name="action_undo">"Undo"</string>
     <string name="action_skip">"Skip"</string>
+    <string name="action_back">"Back"</string>
 
     <string name="msg_no_wallet_found">"No wallet found"</string>
     <string name="msg_add_one_wallet">"Please add one wallet"</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -32,6 +32,24 @@
         <item name="drawerArrowStyle">@style/MoneyWalletDrawerArrowStyle</item>
     </style>
 
+    <!-- ThemedDialog picks one of these two for every alert dialog in the app. ThemeEngine repaints
+         views by hand and never sets an XML theme, and the app theme is light, so without an
+         explicit dark overlay both dark modes would draw a light dialog. -->
+    <style name="MoneyWalletAlertDialogLight" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog"/>
+
+    <style name="MoneyWalletAlertDialogDark" parent="ThemeOverlay.MaterialComponents.MaterialAlertDialog">
+        <item name="colorSurface">@color/dialogDarkBackground</item>
+        <item name="colorOnSurface">@color/dialogDarkTextPrimary</item>
+        <item name="colorOnBackground">@color/dialogDarkTextPrimary</item>
+        <item name="android:colorBackground">@color/dialogDarkBackground</item>
+        <item name="android:textColorPrimary">@color/dialogDarkTextPrimary</item>
+        <item name="android:textColorSecondary">@color/dialogDarkTextSecondary</item>
+        <item name="android:textColorTertiary">@color/dialogDarkTextSecondary</item>
+        <item name="android:textColorHint">@color/dialogDarkTextHint</item>
+        <item name="colorControlNormal">@color/dialogDarkTextSecondary</item>
+        <item name="colorControlHighlight">@color/dialogDarkControlHighlight</item>
+    </style>
+
     <!-- The drawer icon morphs into the back arrow without spinning, as the drawer library's own
          style had it. -->
     <style name="MoneyWalletDrawerArrowStyle" parent="Widget.AppCompat.DrawerArrowToggle">

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivityTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditTransactionActivityTest.java
@@ -8,13 +8,14 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.net.Uri;
 import android.view.View;
+import android.widget.TextView;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.widget.Toolbar;
 import androidx.lifecycle.Lifecycle;
 import androidx.test.core.app.ActivityScenario;
 import androidx.test.core.app.ApplicationProvider;
 
-import com.afollestad.materialdialogs.MaterialDialog;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Attachment;
 import com.oriondev.moneywallet.model.Category;
@@ -271,11 +272,12 @@ public class NewEditTransactionActivityTest {
                 assertFalse(activity.isFinishing());
                 // the lowest this saving reaches is minus 5000 and the ceiling is held at
                 // nothing, so the refusal names 0.00 and not a negative figure
-                MaterialDialog dialog = (MaterialDialog) ShadowDialog.getLatestDialog();
+                AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+                TextView message = dialog.findViewById(android.R.id.message);
                 assertEquals(activity.getString(R.string.error_saving_withdraw_over_balance,
                         MoneyFormatter.getInstance().getNotTintedString(
                                 CurrencyManager.getCurrency("EUR"), 0L)),
-                        dialog.getContentView().getText().toString());
+                        message.getText().toString());
                 moneyPicker(activity).setMoney(0L);
                 save(activity);
                 assertTrue(activity.isFinishing());

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorChooserDialogTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorChooserDialogTest.java
@@ -1,0 +1,272 @@
+package com.oriondev.moneywallet.ui.fragment.dialog;
+
+import android.graphics.Color;
+import android.os.Looper;
+import android.util.DisplayMetrics;
+import android.view.View;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.GridView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.view.ColorSwatchView;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+/**
+ * Drives the color chooser on the JVM under a host fragment that plays the caller: which swatch it
+ * opens on, what the hex field reads, and which color OK hands back. The swatches it reads are the
+ * grid's own children, so what it sees is what the grid draws.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ColorChooserDialogTest {
+
+    private static final String TAG_HOST = "ColorChooserDialogTest::Host";
+    private static final String TAG_DIALOG = "ColorChooserDialogTest::Dialog";
+
+    /** The caller the dialog resolves its callback from, keeping what it was handed. */
+    public static class HostFragment extends Fragment implements ColorChooserDialog.Callback {
+
+        Integer selected;
+        boolean dismissed;
+
+        @Override
+        public void onColorSelection(ColorChooserDialog dialog, int color) {
+            selected = color;
+        }
+
+        @Override
+        public void onColorChooserDismissed(ColorChooserDialog dialog) {
+            dismissed = true;
+        }
+    }
+
+    @Test
+    public void aPreselectThatThePaletteCarriesOpensOnItsSwatch() {
+        run(Color.parseColor("#3F51B5"), false, (host, dialog) -> {
+            assertTrue(swatch(dialog, 4).isSwatchSelected());
+            assertFalse(swatch(dialog, 0).isSwatchSelected());
+            assertEquals("3F51B5", hex(dialog).getText().toString());
+            ok(dialog);
+            assertEquals(Integer.valueOf(0xFF3F51B5), host.selected);
+        });
+    }
+
+    @Test
+    public void aPreselectOutsideThePaletteOpensOnNoSwatchAtAll() {
+        run(Color.parseColor("#FF0000"), false, (host, dialog) -> {
+            GridView grid = grid(dialog);
+            assertEquals(grid.getAdapter().getCount(), grid.getChildCount());
+            for (int index = 0; index < grid.getChildCount(); index++) {
+                assertFalse(swatch(dialog, index).isSwatchSelected());
+            }
+            assertEquals("FF0000", hex(dialog).getText().toString());
+            ok(dialog);
+            assertEquals(Integer.valueOf(0xFFFF0000), host.selected);
+        });
+    }
+
+    @Test
+    public void aColorTypedIntoTheHexFieldSelectsItsSwatch() {
+        run(Color.parseColor("#FF0000"), false, (host, dialog) -> {
+            hex(dialog).setText("4CAF50");
+            layout(dialog);
+            assertEquals("#4CAF50", preview(dialog).getContentDescription().toString());
+            assertTrue(swatch(dialog, 9).isSwatchSelected());
+            ok(dialog);
+            assertEquals(Integer.valueOf(0xFF4CAF50), host.selected);
+        });
+    }
+
+    @Test
+    public void aColorTypedWithAnExtraDigitIsCutToTheSixTheFieldHolds() {
+        run(Color.parseColor("#FF0000"), false, (host, dialog) -> {
+            hex(dialog).setText("4CAF50A");
+            layout(dialog);
+            assertEquals("4CAF50", hex(dialog).getText().toString());
+            assertTrue(swatch(dialog, 9).isSwatchSelected());
+            ok(dialog);
+            assertEquals(Integer.valueOf(0xFF4CAF50), host.selected);
+        });
+    }
+
+    @Test
+    public void aTapOnAHueOtherThanTheRingedOneTakesItsColorAndShade() {
+        run(Color.parseColor("#FF0000"), false, (host, dialog) -> {
+            swatch(dialog, 4).performClick();
+            layout(dialog);
+            assertEquals(10, grid(dialog).getChildCount());
+            // Indigo 500 is the hue itself and the sixth of the shades this level is showing.
+            assertTrue(swatch(dialog, 5).isSwatchSelected());
+            assertEquals("3F51B5", hex(dialog).getText().toString());
+            ok(dialog);
+            assertEquals(Integer.valueOf(0xFF3F51B5), host.selected);
+        });
+    }
+
+    @Test
+    public void backFromAShadeLevelRingsTheFamilyOfTheTypedColorAndDrillingBackInKeepsIt() {
+        run(Color.parseColor("#3F51B5"), false, (host, dialog) -> {
+            swatch(dialog, 4).performClick();
+            layout(dialog);
+            assertEquals(dialog.getString(R.string.action_back), negative(dialog).getText().toString());
+            assertEquals(10, grid(dialog).getChildCount());
+            assertTrue(swatch(dialog, 5).isSwatchSelected());
+            // Red 300, a shade of a hue other than the one this level is showing.
+            hex(dialog).setText("E57373");
+            layout(dialog);
+            GridView shades = grid(dialog);
+            assertEquals(shades.getAdapter().getCount(), shades.getChildCount());
+            for (int index = 0; index < shades.getChildCount(); index++) {
+                assertFalse(swatch(dialog, index).isSwatchSelected());
+            }
+            back(dialog);
+            layout(dialog);
+            assertEquals(19, grid(dialog).getChildCount());
+            assertTrue(swatch(dialog, 0).isSwatchSelected());
+            assertFalse(swatch(dialog, 4).isSwatchSelected());
+            assertEquals("E57373", hex(dialog).getText().toString());
+            swatch(dialog, 0).performClick();
+            layout(dialog);
+            assertEquals(dialog.getString(R.string.action_back), negative(dialog).getText().toString());
+            assertEquals(10, grid(dialog).getChildCount());
+            assertTrue(swatch(dialog, 3).isSwatchSelected());
+            assertEquals("E57373", hex(dialog).getText().toString());
+            ok(dialog);
+            assertEquals(Integer.valueOf(0xFFE57373), host.selected);
+        });
+    }
+
+    @Test
+    public void aPreselectCarryingAnAlphaChannelIsTakenAsItsOpaqueColor() {
+        run(0x803F51B5, false, (host, dialog) -> {
+            assertTrue(swatch(dialog, 4).isSwatchSelected());
+            assertEquals("3F51B5", hex(dialog).getText().toString());
+            ok(dialog);
+            assertEquals(Integer.valueOf(0xFF3F51B5), host.selected);
+        });
+    }
+
+    @Test
+    public void rotatingOnTheShadeLevelKeepsTheLevelTheRingAndTheField() {
+        run(Color.parseColor("#3F51B5"), false, (host, dialog) -> {
+            swatch(dialog, 4).performClick();
+            layout(dialog);
+            // Indigo 50, the first of the shades this level is showing.
+            hex(dialog).setText("E8EAF6");
+            layout(dialog);
+            assertTrue(swatch(dialog, 0).isSwatchSelected());
+
+            mController.recreate();
+            shadowOf(Looper.getMainLooper()).idle();
+            HostFragment restoredHost = (HostFragment) mController.get()
+                    .getSupportFragmentManager().findFragmentByTag(TAG_HOST);
+            assertNotNull(restoredHost);
+            ColorChooserDialog restored = (ColorChooserDialog) restoredHost
+                    .getChildFragmentManager().findFragmentByTag(TAG_DIALOG);
+            assertNotNull(restored);
+            layout(restored);
+            assertEquals(10, grid(restored).getChildCount());
+            assertTrue(swatch(restored, 0).isSwatchSelected());
+            assertEquals("E8EAF6", hex(restored).getText().toString());
+            assertEquals(restored.getString(R.string.action_back),
+                    negative(restored).getText().toString());
+
+            back(restored);
+            layout(restored);
+            assertEquals(19, grid(restored).getChildCount());
+            assertTrue(swatch(restored, 4).isSwatchSelected());
+            ok(restored);
+            assertEquals(Integer.valueOf(0xFFE8EAF6), restoredHost.selected);
+        });
+    }
+
+    private interface Case {
+
+        void run(HostFragment host, ColorChooserDialog dialog);
+    }
+
+    private ActivityController<AppCompatActivity> mController;
+
+    private void run(int preselect, boolean accentPalette, Case body) {
+        // The host is a bare AppCompatActivity, which the manifest does not declare, so it is
+        // driven through a controller instead of through ActivityScenario. The controller is a
+        // field so that a case which recreates the activity can reach it.
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        mController = controller;
+        try {
+            AppCompatActivity activity = controller.get();
+            HostFragment host = new HostFragment();
+            activity.getSupportFragmentManager().beginTransaction().add(host, TAG_HOST).commitNow();
+            ColorChooserDialog dialog = ColorChooserDialog.newInstance(
+                    R.string.dialog_color_picker_title, accentPalette, preselect);
+            dialog.show(host.getChildFragmentManager(), TAG_DIALOG);
+            host.getChildFragmentManager().executePendingTransactions();
+            assertNull(host.selected);
+            layout(dialog);
+            body.run(host, dialog);
+        } finally {
+            controller.close();
+        }
+    }
+
+    /**
+     * Measures and lays out the dialog's decor, which is what attaches the grid's children. The
+     * adapter rebuilds them on the next layout, so this runs again after anything that changes the
+     * grid.
+     */
+    private void layout(ColorChooserDialog dialog) {
+        View decor = dialog.getDialog().getWindow().getDecorView();
+        DisplayMetrics metrics = decor.getResources().getDisplayMetrics();
+        decor.measure(View.MeasureSpec.makeMeasureSpec(metrics.widthPixels, View.MeasureSpec.AT_MOST),
+                View.MeasureSpec.makeMeasureSpec(metrics.heightPixels, View.MeasureSpec.AT_MOST));
+        decor.layout(0, 0, decor.getMeasuredWidth(), decor.getMeasuredHeight());
+    }
+
+    private GridView grid(ColorChooserDialog dialog) {
+        return dialog.getDialog().findViewById(R.id.color_chooser_grid_view);
+    }
+
+    private ColorSwatchView swatch(ColorChooserDialog dialog, int index) {
+        return (ColorSwatchView) grid(dialog).getChildAt(index);
+    }
+
+    private EditText hex(ColorChooserDialog dialog) {
+        return dialog.getDialog().findViewById(R.id.color_chooser_hex_edit_text);
+    }
+
+    private ColorSwatchView preview(ColorChooserDialog dialog) {
+        return dialog.getDialog().findViewById(R.id.color_chooser_preview_view);
+    }
+
+    private Button negative(ColorChooserDialog dialog) {
+        return ((AlertDialog) dialog.getDialog()).getButton(AlertDialog.BUTTON_NEGATIVE);
+    }
+
+    private void back(ColorChooserDialog dialog) {
+        negative(dialog).performClick();
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    private void ok(ColorChooserDialog dialog) {
+        ((AlertDialog) dialog.getDialog()).getButton(AlertDialog.BUTTON_POSITIVE).performClick();
+        // AlertController hands the button click to a Handler, and the looper is paused here.
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/view/theme/ThemedDialogDarkModeTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/view/theme/ThemedDialogDarkModeTest.java
@@ -1,0 +1,203 @@
+package com.oriondev.moneywallet.ui.view.theme;
+
+import android.graphics.Color;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.fragment.dialog.GenericProgressDialog;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Holds the two dialog layouts that are inflated outside a dialog's own themed context to the dark
+ * surface they land on. The app theme is light in every mode, so a color the activity resolves is
+ * dark whatever mode the user picked, and on a dark dialog that leaves text on top of a surface of
+ * nearly its own tone.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ThemedDialogDarkModeTest {
+
+    private static final String TAG_DIALOG = "ThemedDialogDarkModeTest::Dialog";
+
+    /** The mode lives in shared preferences the engine holds open, so it outlives the test. */
+    @After
+    public void restoreLightMode() {
+        ThemeEngine.setMode(ThemeEngine.Mode.LIGHT);
+    }
+
+    @Test
+    public void aTintedInputTakesItsTextAndHintFromTheDialogSurface() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            AppCompatActivity activity = controller.get();
+
+            int lightCard = switchTo(ThemeEngine.Mode.LIGHT);
+            EditText onLight = inflateInput(activity);
+            ThemedDialog.tintInput(onLight);
+            assertDarker("light mode text", onLight.getCurrentTextColor(), lightCard);
+            assertDarker("light mode hint", onLight.getCurrentHintTextColor(), lightCard);
+            assertFadedHint("light mode", onLight);
+
+            int darkCard = switchTo(ThemeEngine.Mode.DARK);
+            assertNotEquals("the card background did not change with the mode", lightCard, darkCard);
+            EditText onDark = inflateInput(activity);
+            ThemedDialog.tintInput(onDark);
+            assertLighter("dark mode text", onDark.getCurrentTextColor(), darkCard);
+            assertLighter("dark mode hint", onDark.getCurrentHintTextColor(), darkCard);
+            assertFadedHint("dark mode", onDark);
+        } finally {
+            controller.close();
+        }
+    }
+
+    @Test
+    public void aProgressDialogInDarkModeDrawsItsMessageOnTheDarkSurface() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            AppCompatActivity activity = controller.get();
+            int darkCard = switchTo(ThemeEngine.Mode.DARK);
+            GenericProgressDialog dialog = GenericProgressDialog.newInstance(
+                    R.string.title_backup_creation, R.string.message_async_init, false);
+            dialog.show(activity.getSupportFragmentManager(), TAG_DIALOG);
+            activity.getSupportFragmentManager().executePendingTransactions();
+            assertNotNull(dialog.getDialog());
+            TextView message = dialog.getDialog().findViewById(R.id.dialog_progress_message);
+            assertNotNull(message);
+            assertLighter("progress message", message.getCurrentTextColor(), darkCard);
+        } finally {
+            controller.close();
+        }
+    }
+
+    @Test
+    public void aProgressDialogInLightModeDrawsItsMessageOnTheLightSurface() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            AppCompatActivity activity = controller.get();
+            int lightCard = switchTo(ThemeEngine.Mode.LIGHT);
+            GenericProgressDialog dialog = GenericProgressDialog.newInstance(
+                    R.string.title_backup_creation, R.string.message_async_init, false);
+            dialog.show(activity.getSupportFragmentManager(), TAG_DIALOG);
+            activity.getSupportFragmentManager().executePendingTransactions();
+            assertNotNull(dialog.getDialog());
+            TextView message = dialog.getDialog().findViewById(R.id.dialog_progress_message);
+            assertNotNull(message);
+            assertDarker("progress message", message.getCurrentTextColor(), lightCard);
+        } finally {
+            controller.close();
+        }
+    }
+
+    /**
+     * The WebDAV form is the one wrapped layout carrying plain widgets, so its colors come from
+     * whatever context inflateScrollableView hands the inflater.
+     */
+    @Test
+    public void theWebdavFormTakesItsColorsFromTheDialogSurface() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            AppCompatActivity activity = controller.get();
+
+            int darkCard = switchTo(ThemeEngine.Mode.DARK);
+            View onDark = ThemedDialog.inflateScrollableView(activity, R.layout.dialog_webdav_setup);
+            EditText darkUrl = onDark.findViewById(R.id.webdav_url_edit_text);
+            TextView darkNote = onDark.findViewById(R.id.webdav_hint_text_view);
+            assertNotNull(darkUrl);
+            assertNotNull(darkNote);
+            assertLighter("dark mode url text", darkUrl.getCurrentTextColor(), darkCard);
+            assertLighter("dark mode url hint", darkUrl.getCurrentHintTextColor(), darkCard);
+            assertLighter("dark mode note", darkNote.getCurrentTextColor(), darkCard);
+
+            int lightCard = switchTo(ThemeEngine.Mode.LIGHT);
+            View onLight = ThemedDialog.inflateScrollableView(activity, R.layout.dialog_webdav_setup);
+            EditText lightUrl = onLight.findViewById(R.id.webdav_url_edit_text);
+            TextView lightNote = onLight.findViewById(R.id.webdav_hint_text_view);
+            assertDarker("light mode url text", lightUrl.getCurrentTextColor(), lightCard);
+            assertDarker("light mode url hint", lightUrl.getCurrentHintTextColor(), lightCard);
+            assertDarker("light mode note", lightNote.getCurrentTextColor(), lightCard);
+        } finally {
+            controller.close();
+        }
+    }
+
+    /**
+     * Robolectric runs in touch mode, and View.isDefaultFocusHighlightNeeded returns false on that
+     * gate before it ever reads the flag, so the flag is what a test here can assert in place of
+     * the highlight the framework would otherwise paint over a focused root.
+     */
+    @Test
+    public void theFocusableDialogRootsSuppressTheDefaultFocusHighlight() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            AppCompatActivity activity = controller.get();
+
+            View chooser = activity.getLayoutInflater().inflate(R.layout.dialog_color_chooser, null);
+            assertFalse("the color chooser root still takes the highlight",
+                    chooser.getDefaultFocusHighlightEnabled());
+
+            View scroller = ThemedDialog.inflateScrollableView(activity, R.layout.dialog_webdav_setup);
+            assertFalse("the wrapping scroller still takes the highlight",
+                    scroller.getDefaultFocusHighlightEnabled());
+
+            View recycler = activity.getLayoutInflater().inflate(R.layout.dialog_recycler_view, null);
+            assertFalse("the recycler root still takes the highlight",
+                    recycler.getDefaultFocusHighlightEnabled());
+        } finally {
+            controller.close();
+        }
+    }
+
+    /** The inflater a caller reaches for, which carries the activity's theme and not a dialog's. */
+    private EditText inflateInput(AppCompatActivity activity) {
+        return activity.getLayoutInflater()
+                .inflate(R.layout.dialog_input, null)
+                .findViewById(R.id.dialog_input_edit_text);
+    }
+
+    /** Switches the engine's mode and hands back the card background that mode carries. */
+    private int switchTo(ThemeEngine.Mode mode) {
+        ThemeEngine.setMode(mode);
+        return ThemeEngine.getTheme().getColorCardBackground();
+    }
+
+    // Util.isColorLight is the single test getBestTextColor and getBestHintColor branch on, so a
+    // color and a background landing on opposite sides of it is what the engine calls readable.
+
+    private void assertLighter(String what, int color, int background) {
+        assertFalse(what + ": the background is not dark", Util.isColorLight(background));
+        assertTrue(what + ": the color is not light on it", Util.isColorLight(color));
+    }
+
+    private void assertDarker(String what, int color, int background) {
+        assertTrue(what + ": the background is not light", Util.isColorLight(background));
+        assertFalse(what + ": the color is not dark on it", Util.isColorLight(color));
+    }
+
+    /** A hint that carries as much alpha as the typed text stops reading as a hint. */
+    private void assertFadedHint(String what, EditText editText) {
+        assertTrue(what + ": the hint is faded past reading",
+                Color.alpha(editText.getCurrentHintTextColor()) >= 64);
+        assertTrue(what + ": the hint is not faded below the text",
+                Color.alpha(editText.getCurrentHintTextColor())
+                        < Color.alpha(editText.getCurrentTextColor()));
+    }
+}


### PR DESCRIPTION
Every dialog in the app came from an outside library last released in 2018. All of them are now built by the app itself, and the library is gone from the build.

Most dialogs read as they did, with the same wording, button colors and button order, on a panel that is a little narrower and rounded at the corners, under a smaller title. The color picker is the one that changed in kind. It opens on a grid of colors, tapping one drills into that color's shades, and the second button becomes a way back to the grid. It drops the transparency slider, the three sliders for the color channels and the toggle between the palette and a custom color, and puts a field of six hex digits under the grid on both levels. Colors are always fully opaque now, and a stored color that carried transparency is read as its opaque color.

Two decisions a reviewer might question. Dialog text takes its color from the app's own three modes and no longer from the screen behind the dialog, which fixed text drawing at nearly the tone of its own panel in both dark modes. And typing six digits is now the only way to reach a color the palette does not carry, where the old dialog had sliders for it.

Tested with 361 tests on the desktop harness, eight driving the color picker and five holding the dialog colors and the focus highlight in light and dark, and on an emulator over a seeded ledger against a build of the current release: 138 device tests, 52 screens across the three modes, right to left and landscape, no crash, the ledger untouched, and the app about three and a half megabytes smaller.

The text field fix was rechecked on the emulator afterwards in all three modes, hint and typed text both readable on the dark panel. Not tested on a device: the two progress dialogs, which appear only during a backup, restore, import or export, and the storage setup form, both held by the desktop tests alone.
