### PR TITLE
Fold a period's transactions under its header on the transactions list

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/preference/PreferenceManager.java
@@ -73,6 +73,7 @@ public class PreferenceManager {
 
     private static final String MAP_TILE_SERVER = "map_tile_server";
     private static final String COLLAPSED_CATEGORIES = "collapsed_categories";
+    private static final String COLLAPSED_PERIODS = "collapsed_periods";
 
     private static final String LAST_DATA_CHANGE_TIME = "last_data_change_time";
 
@@ -153,6 +154,26 @@ public class PreferenceManager {
 
     public static void setCollapsedCategories(Set<String> categoryIds) {
         mPreferences.edit().putStringSet(COLLAPSED_CATEGORIES, categoryIds).apply();
+    }
+
+    /**
+     * @return the keys of the periods whose transactions the user has hidden on the transactions
+     *          list and on a filtered transactions list. A key is the group type number, a colon,
+     *          and the header's start date exactly as the list's header cursor reports it, so a
+     *          folded month and a folded day that begin on the same date are two different keys.
+     *          Nothing stored means nothing hidden, which is how the list has always been drawn.
+     *          Stored once, not held per list, so that two lists cannot write each other's hiding
+     *          away. Each list still has to read it again to redraw, which
+     *          TransactionListFragment does when it resumes.
+     */
+    public static Set<String> getCollapsedPeriods() {
+        // A copy, because getStringSet is documented as returning a set the caller must not
+        // modify, and the callers here are building the next value out of this one.
+        return new HashSet<>(mPreferences.getStringSet(COLLAPSED_PERIODS, Collections.<String>emptySet()));
+    }
+
+    public static void setCollapsedPeriods(Set<String> periodKeys) {
+        mPreferences.edit().putStringSet(COLLAPSED_PERIODS, periodKeys).apply();
     }
 
     public static void setCurrentWallet(Context context, long walletId) {

--- a/app/src/main/java/com/oriondev/moneywallet/storage/wrapper/AbstractHeaderCursor.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/wrapper/AbstractHeaderCursor.java
@@ -79,6 +79,12 @@ public abstract class AbstractHeaderCursor<H> extends AbstractCursor {
         return mIsHeader;
     }
 
+    /** Whether that position holds a header, answered from the index list without moving any cursor. */
+    public boolean isHeaderAt(int position) {
+        return position >= 0 && position < mIndices.size()
+                && mIndices.get(position).getL() == TYPE_HEADER;
+    }
+
     protected void addHeader(H header) {
         int id = mHeaders.size();
         mHeaders.put(id, header);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/TransactionCursorAdapter.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/adapter/recycler/TransactionCursorAdapter.java
@@ -33,6 +33,8 @@ import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.model.Money;
 import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.storage.wrapper.AbstractHeaderCursor;
 import com.oriondev.moneywallet.storage.wrapper.TransactionHeaderCursor;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.DateFormatter;
@@ -40,7 +42,11 @@ import com.oriondev.moneywallet.utils.DateUtils;
 import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.MoneyFormatter;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Created by andrea on 03/03/18.
@@ -67,6 +73,22 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
     private int mIndexCurrency;
 
     private MoneyFormatter mMoneyFormatter;
+
+    /**
+     * Cursor row of each row on screen, in order. Hiding a period's transactions leaves their
+     * cursor rows out of this list, so every position this adapter is asked about is read
+     * through it.
+     */
+    private final List<Integer> mVisibleRows = new ArrayList<>();
+
+    /**
+     * Keys of the periods whose transactions are hidden, as of the last rebuild. Read from the
+     * preference every time instead of kept, because the two lists that draw headers with this
+     * adapter, the transactions list and a filtered transactions list, share one stored set and
+     * are alive at once, since the filtered list opens over the main one. An adapter that
+     * trusted its own copy would write the others' hiding away.
+     */
+    private final Set<String> mCollapsedPeriods = new HashSet<>();
 
     public TransactionCursorAdapter(ActionListener actionListener) {
         this(actionListener, false);
@@ -101,6 +123,113 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
         mIndexTransactionDate = cursor.getColumnIndex(Contract.Transaction.DATE);
         mIndexTransactionMoney = cursor.getColumnIndex(Contract.Transaction.MONEY);
         mIndexCurrency = cursor.getColumnIndex(Contract.Transaction.WALLET_CURRENCY);
+        // The superclass calls this from two places: when it takes a new cursor, after that
+        // cursor is in place and before it tells the list anything changed, and from its own
+        // constructor. The constructor call cannot land here, because this adapter is always
+        // built with no cursor and the fields the walk below needs do not exist until super
+        // returns.
+        rebuildVisibleRows();
+    }
+
+    private void rebuildVisibleRows() {
+        mVisibleRows.clear();
+        mCollapsedPeriods.clear();
+        mCollapsedPeriods.addAll(PreferenceManager.getCollapsedPeriods());
+        Cursor cursor = getCursor();
+        if (cursor == null) {
+            return;
+        }
+        if (mIndexType == -1) {
+            return;
+        }
+        // Moving the wrapper to an item row moves the SQLite cursor under it, so asking every row
+        // what it is paged the whole result set on the main thread on every load. The header rows
+        // are the only ones this walk reads, and the wrapper names them without being moved.
+        AbstractHeaderCursor<?> headerCursor = (AbstractHeaderCursor<?>) cursor;
+        boolean headerIsCollapsed = false;
+        for (int position = 0; position < cursor.getCount(); position++) {
+            if (headerCursor.isHeaderAt(position)) {
+                cursor.moveToPosition(position);
+                headerIsCollapsed = mCollapsedPeriods.contains(periodKey(
+                        cursor.getInt(mIndexHeaderGroupType),
+                        cursor.getString(mIndexHeaderStartDate)));
+                mVisibleRows.add(position);
+            } else if (!headerIsCollapsed) {
+                mVisibleRows.add(position);
+            }
+        }
+    }
+
+    /**
+     * The key a period is stored under: the grouping it was drawn with, then the date it starts
+     * on. The grouping is part of it because a day and the month it opens start on the same date,
+     * and folding one must not fold the other when the user changes the grouping and comes back.
+     */
+    private static String periodKey(int groupType, String startDate) {
+        return groupType + ":" + startDate;
+    }
+
+    /**
+     * Draws the rows again against what is stored now. The list this adapter is in is not the
+     * only one reading that store, so a list coming back to the front has to ask again instead
+     * of drawing what it last built. A set that has not changed is left alone, because the main
+     * list calls this every time it resumes, and rebuilding walks the whole cursor and rebinds
+     * every row on the main thread. Without that, every return from a transaction, the report or
+     * the settings paid for a fold nobody had made.
+     */
+    public void reloadCollapsedPeriods() {
+        if (PreferenceManager.getCollapsedPeriods().equals(mCollapsedPeriods)) {
+            return;
+        }
+        rebuildVisibleRows();
+        notifyDataSetChanged();
+    }
+
+    /*package-local*/ void togglePeriod(String key) {
+        // Read, change, write, so that the other list this adapter shares the stored set with
+        // keeps its own hiding.
+        Set<String> stored = PreferenceManager.getCollapsedPeriods();
+        if (!stored.remove(key)) {
+            stored.add(key);
+        }
+        PreferenceManager.setCollapsedPeriods(stored);
+        rebuildVisibleRows();
+        notifyDataSetChanged();
+    }
+
+    /**
+     * The cursor row an on screen position stands for, or -1 when there is none. Everything that
+     * takes an on screen position goes through this, and so does every read of the cursor from a
+     * click.
+     */
+    private int cursorPosition(int position) {
+        if (mIndexType == -1) {
+            // The calendar and the search results hand this adapter a plain cursor with no header
+            // rows, so nothing folds and positions map straight through. The search rebuilds its
+            // cursor per keystroke, so a boxed copy of every row there would be paid per character.
+            return position;
+        }
+        return position >= 0 && position < mVisibleRows.size() ? mVisibleRows.get(position) : -1;
+    }
+
+    @Override
+    public int getItemCount() {
+        // Guarded, because a cursor swapped away for null leaves the rows built for it behind,
+        // since the superclass only walks a cursor it actually has.
+        if (!isDataValid()) {
+            return 0;
+        }
+        return mIndexType == -1 ? getCursor().getCount() : mVisibleRows.size();
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return super.getItemId(cursorPosition(position));
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
+        super.onBindViewHolder(holder, cursorPosition(position));
     }
 
     @Override
@@ -143,6 +272,19 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
         Money expense = Money.parse(cursor.getString(mIndexHeaderExpense));
         mMoneyFormatter.applyTintedIncome(holder.mIncomeTextView, orZero(income, money));
         mMoneyFormatter.applyTintedExpense(holder.mExpenseTextView, orZero(expense, money));
+        bindPeriodToggle(holder, cursor);
+    }
+
+    private void bindPeriodToggle(HeaderViewHolder holder, Cursor cursor) {
+        boolean collapsed = mCollapsedPeriods.contains(periodKey(
+                cursor.getInt(mIndexHeaderGroupType), cursor.getString(mIndexHeaderStartDate)));
+        holder.mPeriodToggle.setRotation(collapsed ? 0f : 180f);
+        // Named, because a screen reader reaches the arrow on its own and every one of them
+        // would otherwise read the same words. The date range is the one the row just drew.
+        holder.mPeriodToggle.setContentDescription(holder.itemView.getContext().getString(
+                collapsed ? R.string.description_show_period_transactions
+                        : R.string.description_hide_period_transactions,
+                holder.mLeftTextView.getText()));
     }
 
     /**
@@ -183,7 +325,7 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
     @Override
     public int getItemViewType(int position) {
         if (mIndexType != -1) {
-            return getSafeCursor(position).getInt(mIndexType);
+            return getSafeCursor(cursorPosition(position)).getInt(mIndexType);
         } else {
             return TransactionHeaderCursor.TYPE_ITEM;
         }
@@ -195,6 +337,7 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
         private TextView mRightTextView;
         private TextView mIncomeTextView;
         private TextView mExpenseTextView;
+        private ImageView mPeriodToggle;
 
         /*package-local*/ HeaderViewHolder(View itemView) {
             super(itemView);
@@ -202,6 +345,21 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
             mRightTextView = itemView.findViewById(R.id.right_text_view);
             mIncomeTextView = itemView.findViewById(R.id.income_text_view);
             mExpenseTextView = itemView.findViewById(R.id.expense_text_view);
+            mPeriodToggle = itemView.findViewById(R.id.period_toggle_image_view);
+            // Its own listener, because a tap on the row still means what it always did: open
+            // the report of this period, or nothing at all.
+            mPeriodToggle.setOnClickListener(new View.OnClickListener() {
+
+                @Override
+                public void onClick(View view) {
+                    Cursor cursor = getSafeCursor(cursorPosition(getAdapterPosition()));
+                    if (cursor != null) {
+                        togglePeriod(periodKey(cursor.getInt(mIndexHeaderGroupType),
+                                cursor.getString(mIndexHeaderStartDate)));
+                    }
+                }
+
+            });
             // the arrow is a ThemedImageView, which tints itself from the row it sits on and
             // repaints when the mode changes. A theme attribute in the vector would resolve
             // against the xml theme, which is the light one whatever mode the user picked
@@ -218,7 +376,7 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
         @Override
         public void onClick(View v) {
             if (mActionListener != null) {
-                Cursor cursor = getSafeCursor(getAdapterPosition());
+                Cursor cursor = getSafeCursor(cursorPosition(getAdapterPosition()));
                 if (cursor != null) {
                     Date start = DateUtils.getDateFromSQLDateTimeString(cursor.getString(mIndexHeaderStartDate));
                     Date end = DateUtils.getDateFromSQLDateTimeString(cursor.getString(mIndexHeaderEndDate));
@@ -249,7 +407,7 @@ public class TransactionCursorAdapter extends AbstractCursorAdapter<RecyclerView
         @Override
         public void onClick(View v) {
             if (mActionListener != null) {
-                Cursor cursor = getSafeCursor(getAdapterPosition());
+                Cursor cursor = getSafeCursor(cursorPosition(getAdapterPosition()));
                 if (cursor != null) {
                     mActionListener.onTransactionClick(cursor.getLong(mIndexTransactionId));
                 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransactionListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/primary/TransactionListFragment.java
@@ -59,6 +59,8 @@ public class TransactionListFragment extends CursorListFragment implements Trans
 
     private static final String[] HIDDEN_PROJECTION = new String[] {Contract.Transaction.DATE};
 
+    private TransactionCursorAdapter mAdapter;
+
     @Override
     protected void onPrepareRecyclerView(AdvancedRecyclerView recyclerView) {
         recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
@@ -68,7 +70,21 @@ public class TransactionListFragment extends CursorListFragment implements Trans
     @Override
     protected AbstractCursorAdapter onCreateAdapter() {
         // the only one of the four that opens the report from a header click
-        return new TransactionCursorAdapter(this, true);
+        mAdapter = new TransactionCursorAdapter(this, true);
+        return mAdapter;
+    }
+
+    /**
+     * Which periods have their transactions hidden is stored once for the whole application, and
+     * this list is not the only one reading it, since a filtered transactions list opens over this
+     * one. Asking again here is what stops the one underneath drawing a state another has already
+     * changed, which would make its next arrow tap do nothing. The rows themselves need no
+     * reloading, since the loader is watching the transactions already.
+     */
+    @Override
+    public void onResume() {
+        super.onResume();
+        mAdapter.reloadCollapsedPeriods();
     }
 
     @Override

--- a/app/src/main/res/layout/adapter_transaction_header_item.xml
+++ b/app/src/main/res/layout/adapter_transaction_header_item.xml
@@ -25,14 +25,13 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="@dimen/material_component_lists_header_height"
-    android:paddingTop="8dp"
-    android:paddingBottom="8dp"
     android:background="?attr/selectableItemBackground">
 
     <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
         android:id="@+id/left_text_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
         android:layout_marginLeft="@dimen/material_component_lists_header_start_margin"
         android:layout_marginStart="@dimen/material_component_lists_header_start_margin"
         android:layout_marginEnd="8dp"
@@ -54,9 +53,7 @@
         android:layout_marginRight="8dp"
         android:textSize="@dimen/material_component_lists_header_text_size"
         app:layout_constraintTop_toTopOf="@+id/left_text_view"
-        app:layout_constraintEnd_toStartOf="@+id/report_image_view"
-        app:layout_goneMarginEnd="@dimen/material_component_lists_header_end_margin"
-        app:layout_goneMarginRight="@dimen/material_component_lists_header_end_margin"
+        app:layout_constraintEnd_toStartOf="@+id/period_toggle_image_view"
         app:theme_textColor="textColorPrimary"
         tools:text="$ 600.00" />
 
@@ -78,16 +75,17 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="2dp"
+        android:layout_marginBottom="8dp"
         android:layout_marginLeft="@dimen/material_component_lists_header_start_margin"
         android:layout_marginStart="@dimen/material_component_lists_header_start_margin"
         android:layout_marginEnd="8dp"
         android:layout_marginRight="8dp"
         android:orientation="horizontal"
         app:layout_constraintTop_toBottomOf="@+id/header_line_barrier"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintVertical_bias="0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/report_image_view"
-        app:layout_goneMarginEnd="@dimen/material_component_lists_header_end_margin"
-        app:layout_goneMarginRight="@dimen/material_component_lists_header_end_margin">
+        app:layout_constraintEnd_toStartOf="@+id/period_toggle_image_view">
 
         <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
             android:id="@+id/income_label_text_view"
@@ -147,6 +145,29 @@
             tools:text="$ 720.00" />
 
     </LinearLayout>
+
+    <!--
+      The fold arrow. Its gone margin puts its glyph the same 16dp from the edge of the row that
+      the report arrow's keeps. The height is fixed at 48dp because a height taken from the parent
+      constraints excluded the paddings and came out at 37.7dp on a device. The row's 8dp of top
+      and bottom space is carried as margins on the text, not as padding on the row, since a fixed
+      size child taller than a padded wrap content box grows the box instead of centering in it.
+    -->
+    <com.oriondev.moneywallet.ui.view.theme.ThemedImageView
+        android:id="@+id/period_toggle_image_view"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:padding="12dp"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_expand_more_black_24dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/report_image_view"
+        app:layout_goneMarginEnd="4dp"
+        app:layout_goneMarginRight="4dp"
+        app:theme_backgroundColor="colorWindowForeground"
+        tools:ignore="ContentDescription" />
 
     <com.oriondev.moneywallet.ui.view.theme.ThemedImageView
         android:id="@+id/report_image_view"

--- a/app/src/main/res/values/descriptions.xml
+++ b/app/src/main/res/values/descriptions.xml
@@ -45,6 +45,8 @@
     <string name="description_setting_category_icon">"Setting category icon"</string>
     <string name="description_show_subcategories">"Show subcategories of %1$s"</string>
     <string name="description_hide_subcategories">"Hide subcategories of %1$s"</string>
+    <string name="description_show_period_transactions">"Show the transactions of %1$s"</string>
+    <string name="description_hide_period_transactions">"Hide the transactions of %1$s"</string>
     <string name="description_day_has_transactions">"Has transactions"</string>
     <string name="description_show_period_report">"Show the report for this period"</string>
 </resources>

--- a/app/src/test/java/com/oriondev/moneywallet/ui/adapter/recycler/CollapsedPeriodsTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/adapter/recycler/CollapsedPeriodsTest.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.adapter.recycler;
+
+import android.database.MatrixCursor;
+import android.view.ContextThemeWrapper;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.model.Group;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.storage.wrapper.TransactionHeaderCursor;
+import com.oriondev.moneywallet.utils.DateUtils;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A header the user has folded keeps its transactions off the list, and every position the list
+ * asks about has to be answered against the rows that are left, not against the cursor. The
+ * store is one set for the whole application, so a fold written by either of the two lists that
+ * draw headers with this adapter is the same fold, and a list only sees it once it reads the
+ * store again.
+ *
+ * Group.DAILY is used throughout. A daily header starts at midnight of the day its rows fall on,
+ * so the two headers here are keyed "0:2019-03-15 00:00:00" and "0:2019-03-14 00:00:00".
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CollapsedPeriodsTest {
+
+    private static final String FIRST_DAY = "0:2019-03-15 00:00:00";
+    private static final String SECOND_DAY = "0:2019-03-14 00:00:00";
+    private static final String FIRST_DAY_AS_A_MONTH = "2:2019-03-15 00:00:00";
+
+    private static final int HEADER = TransactionHeaderCursor.TYPE_HEADER;
+    private static final int ITEM = TransactionHeaderCursor.TYPE_ITEM;
+
+    private static final String[] COLUMNS = new String[] {
+            Contract.Transaction.ID,
+            Contract.Transaction.DATE,
+            Contract.Transaction.DIRECTION,
+            Contract.Transaction.MONEY,
+            Contract.Transaction.WALLET_CURRENCY,
+            Contract.Transaction.CONFIRMED,
+            Contract.Transaction.COUNT_IN_TOTAL,
+            Contract.Transaction.CATEGORY_NAME,
+            Contract.Transaction.CATEGORY_ICON,
+            Contract.Transaction.DESCRIPTION
+    };
+
+    /** Newest first, which is the order the list queries in. */
+    private static final String[] DATES = new String[] {
+            "2019-03-15 10:00:00",
+            "2019-03-15 10:00:00",
+            "2019-03-15 10:00:00",
+            "2019-03-14 10:00:00",
+            "2019-03-14 10:00:00"
+    };
+
+    /** Nothing folded, so a case cannot be handed what the one before it wrote. */
+    @Before
+    public void clearTheStoredPeriods() {
+        PreferenceManager.setCollapsedPeriods(Collections.<String>emptySet());
+    }
+
+    private MatrixCursor bareCursor() {
+        MatrixCursor cursor = new MatrixCursor(COLUMNS);
+        for (int row = 0; row < DATES.length; row++) {
+            cursor.addRow(new Object[] {
+                    (long) (row + 1), DATES[row], Contract.Direction.EXPENSE, 1000L, "EUR",
+                    1, 1, "Category", null, "Description"
+            });
+        }
+        return cursor;
+    }
+
+    private TransactionHeaderCursor cursor() {
+        return new TransactionHeaderCursor(bareCursor(), Group.DAILY, null, null);
+    }
+
+    private TransactionCursorAdapter adapter() {
+        TransactionCursorAdapter adapter = new TransactionCursorAdapter(new RecordsNothing(), false);
+        adapter.changeCursor(cursor());
+        return adapter;
+    }
+
+    /**
+     * Folds the given keys the way another screen would, then asks this adapter to read the store
+     * again. This is the way a fold arrives from outside; the arrow's own path is togglePeriod,
+     * which theArrowFoldsAndUnfoldsThroughTheAdapter drives instead.
+     */
+    private void fold(TransactionCursorAdapter adapter, String... keys) {
+        PreferenceManager.setCollapsedPeriods(new HashSet<>(Arrays.asList(keys)));
+        adapter.reloadCollapsedPeriods();
+    }
+
+    private void assertTypes(TransactionCursorAdapter adapter, int... types) {
+        assertEquals(types.length, adapter.getItemCount());
+        for (int position = 0; position < types.length; position++) {
+            assertEquals("wrong type at position " + position,
+                    types[position], adapter.getItemViewType(position));
+        }
+    }
+
+    @Test
+    public void withNothingStoredEveryTransactionIsUnderItsHeader() {
+        TransactionCursorAdapter adapter = adapter();
+        assertTypes(adapter, HEADER, ITEM, ITEM, ITEM, HEADER, ITEM, ITEM);
+    }
+
+    @Test
+    public void foldingADayLeavesItsHeaderAndTakesItsTransactions() {
+        TransactionCursorAdapter adapter = adapter();
+        fold(adapter, FIRST_DAY);
+        assertTypes(adapter, HEADER, HEADER, ITEM, ITEM);
+        assertEquals(4L, adapter.getItemId(2));
+        assertEquals(5L, adapter.getItemId(3));
+    }
+
+    @Test
+    public void foldingTheSameDayAgainBringsItsTransactionsBack() {
+        TransactionCursorAdapter adapter = adapter();
+        fold(adapter, FIRST_DAY);
+        fold(adapter);
+        assertTypes(adapter, HEADER, ITEM, ITEM, ITEM, HEADER, ITEM, ITEM);
+        assertTrue(PreferenceManager.getCollapsedPeriods().isEmpty());
+    }
+
+    @Test
+    public void aFoldSurvivesTheListBeingLoadedAgain() {
+        TransactionCursorAdapter adapter = adapter();
+        fold(adapter, FIRST_DAY);
+        adapter.changeCursor(cursor());
+        assertTypes(adapter, HEADER, HEADER, ITEM, ITEM);
+    }
+
+    @Test
+    public void aDayAndTheMonthItOpensAreNotTheSameFold() {
+        TransactionCursorAdapter adapter = adapter();
+        fold(adapter, FIRST_DAY_AS_A_MONTH);
+        assertTypes(adapter, HEADER, ITEM, ITEM, ITEM, HEADER, ITEM, ITEM);
+    }
+
+    @Test
+    public void aFoldWrittenByAnotherScreenIsSeenOnlyOnceThisListReadsAgain() {
+        TransactionCursorAdapter adapter = adapter();
+        PreferenceManager.setCollapsedPeriods(new HashSet<>(Collections.singletonList(FIRST_DAY)));
+        assertEquals(7, adapter.getItemCount());
+        adapter.reloadCollapsedPeriods();
+        assertEquals(4, adapter.getItemCount());
+    }
+
+    @Test
+    public void foldingTheSecondDayLeavesTheFirstDayWhereItWas() {
+        TransactionCursorAdapter adapter = adapter();
+        fold(adapter, SECOND_DAY);
+        assertTypes(adapter, HEADER, ITEM, ITEM, ITEM, HEADER);
+        assertEquals(1L, adapter.getItemId(1));
+        assertEquals(2L, adapter.getItemId(2));
+        assertEquals(3L, adapter.getItemId(3));
+    }
+
+    /**
+     * The other cases here read types and ids, which an adapter that never applied the mapping in
+     * onBindViewHolder still answers correctly. This one binds a real header row, which is where
+     * the wrong cursor row reaches a null start date and the list crashes.
+     */
+    @Test
+    public void aFoldedHeaderBindsTheHeaderThatIsOnScreen() {
+        TransactionCursorAdapter adapter = adapter();
+        fold(adapter, FIRST_DAY);
+        // the application context carries the platform theme, not the one the manifest gives the
+        // activities, and the row's ripple is an AppCompat attribute that only that one resolves
+        FrameLayout parent = new FrameLayout(new ContextThemeWrapper(
+                ApplicationProvider.getApplicationContext(), R.style.MoneyWalletAppTheme));
+        RecyclerView.ViewHolder onScreen = adapter.onCreateViewHolder(parent, HEADER);
+        adapter.onBindViewHolder(onScreen, 1);
+        // position 1 on screen is the second day's header, 2019-03-14, since the first day is
+        // folded and its three transactions are off the list
+        TextView leftTextView = onScreen.itemView.findViewById(R.id.left_text_view);
+        String dateRange = leftTextView.getText().toString();
+        assertTrue("the header drawn at position 1 was " + dateRange, dateRange.contains("14"));
+        assertTrue(toggleDescription(onScreen).startsWith("Hide"));
+        assertEquals(180f, toggle(onScreen).getRotation(), 0f);
+        RecyclerView.ViewHolder folded = adapter.onCreateViewHolder(parent, HEADER);
+        adapter.onBindViewHolder(folded, 0);
+        assertTrue(toggleDescription(folded).startsWith("Show"));
+        assertEquals(0f, toggle(folded).getRotation(), 0f);
+    }
+
+    private static ImageView toggle(RecyclerView.ViewHolder holder) {
+        return holder.itemView.findViewById(R.id.period_toggle_image_view);
+    }
+
+    private static String toggleDescription(RecyclerView.ViewHolder holder) {
+        return String.valueOf(toggle(holder).getContentDescription());
+    }
+
+    @Test
+    public void theArrowFoldsAndUnfoldsThroughTheAdapter() {
+        TransactionCursorAdapter adapter = adapter();
+        adapter.togglePeriod(FIRST_DAY);
+        assertEquals(4, adapter.getItemCount());
+        assertEquals(Collections.singleton(FIRST_DAY), PreferenceManager.getCollapsedPeriods());
+        adapter.togglePeriod(FIRST_DAY);
+        assertEquals(7, adapter.getItemCount());
+        assertTrue(PreferenceManager.getCollapsedPeriods().isEmpty());
+    }
+
+    /**
+     * A holder built with onCreateViewHolder alone answers NO_POSITION from getAdapterPosition,
+     * and every click handler here reads the cursor through that, so a click on such a holder
+     * resolves to no row at all. Laying the adapter out in a real RecyclerView is what gives the
+     * holders a position, and it is also the only way the arrow's own listener is reached from a
+     * view the list built.
+     */
+    private RecyclerView listWith(TransactionCursorAdapter adapter) {
+        RecyclerView recyclerView = new RecyclerView(new ContextThemeWrapper(
+                ApplicationProvider.getApplicationContext(), R.style.MoneyWalletAppTheme));
+        recyclerView.setLayoutManager(new LinearLayoutManager(recyclerView.getContext()));
+        recyclerView.setAdapter(adapter);
+        layOut(recyclerView);
+        return recyclerView;
+    }
+
+    /** The one screen the cases here lay a list out on, so a second pass uses the first one's. */
+    private static void layOut(RecyclerView recyclerView) {
+        recyclerView.measure(
+                View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
+                View.MeasureSpec.makeMeasureSpec(2400, View.MeasureSpec.EXACTLY));
+        recyclerView.layout(0, 0, 1080, 2400);
+    }
+
+    private static View childAt(RecyclerView recyclerView, int position) {
+        View view = recyclerView.getLayoutManager().findViewByPosition(position);
+        assertNotNull("nothing was laid out at position " + position, view);
+        return view;
+    }
+
+    /** The listener the two clicking cases hand the adapter, and the adapter opens the report. */
+    private TransactionCursorAdapter adapter(RecordsClicks listener) {
+        TransactionCursorAdapter adapter = new TransactionCursorAdapter(listener, true);
+        adapter.changeCursor(cursor());
+        return adapter;
+    }
+
+    /**
+     * A transaction row carries the id of the row on screen, not of the cursor row that sat at
+     * that position before the fold took three rows out from above it.
+     */
+    @Test
+    public void aTapOnARowUnderAFoldedHeaderOpensThatRow() {
+        RecordsClicks listener = new RecordsClicks();
+        TransactionCursorAdapter adapter = adapter(listener);
+        fold(adapter, FIRST_DAY);
+        RecyclerView recyclerView = listWith(adapter);
+        // position 2 on screen is the first transaction of the second day, id 4
+        childAt(recyclerView, 2).performClick();
+        assertEquals(4L, listener.mTransactionId);
+        // and position 1 is the second day's header, which opens the report for that day
+        childAt(recyclerView, 1).performClick();
+        assertNotNull("the header click recorded no date", listener.mHeaderStart);
+        // compared as a time, so a date parsed the same way is the same instant
+        assertEquals(DateUtils.getDateFromSQLDateTimeString("2019-03-14 00:00:00").getTime(),
+                listener.mHeaderStart.getTime());
+        // the end of a daily period is the last second of the same day, since the range is built
+        // ending at 23:59:59.999 and the header cursor prints it without the thousandths
+        assertEquals(DateUtils.getDateFromSQLDateTimeString("2019-03-14 23:59:59").getTime(),
+                listener.mHeaderEnd.getTime());
+    }
+
+    /**
+     * The arrow's own listener, from a tap on the view the list laid out to the stored set.
+     *
+     * The list is laid out again at the end, because a fold that is never told to the list leaves
+     * the stored set and the adapter count right and the rows the list itself is holding stale,
+     * and the next scroll on a device reads a row that is no longer on the list.
+     */
+    @Test
+    public void theArrowOnAHeaderFoldsThatHeader() {
+        TransactionCursorAdapter adapter = adapter(new RecordsClicks());
+        RecyclerView recyclerView = listWith(adapter);
+        // position 4 with nothing folded is the second day's header
+        childAt(recyclerView, 4).findViewById(R.id.period_toggle_image_view).performClick();
+        assertEquals(Collections.singleton(SECOND_DAY), PreferenceManager.getCollapsedPeriods());
+        assertEquals(5, adapter.getItemCount());
+        layOut(recyclerView);
+        // the list is holding those five rows, not the seven it laid out before the fold
+        assertEquals(5, recyclerView.getChildCount());
+        // position 4 is now the last row, the folded day's own header, which is still a header
+        // row; a transaction row carries no left_text_view at all
+        TextView leftTextView = childAt(recyclerView, 4).findViewById(R.id.left_text_view);
+        assertNotNull("the row at position 4 was not a header", leftTextView);
+        assertTrue("the header drawn at position 4 was " + leftTextView.getText(),
+                leftTextView.getText().toString().contains("14"));
+    }
+
+    /**
+     * The calendar and the search results build their cursor with a plain CursorLoader, so it
+     * carries no item type column and no header rows. An adapter that showed nothing for such a
+     * cursor would leave both screens blank, and none of the other cases here can see that.
+     */
+    @Test
+    public void aCursorWithoutHeadersShowsEveryRowAsAnItem() {
+        PreferenceManager.setCollapsedPeriods(new HashSet<>(Collections.singletonList(FIRST_DAY)));
+        TransactionCursorAdapter adapter = new TransactionCursorAdapter(new RecordsNothing(), false);
+        adapter.changeCursor(bareCursor());
+        assertTypes(adapter, ITEM, ITEM, ITEM, ITEM, ITEM);
+        assertEquals(1L, adapter.getItemId(0));
+        assertEquals(5L, adapter.getItemId(4));
+        adapter.reloadCollapsedPeriods();
+        assertTypes(adapter, ITEM, ITEM, ITEM, ITEM, ITEM);
+        assertEquals(1L, adapter.getItemId(0));
+        assertEquals(5L, adapter.getItemId(4));
+    }
+
+    @Test
+    public void theHeaderCursorKnowsWhichPositionsAreHeadersWithoutMoving() {
+        TransactionHeaderCursor cursor = cursor();
+        assertTrue(cursor.isHeaderAt(0));
+        assertTrue(cursor.isHeaderAt(4));
+        assertFalse(cursor.isHeaderAt(1));
+        assertFalse(cursor.isHeaderAt(2));
+        assertFalse(cursor.isHeaderAt(3));
+        assertFalse(cursor.isHeaderAt(5));
+        assertFalse(cursor.isHeaderAt(6));
+        assertFalse(cursor.isHeaderAt(7));
+        assertFalse(cursor.isHeaderAt(-1));
+    }
+
+    /**
+     * A loader that resets hands the adapter a null cursor through CursorListFragment, and a
+     * cursor taken away never reaches onLoadColumnIndices, so the rows built for the old cursor
+     * are still held afterwards and only the data valid guard in getItemCount keeps the list
+     * from asking for them.
+     */
+    @Test
+    public void aCursorTakenAwayLeavesNothingOnScreen() {
+        TransactionCursorAdapter adapter = adapter();
+        adapter.changeCursor(null);
+        assertEquals(0, adapter.getItemCount());
+        TransactionCursorAdapter bare = new TransactionCursorAdapter(new RecordsNothing(), false);
+        bare.changeCursor(bareCursor());
+        bare.changeCursor(null);
+        assertEquals(0, bare.getItemCount());
+    }
+
+    /** The adapter needs a listener, and none of these cases clicks anything. */
+    private static class RecordsNothing implements TransactionCursorAdapter.ActionListener {
+
+        @Override
+        public void onHeaderClick(Date startDate, Date endDate) {
+            // never called here
+        }
+
+        @Override
+        public void onTransactionClick(long id) {
+            // never called here
+        }
+    }
+
+    /** Keeps what the last click handed it, so a case can say which row the click resolved to. */
+    private static class RecordsClicks implements TransactionCursorAdapter.ActionListener {
+
+        private long mTransactionId = -1L;
+        private Date mHeaderStart;
+        private Date mHeaderEnd;
+
+        @Override
+        public void onHeaderClick(Date startDate, Date endDate) {
+            mHeaderStart = startDate;
+            mHeaderEnd = endDate;
+        }
+
+        @Override
+        public void onTransactionClick(long id) {
+            mTransactionId = id;
+        }
+    }
+}


### PR DESCRIPTION
Closes #253.

Every period header on the transactions list now has a fold arrow at its end. Tap it and the transactions under that header fold away, tap it again and they come back. With several years of transactions the list can be read as a column of month totals, and a month is opened only when its transactions are wanted. The arrow works for whichever grouping is set, day, week, month or year.

Tapping the header itself does what it always did, on the transactions list it opens the period report.

Which periods are folded is remembered, so a fold survives adding a transaction, rotating the phone and restarting the app. The filtered transactions list a category or a place opens shares the same memory. A folded month and a folded day that start on the same date are remembered apart, so changing the grouping and coming back does not fold the wrong thing. The calendar and the search results have no period headers and are unchanged.

The arrow is named for screen readers with the period it folds.

Tested on a device: folding and unfolding, a restart with a fold in place, the header tap still opening the report, rotation, both dark themes and right to left. Fourteen new unit cases pin which rows are on screen under a fold and which row a tap reaches.

| before | after |
|---|---|
| <img width="260" src="" /> | <img width="260" src="" /> |
