### PR TITLE
Run the wallet, transaction and transfer deletes off the main thread

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SecondaryPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SecondaryPanelFragment.java
@@ -19,7 +19,12 @@
 
 package com.oriondev.moneywallet.ui.fragment.base;
 
+import android.content.ContentResolver;
+import android.content.Context;
+import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
 import androidx.annotation.MenuRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -32,7 +37,12 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.storage.database.SQLiteDataException;
 import com.oriondev.moneywallet.utils.Utils;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 
 /**
  * Created by andrea on 01/04/18.
@@ -41,11 +51,17 @@ public abstract class SecondaryPanelFragment extends Fragment implements Toolbar
 
     private static final String SS_ITEM_ID = "SecondaryPanelFragment::SavedState::ItemId";
 
+    private static final Executor sDeleteExecutor = Executors.newSingleThreadExecutor(
+            r -> new Thread(r, "SecondaryPanelDelete"));
+    private static final Handler sMainHandler = new Handler(Looper.getMainLooper());
+
     private ViewGroup mEmptyLayout;
     private ViewGroup mMainLayout;
     private Toolbar mToolbar;
 
     private long mCurrentId;
+
+    private boolean mDeleting = false;
 
     private boolean mIsCreated = false;
     private long mCachedId = 0;
@@ -79,7 +95,7 @@ public abstract class SecondaryPanelFragment extends Fragment implements Toolbar
             int menuRes = onInflateMenu();
             if (menuRes > 0) {
                 mToolbar.inflateMenu(menuRes);
-                mToolbar.setOnMenuItemClickListener(this);
+                mToolbar.setOnMenuItemClickListener(item -> mDeleting || onMenuItemClick(item));
             }
         }
         mIsCreated = true;
@@ -108,6 +124,54 @@ public abstract class SecondaryPanelFragment extends Fragment implements Toolbar
     public void onSaveInstanceState(@NonNull Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putLong(SS_ITEM_ID, mCurrentId);
+    }
+
+    /**
+     * Deletes a row through the content provider on one worker thread that every panel shares.
+     * The toolbar menu ignores taps until the delete comes back, whichever item the panel shows
+     * in the meantime, so the row cannot be edited, archived or deleted again and no second
+     * delete can be queued from the panel. The result is dropped when the fragment has no view
+     * left. A delete that went through is dropped when the panel has since been pointed at
+     * another item, since the same fragment is reused for every item the list selects, and a
+     * refused delete is reported whichever item the panel shows. With no error callback the
+     * failure is rethrown on the main thread.
+     */
+    protected void deleteItemInBackground(Uri uri, @Nullable Consumer<SQLiteDataException> onError) {
+        Context context = getContext();
+        if (context == null) {
+            return;
+        }
+        ContentResolver resolver = context.getApplicationContext().getContentResolver();
+        long itemId = getItemId();
+        mDeleting = true;
+        sDeleteExecutor.execute(() -> {
+            SQLiteDataException failure = null;
+            try {
+                resolver.delete(uri, null, null);
+            } catch (SQLiteDataException e) {
+                failure = e;
+            }
+            SQLiteDataException error = failure;
+            sMainHandler.post(() -> {
+                if (getView() == null) {
+                    return;
+                }
+                mDeleting = false;
+                if (error != null) {
+                    if (onError != null) {
+                        onError.accept(error);
+                    } else {
+                        throw error;
+                    }
+                    return;
+                }
+                if (getItemId() != itemId) {
+                    return;
+                }
+                navigateBackSafely();
+                showItemId(0L);
+            });
+        });
     }
 
     protected void navigateBackSafely() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragment.java
@@ -20,7 +20,6 @@
 package com.oriondev.moneywallet.ui.fragment.secondary;
 
 import android.app.Activity;
-import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -46,7 +45,6 @@ import com.oriondev.moneywallet.model.Attachment;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
-import com.oriondev.moneywallet.storage.database.SQLiteDataException;
 import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
 import com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity;
 import com.oriondev.moneywallet.ui.fragment.base.SecondaryPanelFragment;
