### PR TITLE
Stop a removed wallet from hiding a budget's transfers

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
+++ b/app/src/main/java/com/oriondev/moneywallet/storage/database/SQLDatabase.java
@@ -3045,6 +3045,7 @@ import java.util.function.Supplier;
                 "LEFT JOIN " + Schema.BudgetWallet.TABLE + " AS bw2 " +
                 "ON t2." + Schema.Transaction.WALLET + " = bw2." + Schema.BudgetWallet.WALLET + " " +
                 "WHERE bw2." + Schema.BudgetWallet.BUDGET + " = b." + Schema.Budget.ID + " " +
+                "AND bw2." + Schema.BudgetWallet.DELETED + " = 0 " +
                 "AND bw2." + Schema.BudgetWallet.WALLET + " != b._wallet_id " +
                 ") " +
                 "GROUP BY b." + Schema.Budget.ID + ",b._wallet_id " +
@@ -3075,6 +3076,7 @@ import java.util.function.Supplier;
                 "LEFT JOIN " + Schema.BudgetWallet.TABLE + " AS bw2 " +
                 "ON t2." + Schema.Transaction.WALLET + " = bw2." + Schema.BudgetWallet.WALLET + " " +
                 "WHERE bw2." + Schema.BudgetWallet.BUDGET + " = b." + Schema.Budget.ID + " " +
+                "AND bw2." + Schema.BudgetWallet.DELETED + " = 0 " +
                 "AND bw2." + Schema.BudgetWallet.WALLET + " != b._wallet_id " +
                 ") " +
 
@@ -3244,6 +3246,7 @@ import java.util.function.Supplier;
                 "LEFT JOIN " + Schema.BudgetWallet.TABLE + " AS bw2 " +
                 "ON t2." + Schema.Transaction.WALLET + " = bw2." + Schema.BudgetWallet.WALLET + " " +
                 "WHERE bw2." + Schema.BudgetWallet.BUDGET + " = b." + Schema.Budget.ID + " " +
+                "AND bw2." + Schema.BudgetWallet.DELETED + " = 0 " +
                 ") " +
                 "UNION " +
 
@@ -3272,6 +3275,7 @@ import java.util.function.Supplier;
                 "LEFT JOIN " + Schema.BudgetWallet.TABLE + " AS bw2 " +
                 "ON t2." + Schema.Transaction.WALLET + " = bw2." + Schema.BudgetWallet.WALLET + " " +
                 "WHERE bw2." + Schema.BudgetWallet.BUDGET + " = b." + Schema.Budget.ID + " " +
+                "AND bw2." + Schema.BudgetWallet.DELETED + " = 0 " +
                 ") " +
                 "UNION " +
 

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivityTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/NewEditBudgetActivityTest.java
@@ -246,6 +246,50 @@ public class NewEditBudgetActivityTest {
     }
 
     @Test
