### PR TITLE
Let the amount keypad edit at a cursor

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -86,7 +86,9 @@
         <activity android:name=".ui.activity.CategoryPickerActivity" />
         <activity android:name=".ui.activity.CategorySortActivity" />
         <activity android:name=".ui.activity.IconListActivity" />
-        <activity android:name=".ui.activity.CalculatorActivity" />
+        <activity
+            android:name=".ui.activity.CalculatorActivity"
+            android:windowSoftInputMode="stateAlwaysHidden" />
         <activity android:name=".ui.activity.CurrencyConverterActivity" />
         <activity android:name=".ui.activity.AboutActivity" />
         <activity android:name=".ui.activity.SearchActivity" />

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/CalculatorActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/CalculatorActivity.java
@@ -21,11 +21,15 @@ package com.oriondev.moneywallet.ui.activity;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.text.InputFilter;
+import android.view.ActionMode;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.TextView;
+import android.widget.EditText;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
@@ -42,6 +46,8 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
     public static final String CURRENCY = "CalculatorActivity::Parameters::Currency";
     public static final String MONEY = "CalculatorActivity::Parameters::Money";
     public static final String ALLOW_NEGATIVE = "CalculatorActivity::Parameters::AllowNegative";
+
+    private static final String SS_CURSOR = "CalculatorActivity::SavedState::Cursor";
 
     public static final int MODE_CALCULATOR = 0;
     public static final int MODE_KEYPAD = 1;
@@ -66,17 +72,51 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
     private static final String OP_DIVISION = "D";
     private static final String OP_EXECUTE = "E";
 
-    private TextView mDisplayTextView;
+    private static final ActionMode.Callback NO_TEXT_ACTION_MODE = new ActionMode.Callback() {
+
+        @Override
+        public boolean onCreateActionMode(ActionMode mode, Menu menu) {
+            return false;
+        }
+
+        @Override
+        public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
+            return false;
+        }
+
+        @Override
+        public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
+            return false;
+        }
+
+        @Override
+        public void onDestroyActionMode(ActionMode mode) {
+        }
+    };
+
+    private EditText mDisplayEditText;
     private Button mActionButton;
     private EquationSolver mSolver;
 
     private boolean mKeypadMode;
     private boolean mAllowNegative;
+    private boolean mRendering;
 
     @Override
     protected void onCreatePanelView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.layout_panel_calculator, parent, true);
-        mDisplayTextView = view.findViewById(R.id.display_text_view);
+        mDisplayEditText = view.findViewById(R.id.display_text_view);
+        // The keypad is the only writer of the field, and the filter refuses every other change.
+        // The field's own state restore would go through that filter and come back empty, so the
+        // render from the solver is the only source of the text and the cursor is carried here.
+        mDisplayEditText.setShowSoftInputOnFocus(false);
+        mDisplayEditText.setFilters(new InputFilter[] {(source, start, end, dest, dstart, dend) ->
+                mRendering ? null : dest.subSequence(dstart, dend)});
+        mDisplayEditText.setSaveEnabled(false);
+        // The popup's cut and paste could not reach the field, so the popup goes.
+        mDisplayEditText.setCustomSelectionActionModeCallback(NO_TEXT_ACTION_MODE);
+        mDisplayEditText.setCustomInsertionActionModeCallback(NO_TEXT_ACTION_MODE);
+        mDisplayEditText.requestFocus();
         mActionButton = view.findViewById(R.id.keyboard_action_button);
         registerListener(view.findViewById(R.id.keyboard_000_button), OP_000);
         registerListener(view.findViewById(R.id.keyboard_0_button), OP_0);
@@ -98,6 +138,9 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
         registerListener(view.findViewById(R.id.keyboard_subtraction_button), OP_SUBTRACTION);
         registerListener(view.findViewById(R.id.keyboard_action_button), OP_EXECUTE);
         mSolver = new EquationSolver(savedInstanceState, this);
+        if (savedInstanceState != null) {
+            setCursor(savedInstanceState.getInt(SS_CURSOR, mDisplayEditText.length()));
+        }
     }
 
     @Override