@@ -154,24 +152,16 @@ public class TransactionItemFragment extends SecondaryPanelFragment implements L
 
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        Activity activity = getActivity();
-                        if (activity != null) {
-                            try {
-                                Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS, getItemId());
-                                ContentResolver contentResolver = activity.getContentResolver();
-                                contentResolver.delete(uri, null, null);
-                                navigateBackSafely();
-                                showItemId(0L);
-                            } catch (SQLiteDataException e) {
-                                if (e.getErrorCode() == Contract.ErrorCode.TRANSACTION_USED_IN_TRANSFER) {
-                                    ThemedDialog.buildMaterialDialog(activity)
-                                            .setTitle(R.string.title_error)
-                                            .setMessage(R.string.message_error_delete_transaction_of_transfer)
-                                            .setPositiveButton(android.R.string.ok, null)
-                                            .show();
-                                }
+                        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS, getItemId());
+                        deleteItemInBackground(uri, e -> {
+                            if (e.getErrorCode() == Contract.ErrorCode.TRANSACTION_USED_IN_TRANSFER) {
+                                ThemedDialog.buildMaterialDialog(requireActivity())
+                                        .setTitle(R.string.title_error)
+                                        .setMessage(R.string.message_error_delete_transaction_of_transfer)
+                                        .setPositiveButton(android.R.string.ok, null)
+                                        .show();
                             }
-                        }
+                        });
                     }
 
                 })

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/TransferItemFragment.java
@@ -20,7 +20,6 @@
 package com.oriondev.moneywallet.ui.fragment.secondary;
 
 import android.app.Activity;
-import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.Context;
 import android.content.DialogInterface;
@@ -150,14 +149,8 @@ public class TransferItemFragment extends SecondaryPanelFragment implements Atta
 
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        Activity activity = getActivity();
-                        if (activity != null) {
-                            Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSFERS, getItemId());
-                            ContentResolver contentResolver = activity.getContentResolver();
-                            contentResolver.delete(uri, null, null);
-                            navigateBackSafely();
-                            showItemId(0L);
-                        }
+                        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSFERS, getItemId());
+                        deleteItemInBackground(uri, null);
                     }
 
                 })

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/WalletItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/WalletItemFragment.java
@@ -20,7 +20,6 @@
 package com.oriondev.moneywallet.ui.fragment.secondary;
 
 import android.app.Activity;
-import android.content.ContentResolver;
 import android.content.ContentUris;
 import android.content.ContentValues;
 import android.content.Context;
@@ -48,7 +47,6 @@ import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
-import com.oriondev.moneywallet.storage.database.SQLiteDataException;
 import com.oriondev.moneywallet.ui.activity.NewEditItemActivity;
 import com.oriondev.moneywallet.ui.activity.NewEditWalletActivity;
 import com.oriondev.moneywallet.ui.fragment.base.SecondaryPanelFragment;
