### PR TITLE
Say so when a hidden parent keeps a subcategory out of the reports

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/CategoryItemFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/CategoryItemFragment.java
@@ -194,7 +194,8 @@ public class CategoryItemFragment extends SecondaryPanelFragment implements Load
                     Contract.Category.PARENT,
                     Contract.Category.PARENT_NAME,
                     Contract.Category.TYPE,
-                    Contract.Category.SHOW_REPORT
+                    Contract.Category.SHOW_REPORT,
+                    Contract.Category.PARENT_SHOW_REPORT
             };
             return new CursorLoader(getActivity(), uri, projection, null, null, null);
         }
@@ -233,7 +234,18 @@ public class CategoryItemFragment extends SecondaryPanelFragment implements Load
             }
             if (cursor.getInt(cursor.getColumnIndex(Contract.Category.SHOW_REPORT)) == 1) {
                 mShowReportCheckBox.setChecked(true);
-                mShowReportCheckBox.setText(R.string.hint_show_category_report_on);
+                // the reports keep a transaction only when its category and its parent are both
+                // included, so a subcategory under a hidden parent is out however its own box
+                // reads. A top level category joins no parent row, and the null that leaves here
+                // means included, which is how the report filter reads it too.
+                int parentShowReport = cursor.getColumnIndex(Contract.Category.PARENT_SHOW_REPORT);
+                int parentName = cursor.getColumnIndex(Contract.Category.PARENT_NAME);
+                if (!cursor.isNull(parentShowReport) && cursor.getInt(parentShowReport) == 0) {
+                    mShowReportCheckBox.setText(getString(R.string.hint_show_category_report_off_parent,
+                            cursor.getString(parentName)));
+                } else {
+                    mShowReportCheckBox.setText(R.string.hint_show_category_report_on);
+                }
             } else {
                 mShowReportCheckBox.setChecked(false);
                 mShowReportCheckBox.setText(R.string.hint_show_category_report_off);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@
     <string name="hint_show_category_report">"Show this category inside the reports"</string>
     <string name="hint_show_category_report_on">"This category is included inside the reports"</string>
     <string name="hint_show_category_report_off">"This category is not included inside the reports"</string>
+    <string name="hint_show_category_report_off_parent">"This category is not included inside the reports, because %1$s is not"</string>
     <string name="hint_confirmed">"Confirmed"</string>
     <string name="hint_show_in_total">"Show in total wallet"</string>
     <string name="hint_income">"Income"</string>

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/secondary/CategoryItemFragmentTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/secondary/CategoryItemFragmentTest.java
@@ -1,0 +1,161 @@
+package com.oriondev.moneywallet.ui.fragment.secondary;
+
+import android.content.ContentResolver;
+import android.content.ContentUris;
+import android.content.ContentValues;
+import android.content.Context;
+import android.os.Looper;
+import android.widget.CheckBox;
+
+import androidx.fragment.app.FragmentActivity;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.storage.database.Contract;
+import com.oriondev.moneywallet.storage.database.DataContentProvider;
+import com.oriondev.moneywallet.storage.database.TestDatabases;
+import com.oriondev.moneywallet.ui.activity.BackupListActivity;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+/**
+ * The reports keep a transaction only when its category and its parent are both included, so a
+ * subcategory under a hidden parent reaches no report however its own box reads. This screen used
+ * to read that box alone and say the category was in the reports when none of its money was.
+ *
+ * What each case reads is the line the screen actually shows, so a branch that picks the wrong one
+ * of the three fails here whatever the stored settings say.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class CategoryItemFragmentTest {
+
+    private static final String ICON = "{\"type\":\"color\",\"color\":\"#000000\",\"name\":\"T\"}";
+    private static final String TAG_FRAGMENT = "CategoryItemFragmentTest::Fragment";
+
+    private Context mContext;
+    private ContentResolver mResolver;
+
+    @Before
+    public void setUp() {
+        mContext = ApplicationProvider.getApplicationContext();
+        TestDatabases.useFreshDatabase(mContext);
+        mResolver = mContext.getContentResolver();
+    }
+
+    @Test
+    public void aTopLevelCategoryInTheReportsSaysSo() {
+        long groceries = insertCategory("Groceries", null, true);
+        try (ActivityScenario<BackupListActivity> scenario =
+                     ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                CheckBox box = showCategory(activity, groceries);
+                assertTrue(box.isChecked());
+                assertEquals(mContext.getString(R.string.hint_show_category_report_on),
+                        box.getText().toString());
+            });
+        }
+    }
+
+    @Test
+    public void aTopLevelCategoryKeptOutSaysSo() {
+        long groceries = insertCategory("Groceries", null, false);
+        try (ActivityScenario<BackupListActivity> scenario =
+                     ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                CheckBox box = showCategory(activity, groceries);
+                assertFalse(box.isChecked());
+                assertEquals(mContext.getString(R.string.hint_show_category_report_off),
+                        box.getText().toString());
+            });
+        }
+    }
+
+    @Test
+    public void aSubcategoryUnderAnIncludedParentSaysItIsIn() {
+        long groceries = insertCategory("Groceries", null, true);
+        long snacks = insertCategory("Snacks", groceries, true);
+        try (ActivityScenario<BackupListActivity> scenario =
+                     ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                CheckBox box = showCategory(activity, snacks);
+                assertTrue(box.isChecked());
+                assertEquals(mContext.getString(R.string.hint_show_category_report_on),
+                        box.getText().toString());
+            });
+        }
+    }
+
+    /**
+     * The one the issue is about. The box stays ticked because that is the stored setting, and the
+     * line beside it names the category holding the money out.
+     */
+    @Test
+    public void aSubcategoryUnderAHiddenParentNamesTheParent() {
+        long groceries = insertCategory("Groceries", null, false);
+        long snacks = insertCategory("Snacks", groceries, true);
+        try (ActivityScenario<BackupListActivity> scenario =
+                     ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                CheckBox box = showCategory(activity, snacks);
+                assertTrue(box.isChecked());
+                assertEquals(mContext.getString(R.string.hint_show_category_report_off_parent,
+                        "Groceries"), box.getText().toString());
+                // both sides of the line above read the same resource, so they move together and
+                // a reword that dropped the parent would pass. This is what pins that the name
+                // of the category holding the money out actually reaches the screen.
+                assertTrue(box.getText().toString().contains("Groceries"));
+            });
+        }
+    }
+
+    /**
+     * Its own setting already answers the question, so naming the parent here would tell the user
+     * about a second reason they cannot act on from this screen.
+     */
+    @Test
+    public void aSubcategoryKeptOutOnItsOwnDoesNotNameTheParent() {
+        long groceries = insertCategory("Groceries", null, false);
+        long snacks = insertCategory("Snacks", groceries, false);
+        try (ActivityScenario<BackupListActivity> scenario =
+                     ActivityScenario.launch(BackupListActivity.class)) {
+            scenario.onActivity(activity -> {
+                CheckBox box = showCategory(activity, snacks);
+                assertFalse(box.isChecked());
+                assertEquals(mContext.getString(R.string.hint_show_category_report_off),
+                        box.getText().toString());
+            });
+        }
+    }
+
+    private CheckBox showCategory(FragmentActivity activity, long categoryId) {
+        CategoryItemFragment fragment = new CategoryItemFragment();
+        activity.getSupportFragmentManager()
+                .beginTransaction()
+                .add(android.R.id.content, fragment, TAG_FRAGMENT)
+                .commitNow();
+        fragment.showItemId(categoryId);
+        shadowOf(Looper.getMainLooper()).idle();
+        return fragment.getView().findViewById(R.id.show_report_check_box);
+    }
+
+    private long insertCategory(String name, Long parent, boolean showReport) {
+        ContentValues values = new ContentValues();
+        values.put(Contract.Category.NAME, name);
+        values.put(Contract.Category.ICON, ICON);
+        values.put(Contract.Category.TYPE, Contract.CategoryType.EXPENSE.getValue());
+        values.put(Contract.Category.SHOW_REPORT, showReport);
+        if (parent != null) {
+            values.put(Contract.Category.PARENT, parent);
+        }
+        return ContentUris.parseId(mResolver.insert(DataContentProvider.CONTENT_CATEGORIES, values));
+    }
+}


### PR DESCRIPTION
A category can be kept out of the reports, and the checkbox is offered for a subcategory as readily as for a top level one. But a subcategory only reaches a report when its parent is included too, so hiding a parent takes its children with it.

The subcategory's own screen did not know that. It read its own setting alone and said the category was included in the reports while none of its money was in one, which is the opposite of what the user had just set up.

It now says so, and names the category holding it out. The checkbox still shows the stored setting, because that setting is real and takes effect again the moment the parent is shown.

Fixes #224.

**What I tested:** an emulator, driving the app itself and not its storage. Hiding Food from its own editor and opening Groceries reads "This category is included inside the reports" on the old build, and "This category is not included inside the reports, because Food is not" on this one, with both stored settings untouched. A subcategory under a visible parent, and a top level category, both still read the ordinary line. Five new tests cover the three lines the screen can show, and the whole unit suite passes.