@@ -136,7 +179,7 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
                 mSolver.clear();
                 break;
             case OP_CANCEL:
-                mSolver.cancel();
+                setCursor(mSolver.backspace(mDisplayEditText.getSelectionStart()));
                 break;
             case OP_EXECUTE:
                 execute();
@@ -154,18 +197,27 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
                 mSolver.appendOperation(EquationSolver.Operation.DIVISION);
                 break;
             case OP_POINT:
-                mSolver.appendPoint();
+                setCursor(mSolver.insertPoint(mDisplayEditText.getSelectionStart()));
                 break;
             default:
-                mSolver.appendNumber(operation);
+                setCursor(mSolver.insertNumber(operation, mDisplayEditText.getSelectionStart()));
                 break;
         }
+    }
+
+    /**
+     * The three editing keys render from inside the solver call, and that render puts the cursor
+     * at the end of the display, so this is what moves it back to where the edit landed.
+     */
+    private void setCursor(int cursor) {
+        mDisplayEditText.setSelection(Math.min(Math.max(cursor, 0), mDisplayEditText.length()));
     }
 
     @Override
     protected void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         mSolver.onSaveInstanceState(outState);
+        outState.putInt(SS_CURSOR, mDisplayEditText.getSelectionStart());
     }
 
     private void execute() {
@@ -195,7 +247,10 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
 
     @Override
     public void onUpdateDisplay(String text) {
-        mDisplayTextView.setText(text);
+        mRendering = true;
+        mDisplayEditText.setText(text);
+        mRendering = false;
+        mDisplayEditText.setSelection(text.length());
         updateActionButton();
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/EquationSolver.java
@@ -45,8 +45,10 @@ public class EquationSolver {
 
     @VisibleForTesting
     /*package-local*/ String mFirstNumber;
-    private String mSecondNumber;
-    private Operation mOperation;
+    @VisibleForTesting
+    /*package-local*/ String mSecondNumber;
+    @VisibleForTesting
+    /*package-local*/ Operation mOperation;
     @VisibleForTesting
     /*package-local*/ CurrencyUnit mCurrency;
     /**
@@ -112,22 +114,6 @@ public class EquationSolver {
         updateDisplaySafely();
     }
 
-    public void cancel() {
-        if (mSecondNumber != null && !mSecondNumber.isEmpty()) {
-            mSecondNumber = mSecondNumber.substring(0, mSecondNumber.length() - 1);
-        } else if (mOperation != null) {
-            mOperation = null;
-        } else if (mFirstNumber != null && !mFirstNumber.isEmpty()) {
-            String number = mFirstNumber.substring(0, mFirstNumber.length() - 1);
-            if (number.isEmpty()) {
-                number = "0";
-            }
-            clearComputedIfValueChanged(number);
-            mFirstNumber = number;
-        }
-        updateDisplaySafely();
-    }
-
     public void appendOperation(Operation operation) {
         if (mOperation == null || execute(false)) {
             mOperation = operation;
@@ -135,31 +121,113 @@ public class EquationSolver {
         }
     }
 
-    public void appendPoint() {
-        String number = mOperation == null ? mFirstNumber : mSecondNumber;
-        if (number == null || number.isEmpty() || number.equals("0")) {
-            number = "0.";
-        } else if (!number.contains(".")) {
-            number += ".";
+    /**
+     * The three editing keys act at a cursor, an index into the string updateDisplaySafely
+     * renders, and hand back where the cursor sits once the edit is in. An index up to the length
+     * of the first number addresses the first number; anything past that addresses the second one,
+     * with the three character operator span pointing at its start. An index outside the display
+     * means the end of the display.
+     */
+    private Target locate(int cursor) {
+        int first = firstLength();
+        if (mOperation == null) {
+            return new Target(true, cursor < 0 || cursor > first ? first : cursor);
         }
-        // No clearComputedIfValueChanged here: a point is the one key that cannot change the
-        // amount. Every string this method can build parses to the number already on the display.
-        mFirstNumber = mOperation == null ? number : mFirstNumber;
-        mSecondNumber = mOperation == null ? null : number;
-        updateDisplaySafely();
+        int second = mSecondNumber == null ? 0 : mSecondNumber.length();
+        int end = first + 3 + second;
+        int at = cursor < 0 || cursor > end ? end : cursor;
+        if (at <= first) {
+            return new Target(true, at);
+        }
+        return new Target(false, Math.max(at - first - 3, 0));
     }
 
-    public void appendNumber(String digit) {
-        String number = mOperation == null ? mFirstNumber : mSecondNumber;
+    private int firstLength() {
+        return mFirstNumber == null ? 0 : mFirstNumber.length();
+    }
+
+    private int cursorOf(Target target, int offset) {
+        return target.mFirst ? offset : firstLength() + 3 + offset;
+    }
+
+    private void store(Target target, String number) {
+        if (target.mFirst) {
+            clearComputedIfValueChanged(number);
+            mFirstNumber = number;
+        } else {
+            mSecondNumber = number;
+        }
+    }
+
+    public int insertPoint(int cursor) {
+        Target target = locate(cursor);
+        String number = target.mFirst ? mFirstNumber : mSecondNumber;
+        int offset = target.mOffset;
+        if (number == null || number.isEmpty() || number.equals("0")) {
+            number = "0.";
+            offset = 2;
+        } else if (!number.contains(".")) {
+            int sign = number.startsWith("-") ? 1 : 0;
+            if (offset <= sign) {
+                // A point typed in front of the digits opens a fraction instead of splitting one.
+                number = number.substring(0, sign) + "0." + number.substring(sign);
+                offset = sign + 2;
+            } else {
+                number = number.substring(0, offset) + "." + number.substring(offset);
+                offset++;
+            }
+        }
+        store(target, number);
+        updateDisplaySafely();
+        return cursorOf(target, offset);
+    }
+
+    public int insertNumber(String digit, int cursor) {
+        Target target = locate(cursor);
+        String number = target.mFirst ? mFirstNumber : mSecondNumber;
+        int offset = target.mOffset;
         if (number == null || number.isEmpty() || number.equals("0")) {
             number = digit.equals("000") ? "0" : digit;
+            offset = number.length();
         } else {
-            number += digit;
+            if (number.startsWith("-") && offset == 0) {
+                // A digit typed in front of a sign belongs after it.
+                offset = 1;
+            }
+            number = number.substring(0, offset) + digit + number.substring(offset);
+            offset += digit.length();
         }
-        clearComputedIfValueChanged(number);
-        mFirstNumber = mOperation == null ? number : mFirstNumber;
-        mSecondNumber = mOperation == null ? null : number;
+        store(target, number);
         updateDisplaySafely();
+        return cursorOf(target, offset);
+    }
+
+    public int backspace(int cursor) {
+        Target target = locate(cursor);
+        String number = target.mFirst ? mFirstNumber : mSecondNumber;
+        int offset = target.mOffset;
+        boolean atOperator = false;
+        if (offset == 0) {
+            if (!target.mFirst && (number == null || number.isEmpty())) {
+                // Nothing left of the second number to delete, so the operator goes instead.
+                mOperation = null;
+                mSecondNumber = null;
+                atOperator = true;
+            } else if (!target.mFirst) {
+                // Nothing to delete here, so the cursor steps back over the operator instead.
+                atOperator = true;
+            }
+        } else {
+            number = number.substring(0, offset - 1) + number.substring(offset);
+            offset--;
+            if (target.mFirst && number.isEmpty()) {
+                number = "0";
+                offset = 1;
+            }
+            store(target, number);
+        }
+        updateDisplaySafely();
+        return atOperator ? firstLength() : cursorOf(target, offset);
     }
 
     public boolean isPendingOperation() {
@@ -249,7 +317,7 @@ public class EquationSolver {
      * changes nothing does not retype what is there.
      */
     private void clearComputedIfValueChanged(String number) {
-        if (mOperation == null && parseNumber(number).compareTo(parseNumber(mFirstNumber)) != 0) {
+        if (parseNumber(number).compareTo(parseNumber(mFirstNumber)) != 0) {
             mComputed = false;
         }
     }
@@ -263,6 +331,17 @@ public class EquationSolver {
             return new BigDecimal(safe);
         } catch (NumberFormatException ignore) {}
         return BigDecimal.valueOf(0);
+    }
+
+    private static class Target {
+
+        private final boolean mFirst;
+        private final int mOffset;
+
+        private Target(boolean first, int offset) {
+            mFirst = first;
+            mOffset = offset;
+        }
     }
 
     public enum Operation {

--- a/app/src/main/res/layout/layout_panel_calculator.xml
+++ b/app/src/main/res/layout/layout_panel_calculator.xml
@@ -32,18 +32,21 @@
         android:orientation="horizontal"
         app:layout_constraintGuide_percent="0.40"/>
 
-    <com.oriondev.moneywallet.ui.view.theme.ThemedTextView
+    <com.oriondev.moneywallet.ui.view.theme.ThemedEditText
         android:id="@+id/display_text_view"
         android:layout_width="0dp"
         android:layout_height="0dp"
+        android:background="@null"
         android:gravity="center_vertical|end"
+        android:hint="@string/hint_money"
+        android:importantForAutofill="no"
         android:textSize="@dimen/activity_calculator_display_text_size"
         android:padding="@dimen/activity_calculator_display_padding"
         app:layout_constraintBottom_toTopOf="@+id/vertical_guideline"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:theme_textColor="textColorPrimary"
+        app:theme_backgroundColor="colorWindowForeground"
         tools:text="568,89 * 3,56" />
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/utils/EquationSolverTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -29,6 +30,12 @@ public class EquationSolverTest {
 
     @InjectMocks
     private EquationSolver equationSolver;
+
+    /**
+     * A cursor outside the display, which every editing key reads as the end of the display: the
+     * position the keypad edited at before it grew a cursor.
+     */
+    private static final int END = -1;
 
     private void mockCurrencyUnit(int decimals) {
         equationSolver.mCurrency = new CurrencyUnit("", "", "", decimals);
@@ -320,9 +327,9 @@ public class EquationSolverTest {
     private void type(String keys) {
         for (char key : keys.toCharArray()) {
             if (key == '.') {
-                equationSolver.appendPoint();
+                equationSolver.insertPoint(END);
             } else {
-                equationSolver.appendNumber(String.valueOf(key));
+                equationSolver.insertNumber(String.valueOf(key), END);
             }
         }
     }
@@ -498,7 +505,7 @@ public class EquationSolverTest {
         enter("20", EquationSolver.Operation.DIVISION, "3");
         assertTrue(equationSolver.execute(false));
 
-        equationSolver.appendNumber("0");
+        equationSolver.insertNumber("0", END);
 
         assertEquals("6.6666666666666670", equationSolver.mFirstNumber);
         assertEquals(667L, equationSolver.getResult());
@@ -514,8 +521,8 @@ public class EquationSolverTest {
         enter("20", EquationSolver.Operation.DIVISION, "3");
         assertTrue(equationSolver.execute(false));
 
-        equationSolver.appendNumber("5");
-        equationSolver.cancel();
+        equationSolver.insertNumber("5", END);
+        equationSolver.backspace(END);
 
         assertEquals("6.666666666666667", equationSolver.mFirstNumber);
         assertEquals(666L, equationSolver.getResult());
@@ -532,7 +539,7 @@ public class EquationSolverTest {
         assertEquals("7.5", equationSolver.mFirstNumber);
 
         for (int press = 0; press < 5; press++) {
-            equationSolver.cancel();
+            equationSolver.backspace(END);
         }
         type("7.5");
 
@@ -545,10 +552,10 @@ public class EquationSolverTest {
         enter("15", EquationSolver.Operation.DIVISION, "2");
         assertTrue(equationSolver.execute(false));
 
-        equationSolver.cancel();
-        equationSolver.cancel();
-        equationSolver.appendPoint();
-        equationSolver.appendNumber("5");
+        equationSolver.backspace(END);
+        equationSolver.backspace(END);
+        equationSolver.insertPoint(END);
+        equationSolver.insertNumber("5", END);
 
         assertEquals("7.5", equationSolver.mFirstNumber);
         assertEquals(7L, equationSolver.getResult());
@@ -560,7 +567,7 @@ public class EquationSolverTest {
         enter("20", EquationSolver.Operation.DIVISION, "3");
         assertTrue(equationSolver.execute(false));
 
-        equationSolver.appendNumber("5");
+        equationSolver.insertNumber("5", END);
 
         assertEquals(666L, equationSolver.getResult());
     }
@@ -571,7 +578,7 @@ public class EquationSolverTest {
         enter("20", EquationSolver.Operation.DIVISION, "3");
         assertTrue(equationSolver.execute(false));
 
-        equationSolver.cancel();
+        equationSolver.backspace(END);
 
         assertEquals(666L, equationSolver.getResult());
     }
@@ -585,7 +592,7 @@ public class EquationSolverTest {
         assertTrue(equationSolver.execute(false));
         assertEquals("0.66700", equationSolver.mFirstNumber);
 
-        equationSolver.cancel();
+        equationSolver.backspace(END);
 
         assertEquals("0.6670", equationSolver.mFirstNumber);
         assertEquals(67L, equationSolver.getResult());
@@ -612,7 +619,7 @@ public class EquationSolverTest {
         mockCurrencyUnit(2);
         type("0.999");
         equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
-        equationSolver.appendPoint();
+        equationSolver.insertPoint(END);
         assertEquals(99L, equationSolver.getResult());
     }
 
@@ -622,7 +629,7 @@ public class EquationSolverTest {
         type("0.999");
         equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
         type("5");
-        equationSolver.cancel();
+        equationSolver.backspace(END);
 
         assertEquals(99L, equationSolver.getResult());
     }
@@ -637,7 +644,7 @@ public class EquationSolverTest {
         assertTrue(equationSolver.execute(false));
         equationSolver.appendOperation(EquationSolver.Operation.ADDITION);
         type("1");
-        equationSolver.cancel();
+        equationSolver.backspace(END);
 
         assertEquals(667L, equationSolver.getResult());
     }
@@ -887,9 +894,261 @@ public class EquationSolverTest {
 
         assertEquals("0", equationSolver.mFirstNumber);
 
-        equationSolver.appendNumber("5");
+        equationSolver.insertNumber("5", END);
 
         assertEquals("5", equationSolver.mFirstNumber);
         assertEquals(500L, equationSolver.getResult());
+    }
+
+    // Editing at a cursor
+
+    @Test
+    public void testInsertNumber_insertsAtTheCursorInsideTheFirstNumber() {
+        equationSolver.mFirstNumber = "12";
+
+        assertEquals(2, equationSolver.insertNumber("5", 1));
+        assertEquals("152", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertNumber_replacesABareZero() {
+        equationSolver.mFirstNumber = "0";
+
+        assertEquals(1, equationSolver.insertNumber("5", 0));
+        assertEquals("5", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertNumber_snapsPastTheSign() {
+        equationSolver.mFirstNumber = "-12";
+
+        assertEquals(2, equationSolver.insertNumber("5", 0));
+        assertEquals("-512", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertNumber_aCursorOutsideTheDisplayMeansItsEnd() {
+        equationSolver.mFirstNumber = "12";
+
+        assertEquals(3, equationSolver.insertNumber("5", END));
+        assertEquals("125", equationSolver.mFirstNumber);
+
+        equationSolver.mFirstNumber = "12";
+
+        assertEquals(3, equationSolver.insertNumber("5", 99));
+        assertEquals("125", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertNumber_editsTheFirstNumberWhileAnOperationIsPending() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mOperation = EquationSolver.Operation.ADDITION;
+        equationSolver.mSecondNumber = "34";
+
+        assertEquals(2, equationSolver.insertNumber("5", 1));
+        assertEquals("152", equationSolver.mFirstNumber);
+        assertEquals("34", equationSolver.mSecondNumber);
+    }
+
+    @Test
+    public void testInsertNumber_insertsAtTheCursorInsideTheSecondNumber() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mOperation = EquationSolver.Operation.ADDITION;
+        equationSolver.mSecondNumber = "34";
+
+        assertEquals(8, equationSolver.insertNumber("5", 7));
+        assertEquals("345", equationSolver.mSecondNumber);
+    }
+
+    @Test
+    public void testInsertNumber_aCursorInTheOperatorSpanMeansTheStartOfTheSecondNumber() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mOperation = EquationSolver.Operation.ADDITION;
+        equationSolver.mSecondNumber = "34";
+
+        assertEquals(6, equationSolver.insertNumber("5", 3));
+        assertEquals("534", equationSolver.mSecondNumber);
+    }
+
+    @Test
+    public void testInsertNumber_startsASecondNumberNobodyTyped() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mOperation = EquationSolver.Operation.ADDITION;
+        equationSolver.mSecondNumber = null;
+
+        assertEquals(6, equationSolver.insertNumber("5", 4));
+        assertEquals("5", equationSolver.mSecondNumber);
+    }
+
+    @Test
+    public void testInsertPoint_atTheFrontOpensAFraction() {
+        equationSolver.mFirstNumber = "12";
+
+        assertEquals(2, equationSolver.insertPoint(0));
+        assertEquals("0.12", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertPoint_splitsTheNumberAtTheCursor() {
+        equationSolver.mFirstNumber = "12";
+
+        assertEquals(2, equationSolver.insertPoint(1));
+        assertEquals("1.2", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertPoint_leavesANumberThatAlreadyHasOneAlone() {
+        equationSolver.mFirstNumber = "1.2";
+
+        assertEquals(3, equationSolver.insertPoint(3));
+        assertEquals("1.2", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertPoint_onABareZero() {
+        equationSolver.mFirstNumber = "0";
+
+        assertEquals(2, equationSolver.insertPoint(0));
+        assertEquals("0.", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertPoint_atTheFrontOfASignedNumberOpensAFractionAfterTheSign() {
+        equationSolver.mFirstNumber = "-12";
+
+        assertEquals(3, equationSolver.insertPoint(1));
+        assertEquals("-0.12", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testBackspace_removesTheCharacterBeforeTheCursor() {
+        equationSolver.mFirstNumber = "152";
+
+        assertEquals(1, equationSolver.backspace(2));
+        assertEquals("12", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testBackspace_atTheFrontOfTheFirstNumberDoesNothing() {
+        equationSolver.mFirstNumber = "152";
+
+        assertEquals(0, equationSolver.backspace(0));
+        assertEquals("152", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testBackspace_aFirstNumberEmptiedBecomesZero() {
+        equationSolver.mFirstNumber = "5";
+
+        assertEquals(1, equationSolver.backspace(1));
+        assertEquals("0", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testBackspace_atTheFrontOfASecondNumberNobodyTypedDropsTheOperation() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mOperation = EquationSolver.Operation.ADDITION;
+        equationSolver.mSecondNumber = null;
+
+        assertEquals(2, equationSolver.backspace(5));
+        assertNull(equationSolver.mOperation);
+        assertNull(equationSolver.mSecondNumber);
+        assertEquals("12", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testBackspace_atTheFrontOfATypedSecondNumberStepsBackOverTheOperator() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mOperation = EquationSolver.Operation.ADDITION;
+        equationSolver.mSecondNumber = "34";
+
+        assertEquals(2, equationSolver.backspace(5));
+        assertEquals("12", equationSolver.mFirstNumber);
+        assertEquals("34", equationSolver.mSecondNumber);
+        assertEquals(EquationSolver.Operation.ADDITION, equationSolver.mOperation);
+
+        assertEquals(2, equationSolver.backspace(4));
+        assertEquals("12", equationSolver.mFirstNumber);
+        assertEquals("34", equationSolver.mSecondNumber);
+        assertEquals(EquationSolver.Operation.ADDITION, equationSolver.mOperation);
+    }
+
+    @Test
+    public void testBackspace_removesFromTheSecondNumber() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mOperation = EquationSolver.Operation.ADDITION;
+        equationSolver.mSecondNumber = "34";
+
+        assertEquals(6, equationSolver.backspace(7));
+        assertEquals("3", equationSolver.mSecondNumber);
+    }
+
+    @Test
+    public void testInsertNumber_anInsertThatChangesTheAmountRetypesIt() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mComputed = true;
+
+        equationSolver.insertNumber("5", 1);
+
+        assertFalse(equationSolver.mComputed);
+    }
+
+    @Test
+    public void testInsertNumber_anInsertThatDoesNotChangeTheAmountLeavesAnAnswerAnAnswer() {
+        equationSolver.mFirstNumber = "12.5";
+        equationSolver.mComputed = true;
+
+        equationSolver.insertNumber("0", END);
+
+        assertTrue(equationSolver.mComputed);
+        assertEquals("12.50", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertNumber_insertsEveryDigitOfTheTripleZeroKeyAtTheCursor() {
+        equationSolver.mFirstNumber = "12";
+
+        assertEquals(4, equationSolver.insertNumber("000", 1));
+        assertEquals("10002", equationSolver.mFirstNumber);
+    }
+
+    @Test
+    public void testInsertNumber_anEditOfTheFirstNumberWhileAnOperationIsPendingRetypesIt() {
+        mockCurrencyUnit(2);
+        equationSolver.mFirstNumber = "6.666666666666667";
+        equationSolver.mComputed = true;
+        equationSolver.mOperation = EquationSolver.Operation.ADDITION;
+        equationSolver.mSecondNumber = null;
+
+        assertEquals(1, equationSolver.insertNumber("9", 0));
+        assertEquals("96.666666666666667", equationSolver.mFirstNumber);
+        assertFalse(equationSolver.mComputed);
+
+        equationSolver.backspace(END);
+
+        assertNull(equationSolver.mOperation);
+        assertEquals(9666L, equationSolver.getResult());
+    }
+
+    @Test
+    public void testInsertPoint_aPointThatChangesTheAmountRetypesIt() {
+        equationSolver.mFirstNumber = "1235";
+        equationSolver.mComputed = true;
+
+        equationSolver.insertPoint(1);
+
+        assertEquals("1.235", equationSolver.mFirstNumber);
+        assertFalse(equationSolver.mComputed);
+    }
+
+    @Test
+    public void testInsertPoint_aPointThatDoesNotChangeTheAmountLeavesAnAnswerAnAnswer() {
+        equationSolver.mFirstNumber = "12";
+        equationSolver.mComputed = true;
+
+        equationSolver.insertPoint(END);
+
+        assertEquals("12.", equationSolver.mFirstNumber);
+        assertTrue(equationSolver.mComputed);
     }
 }


### PR DESCRIPTION
Closes #235.

The amount on the keypad screen was drawn as plain text, so there was nothing to put a cursor in. The only way to change an amount was to backspace it from the end or clear it and start over.

The amount is now an editable field. Tapping it places a cursor, and the keypad's digits, point and backspace act at that cursor. The system keyboard never opens, and nothing but the keypad can write to the field, so a hardware keyboard or a paste is refused. The operator keys, equals and C work as before and put the cursor at the end. A rotation, or a return to the screen after the app was killed, brings the amount back with the cursor where it was.

Typing in front of a minus sign lands after it, a point typed in front of the digits opens a fraction, and backspace in front of a typed second number steps back over the operator instead of doing nothing.

Two things this fixes on the way. Editing the first number while an operation was pending, or typing a point into a calculated answer, kept the answer flag set, so the stored amount was rounded where a typed one is truncated, one cent off. Both now count as retyping the amount.

Tested on the emulator through the real transaction screen, including a kill of the app with the keypad open, and 25 new unit cases.
