### PR TITLE
Let External Memory connect on Android 13 and newer

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -3,8 +3,8 @@
 
     <issue
         id="ScopedStorage"
-        message="WRITE_EXTERNAL_STORAGE is deprecated (and is not granted) when targeting Android 13+. If you need to write to shared storage, use the `MediaStore.createWriteRequest` intent."
-        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.WRITE_EXTERNAL_STORAGE&quot; />"
+        message="WRITE_EXTERNAL_STORAGE no longer provides write access when targeting Android 11+, even when using `requestLegacyExternalStorage`"
+        errorLine1="    &lt;uses-permission android:name=&quot;android.permission.WRITE_EXTERNAL_STORAGE&quot; android:maxSdkVersion=&quot;32&quot; />"
         errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/AndroidManifest.xml"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />

--- a/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendService.java
+++ b/app/src/main/java/com/oriondev/moneywallet/api/disk/DiskBackendService.java
@@ -23,6 +23,7 @@ import android.Manifest;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.pm.PackageManager;
+import android.os.Build;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.api.AbstractBackendServiceDelegate;
@@ -70,8 +71,16 @@ public class DiskBackendService extends AbstractBackendServiceDelegate {
         return R.string.cover_message_backup_external_memory_button;
     }
 
+    /**
+     * From Android 13 the platform denies WRITE_EXTERNAL_STORAGE to an app targeting 33 or
+     * higher without showing any dialog, so gating on it there leaves the cover screen up
+     * forever and {@link #setup} can never clear it.
+     */
     @Override
     public boolean isServiceEnabled(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            return true;
+        }
         String permission = Manifest.permission.WRITE_EXTERNAL_STORAGE;
         int result = ContextCompat.checkSelfPermission(context, permission);
         return result == PackageManager.PERMISSION_GRANTED;

--- a/app/src/test/java/com/oriondev/moneywallet/api/disk/DiskBackendServiceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/api/disk/DiskBackendServiceTest.java
@@ -1,0 +1,43 @@
+package com.oriondev.moneywallet.api.disk;
+
+import android.Manifest;
+import android.app.Application;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+/**
+ * From Android 13 the platform denies WRITE_EXTERNAL_STORAGE to an app targeting 33 or higher,
+ * so the backend has to report itself enabled without it.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class DiskBackendServiceTest {
+
+    private final DiskBackendService mService = new DiskBackendService(null);
+
+    @Test
+    @Config(sdk = {33, 36})
+    public void theBackendIsEnabledFromAndroid13WithoutTheStoragePermission() {
+        Application application = ApplicationProvider.getApplicationContext();
+        shadowOf(application).denyPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        assertTrue(mService.isServiceEnabled(application));
+    }
+
+    @Test
+    @Config(sdk = 32)
+    public void theBackendStillNeedsTheStoragePermissionBelowAndroid13() {
+        Application application = ApplicationProvider.getApplicationContext();
+        shadowOf(application).denyPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        assertFalse(mService.isServiceEnabled(application));
+        shadowOf(application).grantPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+        assertTrue(mService.isServiceEnabled(application));
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragmentTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/secondary/BackupHandlerFragmentTest.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowActivity;
 
 import static org.junit.Assert.assertEquals;
@@ -26,8 +27,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.robolectric.Shadows.shadowOf;
 
 /**
- * The cover button is tapped while the activity is resumed, which is where a backend used to
- * register its launcher and where AndroidX refuses a registration.
+ * Every test drives the backup screen inside a resumed activity, which is where a backend used
+ * to register its launcher and where AndroidX refuses a registration.
  */
 @RunWith(RobolectricTestRunner.class)
 public class BackupHandlerFragmentTest {
@@ -38,6 +39,7 @@ public class BackupHandlerFragmentTest {
     }
 
     @Test
+    @Config(sdk = 32)
     public void theExternalMemoryCoverButtonAsksForStoragePermission() {
         try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
             scenario.onActivity(activity -> {
@@ -47,6 +49,18 @@ public class BackupHandlerFragmentTest {
                 assertEquals(Manifest.permission.WRITE_EXTERNAL_STORAGE, request.requestedPermissions[0]);
             });
         }
+    }
+
+    @Test
+    @Config(sdk = {33, 36})
+    public void theExternalMemoryScreenOpensFromAndroid13WithoutTheStoragePermission() {
+        assertCoverVisibility(BackendServiceFactory.SERVICE_ID_EXTERNAL_MEMORY, View.GONE, View.VISIBLE);
+    }
+
+    @Test
+    @Config(sdk = 32)
+    public void theExternalMemoryScreenStaysCoveredWithoutTheStoragePermissionBelowAndroid13() {
+        assertCoverVisibility(BackendServiceFactory.SERVICE_ID_EXTERNAL_MEMORY, View.VISIBLE, View.GONE);
     }
 
     @Test
@@ -62,13 +76,30 @@ public class BackupHandlerFragmentTest {
     }
 
     private void clickTheCoverButton(FragmentActivity activity, String backendId) {
+        Fragment fragment = showBackupHandler(activity, backendId);
+        View coverActionButton = fragment.requireView().findViewById(R.id.cover_action_button);
+        assertNotNull(coverActionButton);
+        coverActionButton.performClick();
+    }
+
+    private Fragment showBackupHandler(FragmentActivity activity, String backendId) {
         Fragment fragment = BackupHandlerFragment.newInstance(backendId, true, true);
         activity.getSupportFragmentManager()
                 .beginTransaction()
                 .add(android.R.id.content, fragment, "BackupHandlerFragmentTest")
                 .commitNow();
-        View coverActionButton = fragment.requireView().findViewById(R.id.cover_action_button);
-        assertNotNull(coverActionButton);
-        coverActionButton.performClick();
+        return fragment;
+    }
+
+    private void assertCoverVisibility(String backendId, int expectedCover, int expectedPrimary) {
+        try (ActivityScenario<BackupListActivity> scenario = ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                Fragment fragment = showBackupHandler(activity, backendId);
+                View cover = fragment.requireView().findViewById(R.id.cover_layout);
+                View primary = fragment.requireView().findViewById(R.id.primary_layout);
+                assertEquals(expectedCover, cover.getVisibility());
+                assertEquals(expectedPrimary, primary.getVisibility());
+            });
+        }
     }
 }


### PR DESCRIPTION
Fixes #258.

External Memory could not be connected at all on Android 13 or newer. Tapping the button on its cover screen showed a permission warning, no system prompt ever appeared, and the cover screen stayed put.

The app was asking for the old permission to write to shared storage. Since Android 13 the system refuses that request outright for an app targeting 33 or higher, and refuses it without showing anything, so the answer was always no. The screen behind it was gated on holding that same permission, which is why it never cleared.

The permission is now declared only up to Android 12L, and from Android 13 the backend reports itself ready without it. On Android 12L and below nothing changes.

On an Android 16 emulator with the app holding no storage permission at all, the browser opens on Documents, creating a backup wrote a real file there, and restoring that backup worked.

From Android 13 the app lists only backups it created itself. A file that something else puts in Documents is not visible to it. Local folder goes through the system picker and is not affected.

Creating a backup at the top of external storage still fails, as it does on every version from Android 11 up. The browser opens inside Documents, which is writable.

Unit tests pin the new behavior on both sides of the Android 13 line, at Android 12L, at Android 13 itself and at Android 16.