+    public void anIncomeBudgetEditedOffTheWalletThatPaysCountsTheTransferAgain() {
+        long budget = insertBudget(Contract.BudgetType.INCOMES, 700000L, "EUR",
+                new long[] {mWalletA, mWalletB}, null, APRIL_START, APRIL_END, null, null, null);
+        // the one Salary income in wallet A. The leg the transfer pays into wallet B is left out
+        // while wallet A, the wallet it comes from, is in the budget too
+        assertEquals(4000000L, progressOf(budget));
+        assertEquals(4000000L, listedMoneyOf(budget));
+        try (ActivityScenario<NewEditBudgetActivity> scenario =
+                     ActivityScenario.launch(editIntent(budget))) {
+            scenario.onActivity(activity -> {
+                walletsPicker(activity).onWalletsSelected(new Wallet[] {
+                        wallet(mWalletB, "Bank", "EUR")});
+                save(activity);
+                assertTrue(activity.isFinishing());
+            });
+        }
+        assertEquals(Collections.singletonList(mWalletB), walletIdsOf(budget));
+        // the edit takes wallet A out of the budget, so the leg the transfer pays into wallet B
+        // counts, and it is the only income wallet B holds in April
+        assertEquals(4000000000000000L, progressOf(budget));
+        assertEquals(4000000000000000L, listedMoneyOf(budget));
+    }
+
+    @Test
+    public void anExpensesBudgetEditedOffTheWalletThatReceivesCountsTheTransferAgain() {
+        long budget = insertBudget(Contract.BudgetType.EXPENSES, 900000L, "EUR",
+                new long[] {mWalletA, mWalletB}, null, APRIL_START, APRIL_END, null, null, null);
+        assertEquals(aprilExpensesProgress(), progressOf(budget));
+        assertEquals(aprilExpensesProgress(), listedMoneyOf(budget));
+        try (ActivityScenario<NewEditBudgetActivity> scenario =
+                     ActivityScenario.launch(editIntent(budget))) {
+            scenario.onActivity(activity -> {
+                walletsPicker(activity).onWalletsSelected(new Wallet[] {
+                        wallet(mWalletA, "Cash", "EUR")});
+                save(activity);
+                assertTrue(activity.isFinishing());
+            });
+        }
+        assertEquals(Collections.singletonList(mWalletA), walletIdsOf(budget));
+        assertEquals(aprilExpensesInWalletAWithTheTransfer(), progressOf(budget));
+        assertEquals(aprilExpensesInWalletAWithTheTransfer(), listedMoneyOf(budget));
+    }
+
+    @Test
     public void aNewBudgetOnAYenWalletSavesInYen() {
         PreferenceManager.setCurrentWallet(mContext, mWalletD);
         int before = countBudgets();
@@ -1482,6 +1526,14 @@ public class NewEditBudgetActivityTest {
         return 1000L + 20000L + 300000L + 50000000L + 7000000000L + 300000000000000L;
     }
 
+    /**
+     * The April expenses of wallet A alone, where the leg the transfer pays out of it counts
+     * because wallet B is no longer in the budget, and the wallet B row of 9 April is gone.
+     */
+    private static long aprilExpensesInWalletAWithTheTransfer() {
+        return 1000L + 20000L + 300000L + 7000000000L + 300000000000000L + 4000000000000000L;
+    }
+
     // fixtures
 
     private void cancelRollAlarm() {
@@ -1870,6 +1922,23 @@ public class NewEditBudgetActivityTest {
         long progress = cursor.getLong(cursor.getColumnIndex(Contract.Budget.PROGRESS));
         cursor.close();
         return progress;
+    }
+
+    /**
+     * The money on every transaction the budget's own list carries, added up.
+     */
+    private long listedMoneyOf(long budgetId) {
+        Uri uri = Uri.withAppendedPath(
+                ContentUris.withAppendedId(DataContentProvider.CONTENT_BUDGETS, budgetId),
+                "transactions");
+        Cursor cursor = mResolver.query(uri, new String[] {Contract.Transaction.MONEY},
+                null, null, null);
+        long total = 0L;
+        while (cursor.moveToNext()) {
+            total += cursor.getLong(0);
+        }
+        cursor.close();
+        return total;
     }
 
     private void assertRepeatingRow(long budgetId, String startDate, String endDate, String rule,


### PR DESCRIPTION
A budget ignores money you move between two of its own wallets, which is right, since that money never left the budget.

When you take a wallet back out of a budget, the app keeps a record of the old link and only marks it as no longer in use. The part that ignores internal transfers never checks that mark, so it still counts the removed wallet as part of the budget. A transfer into that wallet stays invisible to the budget from then on, and nothing short of building the budget again brings it back.

The wrong figure shows up in two places, the progress on the budgets list and the list of transactions a budget shows you, and this has been the case since 2020.

Fixes #261.

**What I tested:** an emulator carrying a ledger of 464 transactions, and an August budget covering a checking account and a credit card with a payment of 1077.35 moved between them. With the credit card taken out of that budget, the old build showed 3961.80 and this one shows 5039.15, and the payment now appears in the budget's transaction list on the right date. Budgets that never had a wallet removed show the same figure as before. Two new tests cover a spending budget and an earning budget, and the whole unit suite passes.
