### PR TITLE
Bring the Overview and the period screens up to date after an edit

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/background/AbstractGenericLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/AbstractGenericLoader.java
@@ -20,6 +20,7 @@
 package com.oriondev.moneywallet.background;
 
 import android.content.Context;
+import android.net.Uri;
 import androidx.loader.content.AsyncTaskLoader;
 
 /**
@@ -27,6 +28,7 @@ import androidx.loader.content.AsyncTaskLoader;
  */
 public abstract class AbstractGenericLoader<T> extends AsyncTaskLoader<T> {
 
+    private ForceLoadContentObserver mObserver;
     private T mGenericData;
 
     public AbstractGenericLoader(Context context) {
@@ -35,6 +37,15 @@ public abstract class AbstractGenericLoader<T> extends AsyncTaskLoader<T> {
 
     @Override
     public abstract T loadInBackground();
+
+    /**
+     * The uri to watch for writes, or null for a loader whose data cannot change while the app
+     * runs. Without one nothing ever marks the content changed, so the reload below can never
+     * happen and the screen keeps whatever it read the first time.
+     */
+    protected Uri getObservedUri() {
+        return null;
+    }
 
     /* Runs on the UI thread */
     @Override
@@ -54,10 +65,26 @@ public abstract class AbstractGenericLoader<T> extends AsyncTaskLoader<T> {
      */
     @Override
     protected void onStartLoading() {
-        if (mGenericData != null) {
+        Uri observed = getObservedUri();
+        if (observed != null && mObserver == null) {
+            // built here and not in a field, because the observer binds a Handler to the thread
+            // that builds it and a loader is only ever started on the main one. The loaders that
+            // watch nothing then build nothing.
+            mObserver = new ForceLoadContentObserver();
+            // descendants, because no write names the uri above and an observer that did not ask
+            // for them would never hear one
+            getContext().getContentResolver().registerContentObserver(observed, true, mObserver);
+        }
+        // takeContentChanged clears the flag, so it is read once. The cached result goes out only
+        // when nothing is about to replace it, otherwise a screen coming back to a write that
+        // landed while it was away shows the old figures and then the new ones a moment later. A
+        // write that lands while the screen is showing forces a load through the observer instead,
+        // and the two orders race, so that case can still show both.
+        boolean reload = takeContentChanged() || mGenericData == null;
+        if (mGenericData != null && !reload) {
             deliverResult(mGenericData);
         }
-        if (takeContentChanged() || mGenericData == null) {
+        if (reload) {
             forceLoad();
         }
     }
@@ -71,11 +98,33 @@ public abstract class AbstractGenericLoader<T> extends AsyncTaskLoader<T> {
         cancelLoad();
     }
 
+    /**
+     * These screens ask for a fresh loader every time their view is created, and that hands the
+     * old one to the new one to reset once it has delivered. A replacement that never delivers,
+     * because the screen was left or built again first, takes its predecessor down with it and
+     * nothing resets it, so an unregister that lived in onReset alone would leave a watcher
+     * behind for the life of the process. An abandoned loader's result is thrown away, so it has
+     * no use for one either way.
+     */
+    @Override
+    protected void onAbandon() {
+        super.onAbandon();
+        stopWatching();
+    }
+
     @Override
     protected void onReset() {
         super.onReset();
         // Ensure the loader is stopped
         onStopLoading();
+        stopWatching();
         mGenericData = null;
+    }
+
+    private void stopWatching() {
+        if (mObserver != null) {
+            getContext().getContentResolver().unregisterContentObserver(mObserver);
+            mObserver = null;
+        }
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/background/OverviewDataLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/OverviewDataLoader.java
@@ -75,6 +75,11 @@ public class OverviewDataLoader extends AbstractGenericLoader<OverviewData> {
     }
 
     @Override
+    protected Uri getObservedUri() {
+        return DataContentProvider.CONTENT_ALL;
+    }
+
+    @Override
     public OverviewData loadInBackground() {
         Money totalNetIncomes = new Money();
         List<PeriodMoney> periodMoneyList = new ArrayList<>();

--- a/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailFlowLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailFlowLoader.java
@@ -63,6 +63,11 @@ public class PeriodDetailFlowLoader extends AbstractGenericLoader<PeriodDetailFl
         mIncomes = incomes;
     }
 
+    @Override
+    protected Uri getObservedUri() {
+        return DataContentProvider.CONTENT_ALL;
+    }
+
     @Override @SuppressLint("UseSparseArrays")
     public PeriodDetailFlowData loadInBackground() {
         Money totalMoney = new Money();

--- a/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailSummaryLoader.java
+++ b/app/src/main/java/com/oriondev/moneywallet/background/PeriodDetailSummaryLoader.java
@@ -67,6 +67,11 @@ public class PeriodDetailSummaryLoader extends AbstractGenericLoader<PeriodDetai
     }
 
     @Override
+    protected Uri getObservedUri() {
+        return DataContentProvider.CONTENT_ALL;
+    }
+
+    @Override
     public PeriodDetailSummaryData loadInBackground() {
         Money totalNetIncomes = new Money();
         List<PeriodMoney> periodMoneyList = new ArrayList<>();

--- a/app/src/test/java/com/oriondev/moneywallet/background/AbstractGenericLoaderTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/background/AbstractGenericLoaderTest.java
@@ -1,0 +1,240 @@
+package com.oriondev.moneywallet.background;
+
+import android.content.Context;
+import android.database.ContentObserver;
+import android.net.Uri;
+import android.os.Looper;
+
+import androidx.loader.content.Loader;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.oriondev.moneywallet.model.Group;
+import com.oriondev.moneywallet.model.OverviewSetting;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * The screens behind these loaders are reached from a drawer entry and left for a child activity,
+ * which does not rebuild the fragment, so nothing restarts the loader on the way back. What brings
+ * a change home is a write on the watched uri, and until one arrives the result already in hand is
+ * the right thing to hand back. Both halves are pinned here, because a loader that hears nothing
+ * keeps its first answer for as long as the screen lives, and one that hands back an old answer
+ * with a load already running shows a screen coming back the old figures and then the new ones a
+ * moment later.
+ *
+ * What each case reads is what reached a listener, which is what a fragment gets, and not merely
+ * that a method was entered. The loading itself is stubbed out, so nothing here covers what a
+ * real load does on its way back, only which branch the loader takes.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class AbstractGenericLoaderTest {
+
+    private Context mContext;
+    private List<String> mReceived;
+
+    @Before
+    public void setUp() {
+        mContext = ApplicationProvider.getApplicationContext();
+        mReceived = new ArrayList<>();
+    }
+
+    @Test
+    public void aFirstStartLoadsAndHandsBackNothing() {
+        CountingLoader loader = watching(DataContentProvider.CONTENT_ALL);
+        loader.startLoading();
+        assertEquals(1, loader.mLoads);
+        assertEquals(Collections.emptyList(), mReceived);
+    }
+
+    @Test
+    public void aStartWithNothingWrittenSinceHandsBackWhatItHasAndDoesNotLoadAgain() {
+        CountingLoader loader = watching(DataContentProvider.CONTENT_ALL);
+        loader.startLoading();
+        loader.deliverResult("first");
+        loader.stopLoading();
+        loader.startLoading();
+        assertEquals(1, loader.mLoads);
+        // the one the load itself handed over, then the same one again on the way back
+        assertEquals(Arrays.asList("first", "first"), mReceived);
+    }
+
+    @Test
+    public void aWriteWhileTheScreenIsAwayLoadsAgainAndSkipsTheOldAnswer() {
+        CountingLoader loader = watching(DataContentProvider.CONTENT_ALL);
+        loader.startLoading();
+        loader.deliverResult("first");
+        loader.stopLoading();
+        loader.onContentChanged();
+        loader.startLoading();
+        assertEquals(2, loader.mLoads);
+        // still only the one the load handed over, since the old answer is on its way out
+        assertEquals(Collections.singletonList("first"), mReceived);
+    }
+
+    /**
+     * The whole point of the change, end to end. No write in this app names the uri the loaders
+     * watch, they all name a table or a row under it, so this fails if the registration ever stops
+     * asking for descendants or the watcher stops being one that forces a load.
+     */
+    @Test
+    public void aWriteOnTheProviderReachesALoaderWhoseScreenIsAway() {
+        CountingLoader loader = watching(DataContentProvider.CONTENT_ALL);
+        loader.startLoading();
+        loader.deliverResult("first");
+        loader.stopLoading();
+        mContext.getContentResolver().notifyChange(DataContentProvider.CONTENT_TRANSACTIONS, null);
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+        loader.startLoading();
+        assertEquals(2, loader.mLoads);
+        assertEquals(Collections.singletonList("first"), mReceived);
+    }
+
+    @Test
+    public void aLoaderWatchesItsUriWhileItLivesAndLetsItGoOnReset() {
+        Uri uri = DataContentProvider.CONTENT_ALL;
+        // the app puts a watcher of its own on this uri when it starts, so what this reads is the
+        // one the loader adds and not the total
+        int before = watchersOf(uri).size();
+        CountingLoader loader = watching(uri);
+        loader.startLoading();
+        assertEquals(before + 1, watchersOf(uri).size());
+        loader.stopLoading();
+        // a stopped loader keeps watching, which is how a write reaches it while the screen is away
+        assertEquals(before + 1, watchersOf(uri).size());
+        loader.startLoading();
+        assertEquals(before + 1, watchersOf(uri).size());
+        loader.reset();
+        assertEquals(before, watchersOf(uri).size());
+    }
+
+    /**
+     * Asking for a fresh loader hands the old one to the new one to reset once it has delivered,
+     * and a replacement that never delivers takes its predecessor down with it unreset. These
+     * screens ask on every view creation, so that is reachable and the watcher would otherwise
+     * outlive the screen.
+     */
+    @Test
+    public void anAbandonedLoaderLetsItsUriGoWithoutWaitingForAReset() {
+        Uri uri = DataContentProvider.CONTENT_ALL;
+        int before = watchersOf(uri).size();
+        CountingLoader loader = watching(uri);
+        loader.startLoading();
+        loader.deliverResult("first");
+        assertEquals(before + 1, watchersOf(uri).size());
+        loader.abandon();
+        assertEquals(before, watchersOf(uri).size());
+    }
+
+    /**
+     * The watcher binds a handler to whatever thread builds it, and one instrumented case builds a
+     * loader off the main one, so building it with the loader would throw there and nowhere here.
+     */
+    @Test
+    public void aLoaderCanBeBuiltOnAThreadWithNoLooper() throws Exception {
+        final AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread thread = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                try {
+                    new CountingLoader(mContext, DataContentProvider.CONTENT_ALL);
+                } catch (Throwable t) {
+                    thrown.set(t);
+                }
+            }
+        });
+        thread.start();
+        thread.join();
+        assertNull(thrown.get());
+    }
+
+    @Test
+    public void aLoaderWithNoUriWatchesNothing() {
+        Uri uri = DataContentProvider.CONTENT_ALL;
+        int before = watchersOf(uri).size();
+        CountingLoader loader = watching(null);
+        loader.startLoading();
+        assertEquals(before, watchersOf(uri).size());
+    }
+
+    @Test
+    public void everyLoaderOverTheLedgerWatchesItAndTheOthersDoNot() {
+        Date start = new Date(0L);
+        Date end = new Date(1L);
+        OverviewSetting setting = new OverviewSetting(start, end, Group.MONTHLY,
+                OverviewSetting.CashFlow.NET_INCOMES);
+        assertEquals(DataContentProvider.CONTENT_ALL,
+                new OverviewDataLoader(mContext, setting).getObservedUri());
+        assertEquals(DataContentProvider.CONTENT_ALL,
+                new PeriodDetailFlowLoader(mContext, start, end, false).getObservedUri());
+        assertEquals(DataContentProvider.CONTENT_ALL,
+                new PeriodDetailSummaryLoader(mContext, start, end,
+                        PeriodDetailSummaryLoader.GROUP_BY_MONTH).getObservedUri());
+        assertNull(new LicenseLoader(mContext).getObservedUri());
+        assertNull(new ChangeLogLoader(mContext).getObservedUri());
+        assertNull(new IconGroupLoader(mContext).getObservedUri());
+        assertNull(new JsonResourceLoader(mContext, "anything").getObservedUri());
+    }
+
+    private CountingLoader watching(Uri uri) {
+        CountingLoader loader = new CountingLoader(mContext, uri);
+        loader.registerListener(1, new Loader.OnLoadCompleteListener<String>() {
+
+            @Override
+            public void onLoadComplete(Loader<String> source, String data) {
+                mReceived.add(data);
+            }
+        });
+        return loader;
+    }
+
+    private Collection<ContentObserver> watchersOf(Uri uri) {
+        return Shadows.shadowOf(mContext.getContentResolver()).getContentObservers(uri);
+    }
+
+    /**
+     * Counts the loads without running any, so what is read is the branching and not the loading.
+     */
+    private static class CountingLoader extends AbstractGenericLoader<String> {
+
+        private final Uri mObserved;
+
+        private int mLoads;
+
+        private CountingLoader(Context context, Uri observed) {
+            super(context);
+            mObserved = observed;
+        }
+
+        @Override
+        protected Uri getObservedUri() {
+            return mObserved;
+        }
+
+        @Override
+        public String loadInBackground() {
+            return "loaded";
+        }
+
+        @Override
+        public void forceLoad() {
+            mLoads++;
+        }
+    }
+}


### PR DESCRIPTION
The Overview and the period screen behind it read their totals once and then stop listening. Edit or delete a transaction from inside those screens and both keep showing what they showed before, until you switch wallets, change the overview settings, or come back in a way that rebuilds the screen. The list you edited from updates straight away, so the two disagree with each other.

This makes those screens notice writes the way the rest of the app already does, and stops them showing the old totals for a moment when new ones are already on the way.

Fixes #273.

**What I tested:** an emulator carrying a ledger of 464 transactions. Deleting an income of 2.84 from inside the Overview left the period screen and the Overview frozen on the old build, and both now move by exactly that amount while every other month stays put. Eight new tests cover it, including one that writes through the app's own storage and checks the screen fetches its data again, and the whole unit suite passes.
