### PR TITLE
Move every dependency into a version catalog and bump five libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,17 +31,17 @@ jobs:
       # Robolectric fetches the android-all jar for the SDK it runs against, about
       # 190 MB, into the Maven local repository and not the Gradle cache, so the
       # step above does not keep it. Which jar that is follows the Robolectric
-      # version and targetSdk, both set in app/build.gradle, so the key follows
-      # that file. A cache entry is never rewritten on an exact hit, which is why
-      # the key cannot be a constant. A bump would keep restoring the old jar and
-      # fetching the new one on every run. No restore-keys on purpose, since a
-      # restored entry is saved back as a union and nothing prunes a superseded
-      # jar, so an entry would grow by a jar per bump. An unrelated edit to that
-      # file costs one fetch instead.
+      # version, now in gradle/libs.versions.toml, and targetSdk, still in
+      # app/build.gradle, so the key follows both files. A cache entry is never
+      # rewritten on an exact hit, which is why the key cannot be a constant. A
+      # bump would keep restoring the old jar and fetching the new one on every
+      # run. No restore-keys on purpose, since a restored entry is saved back as
+      # a union and nothing prunes a superseded jar, so an entry would grow by a
+      # jar per bump. An unrelated edit to either file costs one fetch instead.
       - uses: actions/cache@v4
         with:
           path: ~/.m2/repository/org/robolectric
-          key: robolectric-${{ hashFiles('app/build.gradle') }}
+          key: robolectric-${{ hashFiles('app/build.gradle', 'gradle/libs.versions.toml') }}
 
       - run: ./gradlew clean testFlossOsmDebugUnitTest assembleFlossOsmDebug assembleFlossOsmDebugAndroidTest lintFlossOsmDebug
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,58 +109,53 @@ configurations {
 }
 
 dependencies {
-    // common dependencies
-    implementation supportDependencies.appcompat
-    implementation supportDependencies.constraintlayout
-    implementation supportDependencies.recyclerview
-    implementation supportDependencies.cardview
-    implementation supportDependencies.annotations
-    implementation supportDependencies.design
-    implementation supportDependencies.preference
-    implementation 'commons-io:commons-io:2.6'
-    // WebDAV needs PROPFIND and MKCOL. Android's HttpURLConnection validates the method against a
-    // fixed list and throws ProtocolException for both, so a real HTTP client is not optional here.
-    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    // Without this line documentfile resolves to 1.0.0, by way of legacy-support-core-utils.
-    // In 1.0.0 fromTreeUri drops the document id, so every folder under a granted tree
-    // resolves to the top of the tree. 1.0.1 keeps the id when the uri is a document uri.
-    implementation 'androidx.documentfile:documentfile:1.1.0'
-    implementation 'androidx.activity:activity:1.13.0'
-    implementation 'androidx.fragment:fragment:1.9.0'
-    // Used directly by the app and never declared until now.
-    implementation 'androidx.core:core:1.18.0'
-    implementation 'androidx.loader:loader:1.2.0'
-    implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
-    implementation 'androidx.viewpager:viewpager:1.1.0'
-    implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.2.0'
-    implementation 'androidx.collection:collection:1.6.0'
-    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.3.0'
-    implementation 'androidx.drawerlayout:drawerlayout:1.2.0'
-    implementation 'net.lingala.zip4j:zip4j:1.3.2'
-    implementation 'com.github.daniel-stoneuk:material-about-library:2.2.4'
-    implementation 'com.github.apl-devs:appintro:v4.2.3'
-    // jcenter-orphaned -> JitPack (aritraroy/PinLockView), same 2.1.0; Java package stays com.andrognito.pinlockview.
-    implementation 'com.github.aritraroy:PinLockView:2.1.0'
-    // jcenter-orphaned -> JitPack. aritraroy/PatternLockView has NO git tag/release, so it is pinned to the
-    // last code-bearing commit (b69afae9c1, libraryVersion 1.0.0). It is a multi-module project, hence the
-    // group.Repo:module coordinate form. Java package stays com.andrognito.patternlockview.
-    implementation 'com.github.aritraroy.PatternLockView:patternlockview:b69afae9c1'
-    implementation 'androidx.biometric:biometric:1.1.0'
-    implementation 'com.github.PhilJay:MPAndroidChart:v3.0.3'
-    implementation 'org.dmfs:lib-recur:0.11.1'
-    implementation 'com.opencsv:opencsv:4.4'
-    implementation 'net.sourceforge.jexcelapi:jxl:2.6.12'
-    implementation 'com.itextpdf:itextpdf:5.5.13'
-    implementation 'com.github.bumptech.glide:glide:4.8.0'
-    annotationProcessor 'com.github.bumptech.glide:compiler:4.8.0'
+    implementation libs.androidx.activity
+    implementation libs.androidx.annotation
+    implementation libs.androidx.appcompat
+    implementation libs.androidx.biometric
+    implementation libs.androidx.cardview
+    implementation libs.androidx.collection
+    implementation libs.androidx.constraintlayout
+    implementation libs.androidx.coordinatorlayout
+    implementation libs.androidx.core
+    implementation libs.androidx.documentfile
+    implementation libs.androidx.drawerlayout
+    implementation libs.androidx.fragment
+    implementation libs.androidx.loader
+    implementation libs.androidx.localbroadcastmanager
+    implementation libs.androidx.preference
+    implementation libs.androidx.recyclerview
+    implementation libs.androidx.swiperefreshlayout
+    implementation libs.androidx.viewpager
+    implementation libs.appintro
+    implementation libs.commons.io
+    implementation libs.glide
+    implementation libs.itextpdf
+    implementation libs.jxl
+    implementation libs.lib.recur
+    implementation libs.material
+    implementation libs.material.about.library
+    implementation libs.mpandroidchart
+    implementation libs.okhttp
+    implementation(libs.opencsv) {
+        // Nothing on the CSVReaderHeaderAware or CSVWriter path names either artifact, and
+        // those two classes are all this app uses opencsv for. Taking the two artifacts out
+        // drops about 480 KB from the release APK, which is not minified, so nothing else
+        // would.
+        exclude group: 'commons-beanutils'
+        exclude group: 'org.apache.commons', module: 'commons-collections4'
+    }
+    implementation libs.patternlockview
+    implementation libs.pinlockview
+    implementation libs.zip4j
     // osm flavor
-    osmImplementation 'org.osmdroid:osmdroid-android:6.1.1'
+    osmImplementation libs.osmdroid
     // test dependencies (local tests)
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:5.23.0'
-    testImplementation 'org.robolectric:robolectric:4.16.1'
-    testImplementation 'androidx.test:core:1.7.0'
+    testImplementation libs.junit
+    testImplementation libs.mockito.core
+    testImplementation libs.robolectric
+    testImplementation libs.androidx.test.core
     // android test dependencies (on-device tests)
-    androidTestImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.7.0'
+    androidTestImplementation libs.junit
+    androidTestImplementation libs.androidx.test.runner
 }

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporter.java
@@ -3,6 +3,7 @@ package com.oriondev.moneywallet.storage.database.data.csv;
 import android.content.Context;
 
 import com.opencsv.CSVReaderHeaderAware;
