### PR TITLE
Stop the app closing when you set up a backup destination

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/api/AbstractBackendServiceDelegate.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/AbstractBackendServiceDelegate.java
@@ -25,6 +25,7 @@ import android.content.Intent;
 import androidx.activity.ComponentActivity;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import androidx.fragment.app.Fragment;
 
 /**
  * Created by andrea on 21/11/18.
@@ -49,6 +50,16 @@ public abstract class AbstractBackendServiceDelegate {
     public abstract int getBackupCoverAction();
 
     public abstract boolean isServiceEnabled(Context context);
+
+    /**
+     * Registers the activity result launchers this backend needs. A Fragment refuses a
+     * registration once its view has been created, so call this from onAttach or onCreate,
+     * never from {@link #setup}, which runs on a click. A backend that registers a launcher
+     * here needs this called before its {@link #setup}.
+     */
+    public void registerLaunchers(@NonNull Fragment fragment) {
+        // most backends have nothing to register
+    }
 
     public abstract void setup(ComponentActivity activity) throws BackendException;
 

--- a/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendService.java
@@ -37,11 +37,14 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
 
 /**
  * Created by andrea on 21/11/18.
  */
 public class DiskBackendService extends AbstractBackendServiceDelegate {
+
+    private ActivityResultLauncher<String> mPermissionLauncher;
 
     public DiskBackendService(BackendServiceStatusListener listener) {
         super(listener);
@@ -82,16 +85,15 @@ public class DiskBackendService extends AbstractBackendServiceDelegate {
     }
 
     @Override
-    public void setup(final ComponentActivity activity) throws BackendException {
-        final ActivityResultLauncher<String> launcher = activity.registerForActivityResult(
+    public void registerLaunchers(@NonNull final Fragment fragment) {
+        mPermissionLauncher = fragment.registerForActivityResult(
                 new ActivityResultContracts.RequestPermission(),
                 new ActivityResultCallback<Boolean>() {
                     @Override
                     public void onActivityResult(Boolean isGranted) {
                         setBackendServiceEnabled(isGranted);
                         if (!isGranted) {
-                            setBackendServiceEnabled(false);
-                            ThemedDialog.buildMaterialDialog(activity)
+                            ThemedDialog.buildMaterialDialog(fragment.requireActivity())
                                     .setTitle(R.string.title_warning)
                                     .setMessage(R.string.message_permission_required_not_granted)
                                     .show();
@@ -99,6 +101,10 @@ public class DiskBackendService extends AbstractBackendServiceDelegate {
                     }
                 }
         );
+    }
+
+    @Override
+    public void setup(final ComponentActivity activity) throws BackendException {
         if (ActivityCompat.shouldShowRequestPermissionRationale(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
             ThemedDialog.buildMaterialDialog(activity)
                     .setTitle(R.string.title_request_permission)
@@ -107,14 +113,14 @@ public class DiskBackendService extends AbstractBackendServiceDelegate {
 
                         @Override
                         public void onClick(DialogInterface dialog, int which) {
-                            launcher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+                            mPermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
                         }
 
                     })
                     .setNegativeButton(android.R.string.cancel, null)
                     .show();
         } else {
-            launcher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+            mPermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE);
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/api/saf/SAFBackendService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/saf/SAFBackendService.java
@@ -1,5 +1,6 @@
 package com.oriondev.moneywallet.api.saf;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -13,9 +14,11 @@ import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 
 import androidx.activity.ComponentActivity;
 import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts.OpenDocumentTree;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
 
 /**
  * Backend service used to access files over the android storage access framework.
@@ -33,6 +36,8 @@ public class SAFBackendService extends AbstractBackendServiceDelegate {
      * Preference key were the root uri is stored.
      */
     private static final String URI = "uri";
+
+    private ActivityResultLauncher<Uri> mFolderLauncher;
 
     public SAFBackendService(BackendServiceStatusListener listener) {
         super(listener);
@@ -80,14 +85,15 @@ public class SAFBackendService extends AbstractBackendServiceDelegate {
     }
 
     @Override
-    public void setup(final ComponentActivity activity) {
-        activity.registerForActivityResult(
+    public void registerLaunchers(@NonNull final Fragment fragment) {
+        mFolderLauncher = fragment.registerForActivityResult(
             new DocumentTreeContract(),
             new ActivityResultCallback<Uri>() {
                 @Override
                 public void onActivityResult(Uri uri) {
                     boolean enabled = false;
                     if (uri != null) {
+                        Activity activity = fragment.requireActivity();
                         activity.getContentResolver().takePersistableUriPermission(
                                 uri,
                                 FLAG_URI_READ_WRITE
@@ -97,7 +103,12 @@ public class SAFBackendService extends AbstractBackendServiceDelegate {
                     }
                     setBackendServiceEnabled(enabled);
                 }
-            }).launch(null);
+            });
+    }
+
+    @Override
+    public void setup(final ComponentActivity activity) {
+        mFolderLauncher.launch(null);
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragment.java
@@ -115,6 +115,9 @@ public class BackupHandlerFragment extends Fragment implements BackupFileAdapter
             mAllowRestore = arguments.getBoolean(ARG_ALLOW_RESTORE, true);
             String backendId = arguments.getString(ARG_BACKEND_ID, null);
             mBackendService = BackendServiceFactory.getServiceById(backendId, this);
+            if (mBackendService != null) {
+                mBackendService.registerLaunchers(this);
+            }
             mFileStack = new ArrayList<>();
             openOnDefaultFolder();
         } else {

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragmentTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragmentTest.java
@@ -1,0 +1,74 @@
+package com.oriondev.moneywallet.ui.fragment.secondary;
+
+import android.Manifest;
+import android.content.Context;
+import android.content.Intent;
+import android.view.View;
+
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.api.BackendServiceFactory;
+import com.oriondev.moneywallet.storage.database.TestDatabases;
+import com.oriondev.moneywallet.ui.activity.BackupListActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowActivity;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.robolectric.Shadows.shadowOf;
+
+/**
+ * The cover button is tapped while the activity is resumed, which is where a backend used to
+ * register its launcher and where AndroidX refuses a registration.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class BackupHandlerFragmentTest {
+
+    @Before
+    public void setUp() {
+        TestDatabases.useFreshDatabase(ApplicationProvider.<Context>getApplicationContext());
+    }
+
+    @Test
+    public void theExternalMemoryCoverButtonAsksForStoragePermission() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                clickTheCoverButton(activity, BackendServiceFactory.SERVICE_ID_EXTERNAL_MEMORY);
+                ShadowActivity.PermissionsRequest request = shadowOf(activity).getLastRequestedPermission();
+                assertNotNull(request);
+                assertEquals(Manifest.permission.WRITE_EXTERNAL_STORAGE, request.requestedPermissions[0]);
+            });
+        }
+    }
+
+    @Test
+    public void theLocalFolderCoverButtonOpensTheFolderPicker() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                clickTheCoverButton(activity, BackendServiceFactory.SERVICE_ID_SAF);
+                Intent picker = shadowOf(activity).getNextStartedActivity();
+                assertNotNull(picker);
+                assertEquals(Intent.ACTION_OPEN_DOCUMENT_TREE, picker.getAction());
+            });
+        }
+    }
+
+    private void clickTheCoverButton(FragmentActivity activity, String backendId) {
+        Fragment fragment = BackupHandlerFragment.newInstance(backendId, true, true);
+        activity.getSupportFragmentManager()
+                .beginTransaction()
+                .add(android.R.id.content, fragment, "BackupHandlerFragmentTest")
+                .commitNow();
+        View coverActionButton = fragment.requireView().findViewById(R.id.cover_action_button);
+        assertNotNull(coverActionButton);
+        coverActionButton.performClick();
+    }
+}


### PR DESCRIPTION
Setting up a backup destination closed the app. On the Backup services screen, tapping the button on either External Memory or Local folder shut Tallybook down every time, so neither destination could be connected at all. 1.7.0 is not affected, the crash arrived after it.

The screen was asking Android for a way to show a picker at the moment you tapped the button, and Android refuses that request once a screen is already up and running. The request now goes in while the screen is being built, and the tap only opens the picker.

Two things get better as a side effect. If Android shuts the app down while the folder picker is open, the folder you then choose comes back to the app instead of being thrown away. The old code also made that request again on every tap and never cleaned up the previous ones.

There is a test for each of the two destinations, and both fail on the current code with the same crash people are hitting.

Tested on an emulator against a real ledger: External Memory reaches the permission request instead of closing, Local folder opens the picker, a chosen folder takes a backup and lists it, and disconnecting hands the folder back. Killing the app behind the picker and then choosing a folder still worked.

Fixes #255
