### PR TITLE
Fix three ways the budget editor saves the wrong thing

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/service/RecurrenceHandlerIntentService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/service/RecurrenceHandlerIntentService.java
@@ -147,7 +147,8 @@ public class RecurrenceHandlerIntentService extends JobIntentService {
     }
 
     /**
-     * Everything a budget row carries except its dates and its rule, which every caller sets.
+     * Everything a budget row carries except its dates, its rule and its currency. Every caller
+     * sets the dates and the rule, and the insert takes the currency from the wallets.
      */
     private ContentValues copyBudget(Cursor cursor) {
         ContentValues contentValues = new ContentValues();
@@ -158,7 +159,6 @@ public class RecurrenceHandlerIntentService extends JobIntentService {
             contentValues.put(Contract.Budget.CATEGORY_ID, cursor.getLong(cursor.getColumnIndex(Contract.Budget.CATEGORY_ID)));
         }
         contentValues.put(Contract.Budget.MONEY, cursor.getLong(cursor.getColumnIndex(Contract.Budget.MONEY)));
-        contentValues.put(Contract.Budget.CURRENCY, cursor.getString(cursor.getColumnIndex(Contract.Budget.CURRENCY)));
         contentValues.put(Contract.Budget.TAG, cursor.getString(cursor.getColumnIndex(Contract.Budget.TAG)));
         contentValues.put(Contract.Budget.RULE_START, cursor.getString(cursor.getColumnIndex(Contract.Budget.RULE_START)));
         contentValues.put(Contract.Budget.WALLET_IDS, cursor.getString(cursor.getColumnIndex(Contract.Budget.WALLET_IDS)));

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/Contract.java
@@ -249,6 +249,8 @@ public class Contract {
         public static final String START_DATE = Schema.Budget.START_DATE;
         public static final String END_DATE = Schema.Budget.END_DATE;
         public static final String MONEY = Schema.Budget.MONEY;
+        // on an insert and on an update through DataContentProvider the value sent is ignored and
+        // the currency is taken from the budget's wallets
         public static final String CURRENCY = Schema.Budget.CURRENCY;
         public static final String RULE = Schema.Budget.RULE;
         public static final String RULE_START = Schema.Budget.RULE_START;

--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -3331,7 +3331,7 @@ import java.util.function.Supplier;
         if (walletIds == null || walletIds.length == 0) {
             throw new SQLiteDataException(Contract.ErrorCode.WALLETS_NOT_FOUND, "No wallet id provided");
         }
-        checkWalletsConsistency(walletIds);
+        String currency = checkWalletsConsistency(walletIds);
         long[] categoryIds = budgetCategoryIds(contentValues);
         ContentValues cv = new ContentValues();
         cv.put(Schema.Budget.TYPE, contentValues.getAsInteger(Contract.Budget.TYPE));
@@ -3343,7 +3343,7 @@ import java.util.function.Supplier;
         cv.put(Schema.Budget.START_DATE, contentValues.getAsString(Contract.Budget.START_DATE));
         cv.put(Schema.Budget.END_DATE, contentValues.getAsString(Contract.Budget.END_DATE));
         cv.put(Schema.Budget.MONEY, contentValues.getAsLong(Contract.Budget.MONEY));
-        cv.put(Schema.Budget.CURRENCY, contentValues.getAsString(Contract.Budget.CURRENCY));
+        cv.put(Schema.Budget.CURRENCY, currency);
         cv.put(Schema.Budget.RULE, contentValues.getAsString(Contract.Budget.RULE));
         cv.put(Schema.Budget.RULE_START, contentValues.getAsString(Contract.Budget.RULE_START));
         cv.put(Schema.Budget.TAG, contentValues.getAsString(Contract.Budget.TAG));
@@ -3417,7 +3417,7 @@ import java.util.function.Supplier;
         if (walletIds == null || walletIds.length == 0) {
             throw new SQLiteDataException(Contract.ErrorCode.WALLETS_NOT_FOUND, "No wallet id provided");
         }
-        checkWalletsConsistency(walletIds);
+        String currency = checkWalletsConsistency(walletIds);
         long[] categoryIds = budgetCategoryIds(contentValues);
         ContentValues cv = new ContentValues();
         cv.put(Schema.Budget.TYPE, contentValues.getAsInteger(Contract.Budget.TYPE));
@@ -3429,7 +3429,7 @@ import java.util.function.Supplier;
         cv.put(Schema.Budget.START_DATE, contentValues.getAsString(Contract.Budget.START_DATE));
         cv.put(Schema.Budget.END_DATE, contentValues.getAsString(Contract.Budget.END_DATE));
         cv.put(Schema.Budget.MONEY, contentValues.getAsLong(Contract.Budget.MONEY));
-        cv.put(Schema.Budget.CURRENCY, contentValues.getAsString(Contract.Budget.CURRENCY));
+        cv.put(Schema.Budget.CURRENCY, currency);
         if (contentValues.containsKey(Contract.Budget.RULE)) {
             cv.put(Schema.Budget.RULE, contentValues.getAsString(Contract.Budget.RULE));
         }
@@ -3561,9 +3561,10 @@ import java.util.function.Supplier;
      * This method is used internally to check if the given array of wallet ids is consistent.
      * If two or more different currencies are found, an exception is thrown.
      * @param walletIds array of wallet id.
+     * @return the currency every wallet in the array has.
      * @throws SQLiteDataException if one of the id is not found or wallets are not consistent.
      */
-    private void checkWalletsConsistency(long[] walletIds) {
+    private String checkWalletsConsistency(long[] walletIds) {
         String savedCurrency = null;
         String[] projection = new String[] {
                 Contract.Wallet.CURRENCY
@@ -3587,6 +3588,7 @@ import java.util.function.Supplier;
                 }
             }
         }
+        return savedCurrency;
     }
 
     /**

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivity.java
@@ -215,9 +215,9 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
 
         });
         // before the one below, because a wallet naming a currency this installation does not
-        // have has no currency to compare and the comparison there would pass it through to
-        // onSaveChanges, which reads the iso straight off it. Validators run in order and stop at
-        // the first refusal, so this is also what decides the message the user is shown
+        // have has no currency to compare and the comparison there would pass it through.
+        // Validators run in order and stop at the first refusal, so this is also what decides the
+        // message the user is shown
         mWalletsEditText.addValidator(new Validator() {
 
             @NonNull
@@ -875,10 +875,13 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
                 contentValues.put(Contract.Budget.START_DATE, DateUtils.getSQLDateString(mStartDatePicker.getCurrentDateTime()));
                 contentValues.put(Contract.Budget.END_DATE, DateUtils.getSQLDateString(mEndDatePicker.getCurrentDateTime()));
                 contentValues.putNull(Contract.Budget.RULE);
-                contentValues.putNull(Contract.Budget.RULE_START);
+                // updateBudget writes a column whose key is present even when null, so this nulled
+                // the day the chain was counted from on a period the chain had already moved past
+                if (!isSupersededPeriod()) {
+                    contentValues.putNull(Contract.Budget.RULE_START);
+                }
             }
             contentValues.put(Contract.Budget.MONEY, mMoneyPicker.getCurrentMoney());
-            contentValues.put(Contract.Budget.CURRENCY, mWalletsPicker.getCurrentWallets()[0].getCurrency().getIso());
             contentValues.put(Contract.Budget.WALLET_IDS, Contract.getObjectIds(mWalletsPicker.getCurrentWallets()));
             ContentResolver contentResolver = getContentResolver();
             try {
@@ -908,6 +911,7 @@ public class NewEditBudgetActivity extends NewEditItemActivity implements MoneyP
                             .setPositiveButton(android.R.string.ok, null)
                             .show();
                 }
+                return;
             }
             RecurrenceBroadcastReceiver.scheduleRecurrenceTask(this);
             setResult(Activity.RESULT_OK);

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivityTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivityTest.java
@@ -1049,6 +1049,7 @@ public class NewEditBudgetActivityTest {
         Cursor row = budgetRow(root);
         assertEquals(350000L, row.getLong(row.getColumnIndex(Contract.Budget.MONEY)));
         assertTrue(row.isNull(row.getColumnIndex(Contract.Budget.RULE)));
+        assertEquals("2019-01-15", row.getString(row.getColumnIndex(Contract.Budget.RULE_START)));
         assertEquals("2019-03-15", row.getString(row.getColumnIndex(Contract.Budget.START_DATE)));
         assertEquals("2019-04-14", row.getString(row.getColumnIndex(Contract.Budget.END_DATE)));
         row.close();
@@ -1068,6 +1069,33 @@ public class NewEditBudgetActivityTest {
                 assertTrue(checkBox(activity, R.id.repeat_checkbox).isChecked());
             });
         }
+    }
+
+    @Test
+    public void aClosedPeriodWithASpentRuleDropsTheRuleAndKeepsItsAnchor() {
+        long root = insertBudget(Contract.BudgetType.EXPENSES, 300000L, "EUR",
+                new long[] {mWalletA}, null, "2019-03-15", "2019-04-14",
+                monthlyUntil(date("2019-01-15"), date("2019-02-01")).getRule(), "2019-01-15", null);
+        insertRolledPeriod(root, "2019-04-15", "2019-05-14");
+        int before = countBudgets();
+        try (ActivityScenario<NewEditBudgetActivity> scenario =
+                     ActivityScenario.launch(editIntent(root))) {
+            scenario.onActivity(activity -> {
+                assertEquals(View.GONE, activity.findViewById(R.id.repeat_checkbox).getVisibility());
+                moneyPicker(activity).setMoney(350000L);
+                save(activity);
+                assertTrue(activity.isFinishing());
+                assertNull(ShadowDialog.getLatestDialog());
+            });
+        }
+        assertEquals(before, countBudgets());
+        Cursor row = budgetRow(root);
+        assertEquals(350000L, row.getLong(row.getColumnIndex(Contract.Budget.MONEY)));
+        assertTrue(row.isNull(row.getColumnIndex(Contract.Budget.RULE)));
+        assertEquals("2019-01-15", row.getString(row.getColumnIndex(Contract.Budget.RULE_START)));
+        assertEquals("2019-03-15", row.getString(row.getColumnIndex(Contract.Budget.START_DATE)));
+        assertEquals("2019-04-14", row.getString(row.getColumnIndex(Contract.Budget.END_DATE)));
+        row.close();
     }
 
     @Test
@@ -1145,7 +1173,6 @@ public class NewEditBudgetActivityTest {
         ContentValues moved = new ContentValues();
         moved.put(Contract.Budget.TYPE, Contract.BudgetType.EXPENSES.getValue());
         moved.put(Contract.Budget.MONEY, 300000L);
-        moved.put(Contract.Budget.CURRENCY, "EUR");
         moved.put(Contract.Budget.WALLET_IDS, idList(new long[] {mWalletA}));
         moved.put(Contract.Budget.START_DATE, "2030-01-01");
         moved.put(Contract.Budget.END_DATE, "2030-01-31");
@@ -1197,6 +1224,60 @@ public class NewEditBudgetActivityTest {
     }
 
     @Test
+    public void aRollOpeningALaterPeriodThenTurningRepeatOffKeepsTheAnchor() {
+        long root = insertBudget(Contract.BudgetType.EXPENSES, 300000L, "EUR",
+                new long[] {mWalletA}, null, "2019-03-15", "2019-04-14", null, "2019-01-15", null);
+        long live = insertRolledPeriod(root, "2019-04-15", "2019-05-14");
+        int before;
+        try (ActivityScenario<NewEditBudgetActivity> scenario =
+                     ActivityScenario.launch(editIntent(live))) {
+            long later = insertRolledPeriod(live, "2019-05-15", "2019-06-14");
+            assertEquals(uuidOf(root) + ":2019-05-15", uuidOf(later));
+            before = countBudgets();
+            scenario.onActivity(activity -> {
+                checkBox(activity, R.id.repeat_checkbox).performClick();
+                assertFalse(checkBox(activity, R.id.repeat_checkbox).isChecked());
+                save(activity);
+                assertTrue(activity.isFinishing());
+                assertNull(ShadowDialog.getLatestDialog());
+            });
+        }
+        assertEquals(before, countBudgets());
+        Cursor row = budgetRow(live);
+        assertTrue(row.isNull(row.getColumnIndex(Contract.Budget.RULE)));
+        assertEquals("2019-01-15", row.getString(row.getColumnIndex(Contract.Budget.RULE_START)));
+        assertEquals("2019-04-15", row.getString(row.getColumnIndex(Contract.Budget.START_DATE)));
+        assertEquals("2019-05-14", row.getString(row.getColumnIndex(Contract.Budget.END_DATE)));
+        row.close();
+    }
+
+    @Test
+    public void theLivePeriodOfAChainTurnedOffDropsTheAnchor() {
+        long root = insertBudget(Contract.BudgetType.EXPENSES, 300000L, "EUR",
+                new long[] {mWalletA}, null, "2019-03-15", "2019-04-14", null, "2019-01-15", null);
+        long live = insertRolledPeriod(root, "2019-04-15", "2019-05-14");
+        int before = countBudgets();
+        try (ActivityScenario<NewEditBudgetActivity> scenario =
+                     ActivityScenario.launch(editIntent(live))) {
+            scenario.onActivity(activity -> {
+                assertTrue(checkBox(activity, R.id.repeat_checkbox).isChecked());
+                checkBox(activity, R.id.repeat_checkbox).performClick();
+                assertFalse(checkBox(activity, R.id.repeat_checkbox).isChecked());
+                save(activity);
+                assertTrue(activity.isFinishing());
+                assertNull(ShadowDialog.getLatestDialog());
+            });
+        }
+        assertEquals(before, countBudgets());
+        Cursor row = budgetRow(live);
+        assertTrue(row.isNull(row.getColumnIndex(Contract.Budget.RULE)));
+        assertTrue(row.isNull(row.getColumnIndex(Contract.Budget.RULE_START)));
+        assertEquals("2019-04-15", row.getString(row.getColumnIndex(Contract.Budget.START_DATE)));
+        assertEquals("2019-05-14", row.getString(row.getColumnIndex(Contract.Budget.END_DATE)));
+        row.close();
+    }
+
+    @Test
     public void aWalletDeletedWhileTheEditorIsOpenReachesTheRefusalDialog() {
         long budget = insertAprilCategoryBudget(new long[] {mWalletA, mUnusedWallet});
         int before = countBudgets();
@@ -1210,6 +1291,7 @@ public class NewEditBudgetActivityTest {
                 TextView message = dialog.findViewById(android.R.id.message);
                 assertEquals(activity.getString(R.string.error_input_missing_multiple_wallets),
                         message.getText().toString());
+                assertFalse(activity.isFinishing());
             });
         }
         assertEquals(before, countBudgets());
@@ -1269,6 +1351,85 @@ public class NewEditBudgetActivityTest {
         assertEquals(APRIL_END, row.getString(row.getColumnIndex(Contract.Budget.END_DATE)));
         row.close();
         assertEquals(Arrays.asList(mWalletA, mWalletB), walletIdsOf(budget));
+    }
+
+    @Test
+    public void theOnlyWalletMovedOntoAnotherCurrencyWhileTheEditorIsOpenSavesInThatCurrency() {
+        long budget = insertBudget(Contract.BudgetType.EXPENSES, 900000L, "EUR",
+                new long[] {mWalletA}, null, APRIL_START, APRIL_END, null, null, null);
+        int before = countBudgets();
+        try (ActivityScenario<NewEditBudgetActivity> scenario =
+                     ActivityScenario.launch(editIntent(budget))) {
+            ContentValues yen = new ContentValues();
+            yen.put(Contract.Wallet.CURRENCY, "JPY");
+            mResolver.update(ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS,
+                    mWalletA), yen, null, null);
+            scenario.onActivity(activity -> {
+                moneyPicker(activity).setMoney(999999L);
+                save(activity);
+                assertTrue(activity.isFinishing());
+                assertNull(ShadowDialog.getLatestDialog());
+            });
+        }
+        assertEquals(before, countBudgets());
+        Cursor row = budgetRow(budget);
+        assertEquals(999999L, row.getLong(row.getColumnIndex(Contract.Budget.MONEY)));
+        assertEquals("JPY", row.getString(row.getColumnIndex(Contract.Budget.CURRENCY)));
+        assertEquals(APRIL_START, row.getString(row.getColumnIndex(Contract.Budget.START_DATE)));
+        assertEquals(APRIL_END, row.getString(row.getColumnIndex(Contract.Budget.END_DATE)));
+        row.close();
+        assertEquals(Collections.singletonList(mWalletA), walletIdsOf(budget));
+    }
+
+    @Test
+    public void aNewBudgetOverTheOnlyWalletMovedOntoAnotherCurrencySavesInThatCurrency() {
+        PreferenceManager.setCurrentWallet(mContext, mWalletA);
+        int before = countBudgets();
+        try (ActivityScenario<NewEditBudgetActivity> scenario =
+                     ActivityScenario.launch(newItemIntent())) {
+            scenario.onActivity(activity -> {
+                moneyPicker(activity).setMoney(500000L);
+                startDatePicker(activity).setCurrentDateTime(date(APRIL_START));
+                endDatePicker(activity).setCurrentDateTime(date(APRIL_END));
+                ContentValues yen = new ContentValues();
+                yen.put(Contract.Wallet.CURRENCY, "JPY");
+                mResolver.update(ContentUris.withAppendedId(DataContentProvider.CONTENT_WALLETS,
+                        mWalletA), yen, null, null);
+                save(activity);
+                assertTrue(activity.isFinishing());
+                assertNull(ShadowDialog.getLatestDialog());
+            });
+        }
+        assertEquals(before + 1, countBudgets());
+        long budget = newestBudget();
+        Cursor row = budgetRow(budget);
+        assertEquals(500000L, row.getLong(row.getColumnIndex(Contract.Budget.MONEY)));
+        assertEquals("JPY", row.getString(row.getColumnIndex(Contract.Budget.CURRENCY)));
+        assertEquals(APRIL_START, row.getString(row.getColumnIndex(Contract.Budget.START_DATE)));
+        assertEquals(APRIL_END, row.getString(row.getColumnIndex(Contract.Budget.END_DATE)));
+        row.close();
+        assertEquals(Collections.singletonList(mWalletA), walletIdsOf(budget));
+    }
+
+    @Test
+    public void aCurrencySentWithABudgetIsReplacedByItsWalletsCurrency() {
+        long budget = insertBudget(Contract.BudgetType.EXPENSES, 900000L, "JPY",
+                new long[] {mWalletA}, null, APRIL_START, APRIL_END, null, null, null);
+        Cursor row = budgetRow(budget);
+        assertEquals("EUR", row.getString(row.getColumnIndex(Contract.Budget.CURRENCY)));
+        row.close();
+        ContentValues sent = new ContentValues();
+        sent.put(Contract.Budget.TYPE, Contract.BudgetType.EXPENSES.getValue());
+        sent.put(Contract.Budget.MONEY, 900000L);
+        sent.put(Contract.Budget.CURRENCY, "JPY");
+        sent.put(Contract.Budget.WALLET_IDS, idList(new long[] {mWalletA}));
+        sent.put(Contract.Budget.START_DATE, APRIL_START);
+        sent.put(Contract.Budget.END_DATE, APRIL_END);
+        mResolver.update(ContentUris.withAppendedId(DataContentProvider.CONTENT_BUDGETS, budget),
+                sent, null, null);
+        row = budgetRow(budget);
+        assertEquals("EUR", row.getString(row.getColumnIndex(Contract.Budget.CURRENCY)));
+        row.close();
     }
 
     @Test


### PR DESCRIPTION
Three fixes to how a budget is saved, all found while writing the budget editor's test class.

A save the app refuses no longer closes the editor. Before, when a budget's wallet had been deleted while the editor was open, the error dialog came up and the editor closed behind it anyway, with nothing saved. Now the dialog shows and the editor stays open.

Editing a period a repeating budget has already moved past no longer erases the day its schedule was counted from. The save treated such a period as repeat being turned off and cleared the anchor along with the schedule. Nothing on screen reads that anchor on a past period, so no period was lost or doubled, but the row stopped saying where its chain began.

A budget's currency now comes from its wallets as they are when it is saved, not from what the editor loaded when it opened. If a budget's only wallet was moved to another currency while the editor was open, the save wrote the old currency over a wallet in the new one, and the budget then compared spending in one currency against a target in another. A new period of a repeating budget takes its currency from the wallets too.

The editor's test class gains six cases and two assertions, each shown failing first. Tested on a device, the currency case before and after the fix and the refused save after it.