@@ -182,24 +180,16 @@ public class WalletItemFragment extends SecondaryPanelFragment implements Loader
 
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        Activity activity = getActivity();
-                        if (activity != null) {
-                            try {
-                                Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, getItemId());
-                                ContentResolver contentResolver = activity.getContentResolver();
-                                contentResolver.delete(uri, null, null);
-                                navigateBackSafely();
-                                showItemId(0L);
-                            } catch (SQLiteDataException e) {
-                                if (e.getErrorCode() == Contract.ErrorCode.WALLET_USED_IN_TRANSFER) {
-                                    ThemedDialog.buildMaterialDialog(activity)
-                                            .setTitle(R.string.title_error)
-                                            .setMessage(R.string.message_error_delete_wallet_of_transfer)
-                                            .setPositiveButton(android.R.string.ok, null)
-                                            .show();
-                                }
+                        Uri uri = ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS, getItemId());
+                        deleteItemInBackground(uri, e -> {
+                            if (e.getErrorCode() == Contract.ErrorCode.WALLET_USED_IN_TRANSFER) {
+                                ThemedDialog.buildMaterialDialog(requireActivity())
+                                        .setTitle(R.string.title_error)
+                                        .setMessage(R.string.message_error_delete_wallet_of_transfer)
+                                        .setPositiveButton(android.R.string.ok, null)
+                                        .show();
                             }
-                        }
+                        });
                     }
 
                 })

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragmentTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/secondary/TransactionItemFragmentTest.java
@@ -1,0 +1,518 @@
+package com.oriondev.moneywallet.ui.fragment.secondary;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+import android.content.Intent;
+import android.database.Cursor;
+import android.os.Looper;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.FragmentActivity;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.TestDatabases;
+import com.oriondev.moneywallet.storage.database.TransferContentValuesBuilder;
+import com.oriondev.moneywallet.ui.activity.BackupListActivity;
+import com.oriondev.moneywallet.ui.activity.NewEditTransactionActivity;
+import com.oriondev.moneywallet.ui.fragment.base.SecondaryPanelFragment;
+import com.oriondev.moneywallet.utils.DateUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowDialog;
+
+import java.lang.reflect.Field;
+import java.util.Date;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.robolectric.Shadows.shadowOf;
+
+/**
+ * The delete behind the panel's trash menu item runs on a worker thread. Every case parks that
+ * worker behind a latch before the click, so the delete the click submits waits in the worker
+ * queue and can neither touch the database nor post anything back until the test counts the latch
+ * down. That fixes the order instead of leaving it to timing.
+ *
+ * The cases pin these things. The row is still stored when the click returns, and the panel is
+ * blank once the posted callback runs. A fragment taken off the screen before the callback lands
+ * keeps the item it was showing. A panel pointed at a second item before the callback lands keeps
+ * that second item and stays on the main layout. The toolbar menu ignores an edit tap while the
+ * delete is going, and lets one through when nothing is going. Selecting the very same row again
+ * while its delete is in flight leaves the toolbar menu dead, since that row is still doomed.
+ * Selecting a second row and then the doomed row again leaves the menu dead too, so the panel
+ * cannot queue a second delete of the row already going. The menu comes back on the second row
+ * once the delete lands, and the panel keeps that second row. A delete the database refuses
+ * reports its error even when the panel has since been pointed at another item.
+ *
+ * Every parked case releases the worker and waits for a marker inside a finally block, and asserts
+ * on the result of that wait after the block, so a case that fails an assertion still reports the
+ * assertion it failed.
+ *
+ * The fragment has no MultiPanelController parent here, so navigateBackSafely does nothing and no
+ * panel is closed in any of these cases.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class TransactionItemFragmentTest {
+
+    private static final String ICON = "{\"type\":\"color\",\"color\":\"#000000\",\"name\":\"T\"}";
+    private static final String TAG_FRAGMENT = "TransactionItemFragmentTest::Fragment";
+
+    private static final long MARKER_TIMEOUT_SECONDS = 5L;
+
+    private ContentResolver mResolver;
+    private long mWalletId;
+    private long mTransactionId;
+    private long mSecondTransactionId;
+
+    @Before
+    public void setUp() {
+        Context context = ApplicationProvider.getApplicationContext();
+        TestDatabases.useFreshDatabase(context);
+        mResolver = context.getContentResolver();
+        mWalletId = insertWallet("Cash");
+        long categoryId = insertCategory();
+        mTransactionId = insertTransaction(mWalletId, categoryId, "Bread");
+        mSecondTransactionId = insertTransaction(mWalletId, categoryId, "Milk");
+    }
+
+    @Test
+    public void theRowGoesAwayOffTheMainThreadAndThePanelBlanksWhenTheCallbackRuns() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                TransactionItemFragment fragment = showTransaction(activity, mTransactionId);
+                View fragmentView = fragment.requireView();
+                CountDownLatch release = parkDeleteWorker();
+                boolean reached;
+                try {
+                    clickDeleteAndConfirm(fragment);
+                    assertTrue("the row went away inside the click", rowExists(mTransactionId));
+                } finally {
+                    release.countDown();
+                    reached = awaitDeleteWorker();
+                }
+                assertTrue("the delete worker did not reach the marker within 5 seconds", reached);
+                idleMainLooper();
+                assertFalse("the row was still stored after the callback", rowExists(mTransactionId));
+                assertEquals(0L, fragment.getItemId());
+                assertEquals(View.VISIBLE, fragmentView
+                        .findViewById(R.id.empty_screen_secondary_panel_layout).getVisibility());
+            });
+        }
+    }
+
+    @Test
+    public void aFragmentTakenOffTheScreenBeforeTheCallbackKeepsItsItem() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                TransactionItemFragment fragment = showTransaction(activity, mTransactionId);
+                CountDownLatch release = parkDeleteWorker();
+                boolean reached;
+                try {
+                    clickDeleteAndConfirm(fragment);
+                    activity.getSupportFragmentManager()
+                            .beginTransaction()
+                            .remove(fragment)
+                            .commitNow();
+                } finally {
+                    release.countDown();
+                    reached = awaitDeleteWorker();
+                }
+                assertTrue("the delete worker did not reach the marker within 5 seconds", reached);
+                idleMainLooper();
+                assertEquals(mTransactionId, fragment.getItemId());
+            });
+        }
+    }
+
+    @Test
+    public void aPanelPointedAtAnotherItemBeforeTheCallbackKeepsThatItem() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                TransactionItemFragment fragment = showTransaction(activity, mTransactionId);
+                View fragmentView = fragment.requireView();
+                CountDownLatch release = parkDeleteWorker();
+                boolean reached;
+                try {
+                    clickDeleteAndConfirm(fragment);
+                    fragment.showItemId(mSecondTransactionId);
+                    idleMainLooper();
+                } finally {
+                    release.countDown();
+                    reached = awaitDeleteWorker();
+                }
+                assertTrue("the delete worker did not reach the marker within 5 seconds", reached);
+                idleMainLooper();
+                assertEquals(mSecondTransactionId, fragment.getItemId());
+                assertTrue("the second row went away", rowExists(mSecondTransactionId));
+                assertFalse("the first row was still stored", rowExists(mTransactionId));
+                assertEquals(View.VISIBLE, fragmentView
+                        .findViewById(R.id.main_screen_secondary_panel_scroll_view).getVisibility());
+            });
+        }
+    }
+
+    @Test
+    public void theToolbarMenuIgnoresAnEditWhileTheDeleteIsInFlight() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                TransactionItemFragment fragment = showTransaction(activity, mTransactionId);
+                Toolbar toolbar = fragment.requireView().findViewById(R.id.secondary_toolbar);
+                assertNotNull(toolbar);
+                CountDownLatch release = parkDeleteWorker();
+                boolean reached;
+                try {
+                    clickDeleteAndConfirm(fragment);
+                    toolbar.getMenu().performIdentifierAction(R.id.action_edit_item, 0);
+                    idleMainLooper();
+                    assertNull("the edit went through while the delete was in flight",
+                            shadowOf(activity).getNextStartedActivity());
+                } finally {
+                    release.countDown();
+                    reached = awaitDeleteWorker();
+                }
+                assertTrue("the delete worker did not reach the marker within 5 seconds", reached);
+                idleMainLooper();
+                assertFalse("the row was still stored after the callback", rowExists(mTransactionId));
+            });
+        }
+    }
+
+    @Test
+    public void theSameRowSelectedAgainDuringTheDeleteKeepsTheToolbarDead() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                TransactionItemFragment fragment = showTransaction(activity, mTransactionId);
+                Toolbar toolbar = fragment.requireView().findViewById(R.id.secondary_toolbar);
+                assertNotNull(toolbar);
+                CountDownLatch release = parkDeleteWorker();
+                boolean reached;
+                try {
+                    clickDeleteAndConfirm(fragment);
+                    fragment.showItemId(mTransactionId);
+                    idleMainLooper();
+                    toolbar.getMenu().performIdentifierAction(R.id.action_edit_item, 0);
+                    idleMainLooper();
+                    assertNull("the edit went through on the row whose delete was in flight",
+                            shadowOf(activity).getNextStartedActivity());
+                } finally {
+                    release.countDown();
+                    reached = awaitDeleteWorker();
+                }
+                assertTrue("the delete worker did not reach the marker within 5 seconds", reached);
+                idleMainLooper();
+                assertFalse("the row was still stored after the callback", rowExists(mTransactionId));
+                assertEquals(0L, fragment.getItemId());
+            });
+        }
+    }
+
+    @Test
+    public void theDoomedRowSelectedAgainAfterAnotherOneKeepsTheToolbarDead() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                TransactionItemFragment fragment = showTransaction(activity, mTransactionId);
+                Toolbar toolbar = fragment.requireView().findViewById(R.id.secondary_toolbar);
+                assertNotNull(toolbar);
+                CountDownLatch release = parkDeleteWorker();
+                boolean reached;
+                try {
+                    clickDeleteAndConfirm(fragment);
+                    fragment.showItemId(mSecondTransactionId);
+                    idleMainLooper();
+                    fragment.showItemId(mTransactionId);
+                    idleMainLooper();
+                    toolbar.getMenu().performIdentifierAction(R.id.action_edit_item, 0);
+                    idleMainLooper();
+                    assertNull("the edit went through on the row whose delete was in flight",
+                            shadowOf(activity).getNextStartedActivity());
+                } finally {
+                    release.countDown();
+                    reached = awaitDeleteWorker();
+                }
+                assertTrue("the delete worker did not reach the marker within 5 seconds", reached);
+                idleMainLooper();
+                assertFalse("the row was still stored after the callback", rowExists(mTransactionId));
+                assertEquals(0L, fragment.getItemId());
+            });
+        }
+    }
+
+    @Test
+    public void theToolbarMenuComesBackOnTheOtherItemOnceTheDeleteLands() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                TransactionItemFragment fragment = showTransaction(activity, mTransactionId);
+                Toolbar toolbar = fragment.requireView().findViewById(R.id.secondary_toolbar);
+                assertNotNull(toolbar);
+                CountDownLatch release = parkDeleteWorker();
+                boolean reached;
+                try {
+                    clickDeleteAndConfirm(fragment);
+                    fragment.showItemId(mSecondTransactionId);
+                    idleMainLooper();
+                } finally {
+                    release.countDown();
+                    reached = awaitDeleteWorker();
+                }
+                assertTrue("the delete worker did not reach the marker within 5 seconds", reached);
+                idleMainLooper();
+                toolbar.getMenu().performIdentifierAction(R.id.action_edit_item, 0);
+                idleMainLooper();
+                Intent started = shadowOf(activity).getNextStartedActivity();
+                assertNotNull("the edit was still ignored after the delete landed", started);
+                assertNotNull(started.getComponent());
+                assertEquals(NewEditTransactionActivity.class.getName(),
+                        started.getComponent().getClassName());
+                assertEquals(mSecondTransactionId, fragment.getItemId());
+                assertTrue("the second row went away", rowExists(mSecondTransactionId));
+            });
+        }
+    }
+
+    @Test
+    public void aRefusedDeleteIsReportedWhenThePanelHasMovedOn() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                long secondWalletId = insertWallet("Bank");
+                long transferId = insertTransfer(mWalletId, secondWalletId);
+                long legId = transferFromTransactionId(transferId);
+                TransactionItemFragment fragment = showTransaction(activity, legId);
+                CountDownLatch release = parkDeleteWorker();
+                AlertDialog confirm;
+                boolean reached;
+                try {
+                    confirm = clickDeleteAndConfirm(fragment);
+                    fragment.showItemId(mSecondTransactionId);
+                    idleMainLooper();
+                } finally {
+                    release.countDown();
+                    reached = awaitDeleteWorker();
+                }
+                assertTrue("the delete worker did not reach the marker within 5 seconds", reached);
+                idleMainLooper();
+                assertTrue("the leg of the transfer was deleted", rowExists(legId));
+                assertEquals(mSecondTransactionId, fragment.getItemId());
+                AlertDialog reported = (AlertDialog) ShadowDialog.getLatestDialog();
+                assertNotNull(reported);
+                assertNotSame("no error dialog was put up", confirm, reported);
+                assertTrue("the error dialog was not showing", reported.isShowing());
+                TextView message = reported.findViewById(android.R.id.message);
+                assertNotNull(message);
+                assertEquals(activity.getString(R.string.message_error_delete_transaction_of_transfer),
+                        message.getText().toString());
+            });
+        }
+    }
+
+    @Test
+    public void theToolbarMenuOpensTheEditorWhenNoDeleteIsInFlight() {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                TransactionItemFragment fragment = showTransaction(activity, mTransactionId);
+                Toolbar toolbar = fragment.requireView().findViewById(R.id.secondary_toolbar);
+                assertNotNull(toolbar);
+                toolbar.getMenu().performIdentifierAction(R.id.action_edit_item, 0);
+                idleMainLooper();
+                Intent started = shadowOf(activity).getNextStartedActivity();
+                assertNotNull("the toolbar menu never reached the fragment", started);
+                assertNotNull(started.getComponent());
+                assertEquals(NewEditTransactionActivity.class.getName(),
+                        started.getComponent().getClassName());
+            });
+        }
+    }
+
+    /**
+     * Holds the one worker thread the panel deletes on, so work handed to it after this call sits
+     * in its queue until the returned latch is counted down. The executor is a private static
+     * field shared by every test in the run, so each caller has to release it in a finally block
+     * or the next delete waits forever.
+     */
+    private CountDownLatch parkDeleteWorker() {
+        CountDownLatch release = new CountDownLatch(1);
+        submitToDeleteWorker(() -> {
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+        return release;
+    }
+
+    /**
+     * Waits until a marker handed to the delete worker has run. The worker is one thread serving
+     * a queue in order, so a marker submitted after a delete only runs once that delete has
+     * returned, and the delete posts its callback to the main handler before it returns. So when
+     * this call comes back the callback is already sitting in the main queue and one idle round
+     * dispatches it. It sits in the same finally block as the release, so a case that fails an
+     * assertion cannot leave its delete running into the next case.
+     *
+     * It reports the timeout as a returned false and never fails from inside that finally block,
+     * since an AssertionError thrown there would replace the one the try block was already
+     * carrying and hide the assertion the case actually failed. Each case stores the returned
+     * value and asserts on it right after the block.
+     */
+    private boolean awaitDeleteWorker() {
+        CountDownLatch reached = new CountDownLatch(1);
+        submitToDeleteWorker(reached::countDown);
+        try {
+            return reached.await(MARKER_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+
+    private void submitToDeleteWorker(Runnable runnable) {
+        try {
+            Field field = SecondaryPanelFragment.class.getDeclaredField("sDeleteExecutor");
+            field.setAccessible(true);
+            Executor executor = (Executor) field.get(null);
+            executor.execute(runnable);
+        } catch (ReflectiveOperationException e) {
+            fail("the delete executor could not be reached, " + e);
+        }
+    }
+
+    private void idleMainLooper() {
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    private TransactionItemFragment showTransaction(FragmentActivity activity, long transactionId) {
+        TransactionItemFragment fragment = new TransactionItemFragment();
+        activity.getSupportFragmentManager()
+                .beginTransaction()
+                .add(android.R.id.content, fragment, TAG_FRAGMENT)
+                .commitNow();
+        fragment.showItemId(transactionId);
+        idleMainLooper();
+        return fragment;
+    }
+
+    /**
+     * AlertController hands a button press to the dialog's listener through a message on the main
+     * looper, so the queue is drained once here to get the press across. The worker is parked
+     * before this call, so the delete only lands in the worker queue and no result of it can
+     * reach the main queue while this drain is running. The confirm dialog is returned so a
+     * caller can tell it apart from a dialog the delete itself puts up later.
+     */
+    private AlertDialog clickDeleteAndConfirm(TransactionItemFragment fragment) {
+        Toolbar toolbar = fragment.requireView().findViewById(R.id.secondary_toolbar);
+        assertNotNull(toolbar);
+        MenuItem delete = toolbar.getMenu().findItem(R.id.action_delete_item);
+        assertNotNull(delete);
+        fragment.onMenuItemClick(delete);
+        AlertDialog dialog = (AlertDialog) ShadowDialog.getLatestDialog();
+        assertNotNull(dialog);
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick();
+        idleMainLooper();
+        return dialog;
+    }
+
+    private boolean rowExists(long transactionId) {
+        Cursor cursor = mResolver.query(
+                ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSACTIONS, transactionId),
+                new String[] {"*"}, null, null, null);
+        if (cursor == null) {
+            return false;
+        }
+        boolean exists = cursor.moveToFirst();
+        cursor.close();
+        return exists;
+    }
+
+    /**
+     * Reads the id of the transaction the transfer takes the money from. The transfer query
+     * exposes it as Contract.Transfer.TRANSACTION_FROM_ID, so no guess about which of the
+     * transfer type transactions belongs to this transfer is needed.
+     */
+    private long transferFromTransactionId(long transferId) {
+        Cursor cursor = mResolver.query(
+                ContentUris.withAppendedId(DataContentProvider.CONTENT_TRANSFERS, transferId),
+                new String[] {Contract.Transfer.TRANSACTION_FROM_ID}, null, null, null);
+        assertNotNull(cursor);
+        assertTrue("the transfer row was not stored", cursor.moveToFirst());
+        long transactionId = cursor.getLong(
+                cursor.getColumnIndex(Contract.Transfer.TRANSACTION_FROM_ID));
+        cursor.close();
+        return transactionId;
+    }
+
+    private long insertWallet(String name) {
+        ContentValues values = new ContentValues();
+        values.put(Contract.Wallet.NAME, name);
+        values.put(Contract.Wallet.ICON, ICON);
+        values.put(Contract.Wallet.CURRENCY, "EUR");
+        values.put(Contract.Wallet.START_MONEY, 0L);
+        values.put(Contract.Wallet.COUNT_IN_TOTAL, true);
+        values.put(Contract.Wallet.ARCHIVED, false);
+        return ContentUris.parseId(mResolver.insert(DataContentProvider.CONTENT_WALLETS, values));
+    }
+
+    private long insertCategory() {
+        ContentValues values = new ContentValues();
+        values.put(Contract.Category.NAME, "Groceries");
+        values.put(Contract.Category.ICON, ICON);
+        values.put(Contract.Category.TYPE, Contract.CategoryType.EXPENSE.getValue());
+        values.put(Contract.Category.SHOW_REPORT, true);
+        return ContentUris.parseId(mResolver.insert(DataContentProvider.CONTENT_CATEGORIES, values));
+    }
+
+    private long insertTransaction(long walletId, long categoryId, String description) {
+        ContentValues values = new ContentValues();
+        values.put(Contract.Transaction.MONEY, 1250L);
+        values.put(Contract.Transaction.DATE, DateUtils.getSQLDateTimeString(new Date()));
+        values.put(Contract.Transaction.DESCRIPTION, description);
+        values.put(Contract.Transaction.CATEGORY_ID, categoryId);
+        values.put(Contract.Transaction.DIRECTION, Contract.Direction.EXPENSE);
+        values.put(Contract.Transaction.TYPE, NewEditTransactionActivity.TYPE_STANDARD);
+        values.put(Contract.Transaction.WALLET_ID, walletId);
+        values.put(Contract.Transaction.CONFIRMED, true);
+        values.put(Contract.Transaction.COUNT_IN_TOTAL, true);
+        return ContentUris.parseId(mResolver.insert(DataContentProvider.CONTENT_TRANSACTIONS, values));
+    }
+
+    /**
+     * Inserts a transfer the same way the editor does, through the builder that owns the column
+     * set. The tax amount has to be written even when it is zero, since insertTransfer reads it
+     * as a long to decide whether a tax transaction is needed.
+     */
+    private long insertTransfer(long fromWalletId, long toWalletId) {
+        ContentValues values = new TransferContentValuesBuilder()
+                .description("Move")
+                .date(DateUtils.getSQLDateTimeString(new Date()))
+                .fromWalletId(fromWalletId)
+                .toWalletId(toWalletId)
+                .taxWalletId(fromWalletId)
+                .fromMoney(500L)
+                .toMoney(500L)
+                .taxMoney(0L)
+                .note("")
+                .confirmed(true)
+                .countInTotal(true)
+                .build();
+        return ContentUris.parseId(mResolver.insert(DataContentProvider.CONTENT_TRANSFERS, values));
+    }
+}


### PR DESCRIPTION
Deleting a wallet, a transaction or a transfer from its detail panel ran the whole delete on the main thread, including removing the rows' attachment files after the commit. A wallet with many transactions and attachments froze the screen for the whole delete.

The delete now runs on one worker thread shared by every detail panel, and the panel closes when the result comes back. The files still go after the commit, just not on the main thread. The twelve other detail panels that delete rows without touching the attachment folder are left as they were.

A free main thread opened three windows the old code never had, and each is closed here. The panel is one screen reused for every row the list selects, so a result that comes back after the user has tapped another row leaves that row alone. The panel's menu ignores taps until the delete comes back, so the row being deleted cannot be edited, archived or deleted a second time, and a refused delete is always reported, even if the user has moved to another row. If the screen is rebuilt mid delete, by a rotation, the rebuilt panel shows its empty state once the row is gone.

Tested on an emulator with a transaction with an attachment and a wallet holding two, files gone and panels closed, a rotation fired with the confirm tap, no crash, and both "used in a transfer" refusals reaching their dialog. A Robolectric test pins each guard.
