### PR TITLE
Keep a settings row readable after the theme changes

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedInputPreference.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedInputPreference.java
@@ -20,16 +20,19 @@
 package com.oriondev.moneywallet.ui.preference;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import android.content.DialogInterface;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 import androidx.appcompat.app.AlertDialog;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
 import android.text.TextUtils;
 import android.util.AttributeSet;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 
 /**
@@ -123,5 +126,12 @@ public class ThemedInputPreference extends Preference {
                 .setNegativeButton(android.R.string.cancel, null)
                 .create();
         ThemedDialog.showWithInput(dialog, inputEditText, mAllowEmptyInput);
+    }
+
+    // see ThemedPreference.onBindViewHolder
+    @Override
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        ThemeEngine.applyTheme(holder.itemView, true);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedListPreference.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedListPreference.java
@@ -20,12 +20,15 @@
 package com.oriondev.moneywallet.ui.preference;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import android.content.DialogInterface;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
 import android.view.View;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 
 /**
@@ -124,5 +127,12 @@ public class ThemedListPreference extends Preference {
                 })
                 .setNegativeButton(android.R.string.cancel, null)
                 .show();
+    }
+
+    // see ThemedPreference.onBindViewHolder
+    @Override
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        ThemeEngine.applyTheme(holder.itemView, true);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedPreference.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedPreference.java
@@ -20,10 +20,13 @@
 package com.oriondev.moneywallet.ui.preference;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import androidx.preference.Preference;
+import androidx.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 
 /**
  * Created by andrea on 15/04/18.
@@ -47,5 +50,19 @@ public class ThemedPreference extends Preference {
 
     private void initialize() {
         setLayoutResource(R.layout.layout_preference_material_design);
+    }
+
+    /**
+     * Repaints the row after the library has bound it.
+     * <p>
+     * PreferenceViewHolder copies the title's colors as the row is built and PreferenceGroupAdapter
+     * puts that copy back before every bind, so a row built in one theme mode and rebound in
+     * another loses its title to the mode it was built under. Deep dark made that unreadable,
+     * because the copy was black and the window behind it was too.
+     */
+    @Override
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        ThemeEngine.applyTheme(holder.itemView, true);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedPreferenceCategory.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedPreferenceCategory.java
@@ -20,10 +20,13 @@
 package com.oriondev.moneywallet.ui.preference;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 
 /**
  * Created by andrea on 28/07/18.
@@ -52,5 +55,12 @@ public class ThemedPreferenceCategory extends PreferenceCategory {
 
     private void initialize() {
         setLayoutResource(R.layout.layout_preference_category_material_design);
+    }
+
+    // see ThemedPreference.onBindViewHolder
+    @Override
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        ThemeEngine.applyTheme(holder.itemView, true);
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedSwitchPreference.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/preference/ThemedSwitchPreference.java
@@ -20,10 +20,13 @@
 package com.oriondev.moneywallet.ui.preference;
 
 import android.content.Context;
+import androidx.annotation.NonNull;
 import androidx.preference.SwitchPreferenceCompat;
+import androidx.preference.PreferenceViewHolder;
 import android.util.AttributeSet;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
 
 /**
  * Created by andrea on 25/07/18.
@@ -47,5 +50,12 @@ public class ThemedSwitchPreference extends SwitchPreferenceCompat {
 
     private void initialize() {
         setLayoutResource(R.layout.layout_preference_material_design);
+    }
+
+    // see ThemedPreference.onBindViewHolder
+    @Override
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        ThemeEngine.applyTheme(holder.itemView, true);
     }
 }

--- a/app/src/test/java/com/oriondev/moneywallet/ui/preference/PreferenceTitleThemeTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/preference/PreferenceTitleThemeTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.preference;
+
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.preference.Preference;
+import androidx.preference.PreferenceGroupAdapter;
+import androidx.preference.PreferenceManager;
+import androidx.preference.PreferenceScreen;
+import androidx.preference.PreferenceViewHolder;
+
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * A settings row keeps the current title color when its value changes.
+ * <p>
+ * The library copies the title's colors as the row is built and puts that copy back on every
+ * bind, so a row built under one theme and rebound under another used to lose its title to the
+ * theme it was built with. Deep dark made that unreadable, because the copy was black and the
+ * window behind it was too.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class PreferenceTitleThemeTest {
+
+    private PreferenceGroupAdapter mAdapter;
+    private int mTitleColorAsBuilt;
+
+    /** The theme lives in shared preferences the engine holds open, so it outlives the test. */
+    @After
+    public void restoreTheDefaultMode() {
+        ThemeEngine.setMode(ThemeEngine.Mode.LIGHT);
+    }
+
+    /**
+     * Every row that draws its title in the primary text color. The theme type row is a
+     * ThemedListPreference and it rebinds inside the same tap that changes the mode, so it is the
+     * one that has to survive.
+     */
+    @Test
+    public void aRowReboundAfterAModeChangeKeepsTheNewModesTitleColor() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            AppCompatActivity activity = controller.get();
+            assertAModeChangeSurvivesARebind(activity, new ThemedPreference(activity));
+            assertAModeChangeSurvivesARebind(activity, new ColorPreference(activity));
+            assertAModeChangeSurvivesARebind(activity, new ThemedListPreference(activity));
+            assertAModeChangeSurvivesARebind(activity, new ThemedInputPreference(activity));
+            assertAModeChangeSurvivesARebind(activity, new ThemedSwitchPreference(activity));
+        } finally {
+            controller.close();
+        }
+    }
+
+    /**
+     * A section header draws its title in the accent, so the accent itself is what has to change
+     * for the header to be pinned at all. The engine keeps an accent only where it clears a
+     * contrast floor against the window and the card, and both of those are per mode, so the
+     * color here holds up in all three modes and the assertion reads the accent back instead of
+     * trusting it landed.
+     */
+    @Test
+    public void aCategoryReboundAfterAnAccentChangeKeepsTheNewAccent() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        int originalAccent = ThemeEngine.getTheme().getColorAccent();
+        try {
+            AppCompatActivity activity = controller.get();
+            ThemeEngine.setMode(ThemeEngine.Mode.LIGHT);
+            PreferenceViewHolder holder = buildRow(activity, new ThemedPreferenceCategory(activity));
+            TextView header = titleOf(holder);
+
+            ThemeEngine.setColorAccent(0xFF009688);
+            ThemeEngine.applyTheme(holder.itemView, true);
+            int after = header.getCurrentTextColor();
+            assertEquals("the contrast floor dropped the accent before it reached the header",
+                    ThemeEngine.getTheme().getColorAccent(), after);
+            assertNotEquals("the header was built in the color the rebind has to keep, so a rebind"
+                    + " proves nothing", mTitleColorAsBuilt, after);
+
+            mAdapter.onBindViewHolder(holder, 0);
+            assertEquals("the rebind put back the accent the header was built with",
+                    after, header.getCurrentTextColor());
+        } finally {
+            ThemeEngine.setColorAccent(originalAccent);
+            controller.close();
+        }
+    }
+
+    private void assertAModeChangeSurvivesARebind(AppCompatActivity activity, Preference preference) {
+        String name = preference.getClass().getSimpleName();
+        ThemeEngine.setMode(ThemeEngine.Mode.LIGHT);
+        PreferenceViewHolder holder = buildRow(activity, preference);
+        TextView title = titleOf(holder);
+        int light = ThemeEngine.getTheme().getTextColorPrimary();
+        assertEquals(name + " did not start in the light mode color",
+                light, title.getCurrentTextColor());
+
+        ThemeEngine.setMode(ThemeEngine.Mode.DEEP_DARK);
+        ThemeEngine.applyTheme(holder.itemView, true);
+        int deepDark = ThemeEngine.getTheme().getTextColorPrimary();
+        assertEquals(name + " was not repainted for deep dark",
+                deepDark, title.getCurrentTextColor());
+        assertNotEquals(name + " was built in the color the rebind has to keep, so a rebind proves"
+                + " nothing", mTitleColorAsBuilt, deepDark);
+
+        mAdapter.onBindViewHolder(holder, 0);
+        assertEquals(name + " lost its title to the color it was built with",
+                deepDark, title.getCurrentTextColor());
+    }
+
+    /**
+     * Builds one row through the library, the way a settings screen does, and paints it for the
+     * theme in force. Nothing themes a view in a unit test, so the row is painted here by hand,
+     * after the holder has already copied the platform's own color. On a device the inflater
+     * paints first and the copy is the engine's, which is a different value and the same defect.
+     * <p>
+     * The color the row is built in is recorded, because that is what a rebind restores, and a
+     * test that expects the rebind to land on that same color would pass with the fix deleted.
+     */
+    private PreferenceViewHolder buildRow(AppCompatActivity activity, Preference preference) {
+        preference.setTitle("Income color");
+        PreferenceManager manager = new PreferenceManager(activity);
+        PreferenceScreen screen = manager.createPreferenceScreen(activity);
+        screen.addPreference(preference);
+        mAdapter = new PreferenceGroupAdapter(screen);
+        PreferenceViewHolder holder = mAdapter.onCreateViewHolder(
+                new FrameLayout(activity), mAdapter.getItemViewType(0));
+        mTitleColorAsBuilt = titleOf(holder).getCurrentTextColor();
+        ThemeEngine.applyTheme(holder.itemView, true);
+        return holder;
+    }
+
+    private TextView titleOf(PreferenceViewHolder holder) {
+        TextView title = (TextView) holder.findViewById(android.R.id.title);
+        assertNotNull("the row has no title view", title);
+        return title;
+    }
+}


### PR DESCRIPTION
Set the theme to Deep dark, then change the income color, the expense color, the primary color or the accent. The title of the row you just changed turns black on a black window. The value you picked is applied and every other row stays readable, so only that one row goes missing.

The settings list copies the color of a row's title when the row is first drawn, and puts that copy back every time the row is drawn again. This app has no dark theme in its resources. All three modes start from the same light theme and the dark ones are painted on as the app runs, so the copy is only right for the mode the row was built under. Changing a value draws that row again and the old copy comes back. The theme type row loses itself on the same tap that changes the mode, because picking a mode also rewrites the line underneath it. Only the title is copied, which is why the line underneath stays readable.

Every settings row now repaints itself after it is drawn again. That reaches the four color rows, the theme type row, and the section headers.

Tested on an Android 16 emulator against all four colors and the theme type, in both directions between the three modes, reading the drawn pixel values back instead of judging by eye. There is a test for each kind of row, and each fails if the repaint is taken out.