+import com.opencsv.exceptions.CsvValidationException;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.MoneyScale;
 import com.oriondev.moneywallet.storage.database.Contract;
@@ -151,7 +152,7 @@ public class CSVDataImporter extends AbstractDataImporter {
      * second pass, and the transaction that pass runs in takes the rows before it back out.
      */
     private void readRows(CSVReaderHeaderAware reader, boolean write) throws IOException {
-        Map<String, String> lineMap = reader.readMap();
+        Map<String, String> lineMap = readMap(reader);
         while (lineMap != null) {
             try {
                 readRow(lineMap, write);
@@ -164,7 +165,20 @@ public class CSVDataImporter extends AbstractDataImporter {
                 }
                 throw new RuntimeException("Line " + reader.getLinesRead() + ": " + e.getMessage(), e);
             }
-            lineMap = reader.readMap();
+            lineMap = readMap(reader);
+        }
+    }
+
+    /**
+     * opencsv declares a checked CsvValidationException on readMap, and IOException is what
+     * every caller above this class already handles. A row the parser cannot read throws
+     * CsvMalformedLineException, which is already an IOException and passes through untouched.
+     */
+    private static Map<String, String> readMap(CSVReaderHeaderAware reader) throws IOException {
+        try {
+            return reader.readMap();
+        } catch (CsvValidationException e) {
+            throw new IOException(e);
         }
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/adapter/pager/BarChartViewPagerAdapter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/adapter/pager/BarChartViewPagerAdapter.java
@@ -26,14 +26,10 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.github.mikephil.charting.charts.BarChart;
-import com.github.mikephil.charting.components.AxisBase;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.BarData;
-import com.github.mikephil.charting.data.Entry;
-import com.github.mikephil.charting.formatter.IAxisValueFormatter;
-import com.github.mikephil.charting.formatter.IValueFormatter;
-import com.github.mikephil.charting.utils.ViewPortHandler;
+import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.PeriodDetailSummaryData;
@@ -67,10 +63,10 @@ public class BarChartViewPagerAdapter  extends PagerAdapter {
             xAxis.setCenterAxisLabels(true);
             xAxis.setAxisMinimum(0f);
             xAxis.setAxisMaximum(mData.getPeriodCount());
-            xAxis.setValueFormatter(new IAxisValueFormatter() {
+            xAxis.setValueFormatter(new ValueFormatter() {
 
                 @Override
-                public String getFormattedValue(float value, AxisBase axis) {
+                public String getFormattedValue(float value) {
                     return String.valueOf((int) value + 1);
                 }
 
@@ -117,7 +113,7 @@ public class BarChartViewPagerAdapter  extends PagerAdapter {
         notifyDataSetChanged();
     }
 
-    private static class IMoneyFormatter implements IAxisValueFormatter, IValueFormatter {
+    private static class IMoneyFormatter extends ValueFormatter {
 
         private final CurrencyUnit mCurrencyUnit;
         private final MoneyFormatter mMoneyFormatter;
@@ -128,12 +124,7 @@ public class BarChartViewPagerAdapter  extends PagerAdapter {
         }
 
         @Override
-        public String getFormattedValue(float value, AxisBase axis) {
-            return mMoneyFormatter.getNotTintedString(mCurrencyUnit, (long) value);
-        }
-
-        @Override
-        public String getFormattedValue(float value, Entry entry, int dataSetIndex, ViewPortHandler viewPortHandler) {
+        public String getFormattedValue(float value) {
             return mMoneyFormatter.getNotTintedString(mCurrencyUnit, (long) value);
         }
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/adapter/pager/OverviewChartViewPagerAdapter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/adapter/pager/OverviewChartViewPagerAdapter.java
@@ -28,13 +28,12 @@ import android.view.ViewGroup;
 import com.github.mikephil.charting.charts.BarChart;
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.charts.RadarChart;
-import com.github.mikephil.charting.components.AxisBase;
 import com.github.mikephil.charting.components.XAxis;
 import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.BarData;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.RadarData;
-import com.github.mikephil.charting.formatter.IAxisValueFormatter;
+import com.github.mikephil.charting.formatter.ValueFormatter;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.OverviewData;
 
@@ -77,10 +76,10 @@ public class OverviewChartViewPagerAdapter extends PagerAdapter {
                             xAxis.setAxisMinimum(-1f);
                         }
                         xAxis.setAxisMaximum(mOverviewData.getPeriodCount());
-                        xAxis.setValueFormatter(new IAxisValueFormatter() {
+                        xAxis.setValueFormatter(new ValueFormatter() {
 
                             @Override
-                            public String getFormattedValue(float value, AxisBase axis) {
+                            public String getFormattedValue(float value) {
                                 return String.valueOf((int) value + 1);
                             }
 
@@ -106,10 +105,10 @@ public class OverviewChartViewPagerAdapter extends PagerAdapter {
                         xAxis.setGranularity(1f);
                         xAxis.setAxisMinimum(-1f);
                         xAxis.setAxisMaximum(mOverviewData.getPeriodCount());
-                        xAxis.setValueFormatter(new IAxisValueFormatter() {
+                        xAxis.setValueFormatter(new ValueFormatter() {
 
                             @Override
-                            public String getFormattedValue(float value, AxisBase axis) {
+                            public String getFormattedValue(float value) {
                                 return String.valueOf((int) value + 1);
                             }
 

--- a/app/src/test/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporterTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/storage/database/data/csv/CSVDataImporterTest.java
@@ -134,7 +134,7 @@ public class CSVDataImporterTest {
      * same file is a separate test below.
      */
     @Test
-    public void aByteOrderMarkDoesNotHideTheFirstColumn() throws IOException {
+    public void aByteOrderMarkDoesNotHideTheFirstColumn() throws Exception {
         File file = write("\uFEFF\"wallet\",\"currency\"\n\"Probe\",\"EUR\"\n");
         try (CSVReaderHeaderAware reader = new CSVReaderHeaderAware(CSVDataImporter.openFile(file))) {
             assertEquals("Probe", reader.readMap().get("wallet"));
@@ -148,7 +148,7 @@ public class CSVDataImporterTest {
      * its first character.
      */
     @Test
-    public void aFileWithoutOneKeepsItsFirstCharacter() throws IOException {
+    public void aFileWithoutOneKeepsItsFirstCharacter() throws Exception {
         File file = write("\"wallet\",\"currency\"\n\"Probe\",\"EUR\"\n");
         try (CSVReaderHeaderAware reader = new CSVReaderHeaderAware(CSVDataImporter.openFile(file))) {
             assertEquals("Probe", reader.readMap().get("wallet"));
@@ -161,7 +161,7 @@ public class CSVDataImporterTest {
      * column, so every row is refused for having no wallet column and nothing on screen shows why.
      */
     @Test
-    public void everyMarkAtTheFrontComesOff() throws IOException {
+    public void everyMarkAtTheFrontComesOff() throws Exception {
         File file = write("\uFEFF\uFEFF\"wallet\",\"currency\"\n\"Probe\",\"EUR\"\n");
         try (CSVReaderHeaderAware reader = new CSVReaderHeaderAware(CSVDataImporter.openFile(file))) {
             assertEquals("Probe", reader.readMap().get("wallet"));

--- a/build.gradle
+++ b/build.gradle
@@ -40,18 +40,6 @@ allprojects {
     }
 }
 
-ext {
-    supportDependencies = [
-            appcompat : 'androidx.appcompat:appcompat:1.8.0',
-            recyclerview : 'androidx.recyclerview:recyclerview:1.4.0',
-            cardview: 'androidx.cardview:cardview:1.0.0',
-            annotations : 'androidx.annotation:annotation:1.10.0',
-            design : 'com.google.android.material:material:1.14.0',
-            preference: 'androidx.preference:preference:1.2.1',
-            constraintlayout : 'androidx.constraintlayout:constraintlayout:2.2.2'
-    ]
-}
-
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -43,4 +43,8 @@ org.gradle.jvmargs=-Xmx1536m
 # runtime inside the application settings.
 ApiKey_OpenExchangeRates="INSERT_API_KEY_HERE"
 android.useAndroidX=true
+# checkJetifier lists four libraries that pull com.android.support:appcompat-v7. PinLockView
+# has no release after 2.1.0 and PatternLockView has never had one, so the flag stays on.
+# material-about-library and appintro do have AndroidX releases, and moving those two alone
+# would not let it go.
 android.enableJetifier=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,94 @@
+[versions]
+activity = "1.13.0"
+annotation = "1.10.0"
+appcompat = "1.8.0"
+appintro = "v4.2.3"
+biometric = "1.1.0"
+cardview = "1.0.0"
+collection = "1.6.0"
+commons-io = "2.6"
+constraintlayout = "2.2.2"
+coordinatorlayout = "1.3.0"
+core = "1.18.0"
+documentfile = "1.1.0"
+drawerlayout = "1.2.0"
+fragment = "1.9.0"
+glide = "4.16.0"
+itextpdf = "5.5.13"
+junit = "4.13.2"
+jxl = "2.6.12"
+lib-recur = "0.17.1"
+loader = "1.2.0"
+localbroadcastmanager = "1.1.0"
+material = "1.14.0"
+material-about-library = "2.2.4"
+mockito-core = "5.23.0"
+mpandroidchart = "v3.1.0"
+okhttp = "4.12.0"
+opencsv = "5.12.0"
+osmdroid = "6.1.20"
+patternlockview = "b69afae9c1"
+pinlockview = "2.1.0"
+preference = "1.2.1"
+recyclerview = "1.4.0"
+robolectric = "4.16.1"
+swiperefreshlayout = "1.2.0"
+test-core = "1.7.0"
+test-runner = "1.7.0"
+viewpager = "1.1.0"
+zip4j = "1.3.2"
+
+[libraries]
+androidx-activity = { module = "androidx.activity:activity", version.ref = "activity" }
+androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
+androidx-biometric = { module = "androidx.biometric:biometric", version.ref = "biometric" }
+androidx-cardview = { module = "androidx.cardview:cardview", version.ref = "cardview" }
+androidx-collection = { module = "androidx.collection:collection", version.ref = "collection" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraintlayout" }
+androidx-coordinatorlayout = { module = "androidx.coordinatorlayout:coordinatorlayout", version.ref = "coordinatorlayout" }
+# Used directly by the app, so it is named here instead of arriving transitively.
+androidx-core = { module = "androidx.core:core", version.ref = "core" }
+# Without this line documentfile resolves to 1.0.0, by way of legacy-support-core-utils.
+# In 1.0.0 fromTreeUri drops the document id, so every folder under a granted tree
+# resolves to the top of the tree. 1.0.1 keeps the id when the uri is a document uri.
+androidx-documentfile = { module = "androidx.documentfile:documentfile", version.ref = "documentfile" }
+androidx-drawerlayout = { module = "androidx.drawerlayout:drawerlayout", version.ref = "drawerlayout" }
+androidx-fragment = { module = "androidx.fragment:fragment", version.ref = "fragment" }
+androidx-loader = { module = "androidx.loader:loader", version.ref = "loader" }
+androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "localbroadcastmanager" }
+androidx-preference = { module = "androidx.preference:preference", version.ref = "preference" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "recyclerview" }
+androidx-swiperefreshlayout = { module = "androidx.swiperefreshlayout:swiperefreshlayout", version.ref = "swiperefreshlayout" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "test-core" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "test-runner" }
+androidx-viewpager = { module = "androidx.viewpager:viewpager", version.ref = "viewpager" }
+appintro = { module = "com.github.apl-devs:appintro", version.ref = "appintro" }
+# Newer versions route FileUtils.forceDelete through java.nio.file from 2.7, and
+# FileUtils.moveFile from 2.9.0. That package arrived in API 26 and minSdk here is 24.
+# The app calls both.
+commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
+itextpdf = { module = "com.itextpdf:itextpdf", version.ref = "itextpdf" }
+junit = { module = "junit:junit", version.ref = "junit" }
+jxl = { module = "net.sourceforge.jexcelapi:jxl", version.ref = "jxl" }
+lib-recur = { module = "org.dmfs:lib-recur", version.ref = "lib-recur" }
+material = { module = "com.google.android.material:material", version.ref = "material" }
+material-about-library = { module = "com.github.daniel-stoneuk:material-about-library", version.ref = "material-about-library" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
+mpandroidchart = { module = "com.github.PhilJay:MPAndroidChart", version.ref = "mpandroidchart" }
+# WebDAV needs PROPFIND and MKCOL. Android's HttpURLConnection validates the method against a
+# fixed list and throws ProtocolException for both, so a real HTTP client is not optional here.
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+opencsv = { module = "com.opencsv:opencsv", version.ref = "opencsv" }
+osmdroid = { module = "org.osmdroid:osmdroid-android", version.ref = "osmdroid" }
+# jcenter-orphaned -> JitPack. aritraroy/PatternLockView has NO git tag/release, so it is pinned to the
+# last code-bearing commit (b69afae9c1, libraryVersion 1.0.0). It is a multi-module project, hence the
+# group.Repo:module coordinate form. Java package stays com.andrognito.patternlockview.
+patternlockview = { module = "com.github.aritraroy.PatternLockView:patternlockview", version.ref = "patternlockview" }
+# jcenter-orphaned -> JitPack (aritraroy/PinLockView), same 2.1.0; Java package stays com.andrognito.pinlockview.
+pinlockview = { module = "com.github.aritraroy:PinLockView", version.ref = "pinlockview" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+# 2.x moved ZipFile out of net.lingala.zip4j.core and removed Zip4jConstants and
+# net.lingala.zip4j.io.ZipInputStream. The backup code imports all three.
+zip4j = { module = "net.lingala.zip4j:zip4j", version.ref = "zip4j" }


### PR DESCRIPTION
Every dependency version now lives in one file instead of being spread through the build scripts, so there is one place to look and one place to change.

Five libraries move to their current releases. Three of them needed nothing beyond the new version. The chart library and the CSV library each changed something the app calls, so a small amount of app code moved with them.

The one thing you can see: labels along the edges of the bar and line charts sit a few pixels differently. The bars, the grid lines and the values themselves are unchanged, and the radar chart is identical.

The app also gets smaller. Two pieces the CSV library brings along serve a feature this app never touches, and leaving them out more than pays for all five updates, so the release build comes out about 200 kB smaller than before.

Three things were left alone on purpose. One library stayed on its old version, because a newer one ships a whole extra runtime the app has no use for. Another stayed because the newer versions call something Android did not have at the oldest version this app supports. And the compatibility layer for the old support libraries stays switched on, because two libraries still need it and neither has a release that drops it.

Tested on an emulator, and on a second one running the oldest Android version the app supports: charts, maps, image loading, and CSV import and export all still work.
