### PR TITLE
Show a color while it is being picked

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/picker/ColorPicker.java
+++ b/app/src/main/java/com/oriondev/moneywallet/picker/ColorPicker.java
@@ -58,6 +58,7 @@ public class ColorPicker extends Fragment implements ColorChooserDialog.Callback
 
     private int mCurrentColor;
     private boolean mAccentPalette;
+    private boolean mPreviewed;
 
     @Override
     public void onAttach(Context context) {
@@ -135,12 +136,27 @@ public class ColorPicker extends Fragment implements ColorChooserDialog.Callback
     }
 
     @Override
+    public boolean onColorPreview(ColorChooserDialog dialog, int color) {
+        mPreviewed = mController != null && mController.onColorPreview(getTag(), color);
+        return mPreviewed;
+    }
+
+    /** Only a picker that showed something ends anything, since ending it is not per picker. */
+    @Override
     public void onColorChooserDismissed(ColorChooserDialog dialog) {
-        // nothing to do: the dialog is built fresh on every showPicker
+        if (mPreviewed && mController != null) {
+            mPreviewed = false;
+            mController.onColorPreviewEnded();
+        }
     }
 
     public interface Controller {
 
         void onColorChanged(String tag, int color, boolean autoFired);
+
+        /** @return true if the color is now showing somewhere, so the chooser can drop its dim. */
+        boolean onColorPreview(String tag, int color);
+
+        void onColorPreviewEnded();
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java
@@ -221,8 +221,10 @@ public abstract class ThemedActivity extends AppCompatActivity implements ThemeE
 
     @Override
     protected void onDestroy() {
-        super.onDestroy();
+        // Before the teardown, not after it: a fragment being torn down inside super.onDestroy
+        // can change the theme, and this activity is in no state to be repainted.
         ThemeEngine.unregisterObserver(this);
+        super.onDestroy();
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorChooserDialog.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorChooserDialog.java
@@ -29,6 +29,8 @@ import android.text.InputFilter;
 import android.text.TextWatcher;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
 import android.widget.BaseAdapter;
 import android.widget.EditText;
 import android.widget.GridView;
@@ -62,6 +64,7 @@ public class ColorChooserDialog extends DialogFragment {
     private static final String SS_HUE_INDEX = "ColorChooserDialog::SavedState::HueIndex";
     private static final String SS_SHADE_INDEX = "ColorChooserDialog::SavedState::ShadeIndex";
     private static final String SS_SELECTED_COLOR = "ColorChooserDialog::SavedState::SelectedColor";
+    private static final String SS_PREVIEWING = "ColorChooserDialog::SavedState::Previewing";
 
     private static final int HEX_DIGITS = 6;
 
@@ -81,6 +84,8 @@ public class ColorChooserDialog extends DialogFragment {
     private int[][] mShades;
 
     private boolean mInShadeLevel;
+    private boolean mPreviewing;
+    private boolean mWritingHex;
     private int mHueIndex;
     private int mShadeIndex;
     private int mSelectedColor;
@@ -111,6 +116,7 @@ public class ColorChooserDialog extends DialogFragment {
             mHueIndex = savedInstanceState.getInt(SS_HUE_INDEX);
             mShadeIndex = savedInstanceState.getInt(SS_SHADE_INDEX);
             mSelectedColor = savedInstanceState.getInt(SS_SELECTED_COLOR);
+            mPreviewing = savedInstanceState.getBoolean(SS_PREVIEWING);
         } else {
             mSelectedColor = 0xFF000000 | (arguments != null ? arguments.getInt(ARG_PRESELECT_COLOR) : Color.BLACK);
             findPreselect(mSelectedColor);
@@ -186,6 +192,12 @@ public class ColorChooserDialog extends DialogFragment {
 
         });
         invalidateNegativeButton();
+        if (mPreviewing) {
+            // The screens behind are new ones that know nothing about a preview the old ones
+            // were showing, and the field cannot put it back on its own, because its watcher is what
+            // restores it, and it ignores a value that is not six digits of a real color.
+            previewSelection();
+        }
     }
 
     @Override
@@ -195,6 +207,7 @@ public class ColorChooserDialog extends DialogFragment {
         outState.putInt(SS_HUE_INDEX, mHueIndex);
         outState.putInt(SS_SHADE_INDEX, mShadeIndex);
         outState.putInt(SS_SELECTED_COLOR, mSelectedColor);
+        outState.putBoolean(SS_PREVIEWING, mPreviewing);
     }
 
     @Override
@@ -239,7 +252,7 @@ public class ColorChooserDialog extends DialogFragment {
     }
 
     private void onHexTyped(String text) {
-        if (text.length() != HEX_DIGITS) {
+        if (mWritingHex || text.length() != HEX_DIGITS) {
             return;
         }
         try {
@@ -247,7 +260,7 @@ public class ColorChooserDialog extends DialogFragment {
         } catch (IllegalArgumentException e) {
             return;
         }
-        mPreviewView.setColor(mSelectedColor);
+        previewSelection();
         if (mInShadeLevel) {
             mShadeIndex = mHueIndex >= 0 ? findShade(mHueIndex, mSelectedColor) : -1;
         } else {
@@ -256,8 +269,14 @@ public class ColorChooserDialog extends DialogFragment {
         ((BaseAdapter) mGridView.getAdapter()).notifyDataSetChanged();
     }
 
+    /**
+     * The field's own watcher is what makes a typed color take effect, and it cannot tell a
+     * keystroke from this, so a write of a color the dialog already knows about is held off it.
+     */
     private void writeHex(@ColorInt int color) {
+        mWritingHex = true;
         mHexEditText.setText(String.format(Locale.US, "%06X", 0xFFFFFF & color));
+        mWritingHex = false;
     }
 
     private void onSwatchClicked(int position) {
@@ -275,8 +294,29 @@ public class ColorChooserDialog extends DialogFragment {
             mInShadeLevel = true;
         }
         writeHex(mSelectedColor);
-        mPreviewView.setColor(mSelectedColor);
+        previewSelection();
         invalidate();
+    }
+
+    /**
+     * The dim goes while a preview is up, because the surface being previewed is behind this
+     * dialog and the dim is over it, and it comes back when the engine turns a preview down.
+     * Walking back to the color that is stored is one of those, and it has to look like the
+     * chooser did when it opened on that same color.
+     */
+    private void previewSelection() {
+        mPreviewView.setColor(mSelectedColor);
+        mPreviewing = mCallback.onColorPreview(this, mSelectedColor);
+        Dialog dialog = getDialog();
+        Window window = dialog != null ? dialog.getWindow() : null;
+        if (window == null) {
+            return;
+        }
+        if (mPreviewing) {
+            window.clearFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+        } else {
+            window.addFlags(WindowManager.LayoutParams.FLAG_DIM_BEHIND);
+        }
     }
 
     private void invalidate() {
@@ -296,6 +336,15 @@ public class ColorChooserDialog extends DialogFragment {
         void onColorSelection(ColorChooserDialog dialog, @ColorInt int color);
 
         void onColorChooserDismissed(ColorChooserDialog dialog);
+
+        /**
+         * The color under the cursor, before OK and possibly never chosen. Returning true says
+         * something outside this dialog is now showing it, which is what the dim behind the dialog
+         * is dropped for.
+         */
+        default boolean onColorPreview(ColorChooserDialog dialog, @ColorInt int color) {
+            return false;
+        }
     }
 
     private class SwatchAdapter extends BaseAdapter {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UserInterfaceSettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UserInterfaceSettingFragment.java
@@ -428,4 +428,21 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
                 break;
         }
     }
+
+    @Override
+    public boolean onColorPreview(String tag, int color) {
+        switch (tag) {
+            case TAG_COLOR_PRIMARY:
+                return ThemeEngine.previewColorPrimary(color);
+            case TAG_COLOR_ACCENT:
+                return ThemeEngine.previewColorAccent(color);
+            default:
+                return false;
+        }
+    }
+
+    @Override
+    public void onColorPreviewEnded() {
+        ThemeEngine.clearPreview();
+    }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemeEngine.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemeEngine.java
@@ -29,6 +29,7 @@ import android.view.ViewGroup;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This class is responsible to dynamically theme the user interface at runtime.
@@ -138,6 +139,9 @@ public class ThemeEngine implements ITheme {
 
     private static ThemeEngine sInstance;
 
+    private static Integer sPreviewColorPrimary;
+    private static Integer sPreviewColorAccent;
+
     public static void initialize(Context context) {
         if (sInstance == null) {
             sInstance = new ThemeEngine(context);
@@ -152,10 +156,69 @@ public class ThemeEngine implements ITheme {
         mThemeObserverList.remove(observer);
     }
 
+    /**
+     * Shows a color without storing it, so a chooser can repaint the screen behind it while it
+     * is open. The stored value is untouched, which is what makes cancelling free. Clear it from
+     * clearPreview once the chooser is gone.
+     * <p>
+     * The color that is stored is never an override, and a chooser opens on it and can be walked
+     * back to it. That is not only to save a repaint of every observer. The stored dark primary
+     * is its own value while a previewed one is derived from the primary, and out of the box
+     * those two are not the same color, so showing the stored primary as an override would move
+     * the status bar to a color no screen will have once the chooser is gone.
+     *
+     * @return whether the screen is now showing something other than what is stored
+     */
+    @UiThread
+    public static boolean previewColorPrimary(int colorPrimary) {
+        if (sInstance == null) {
+            return false;
+        }
+        Integer showing = colorPrimary == sInstance.getStoredColorPrimary() ? null : colorPrimary;
+        if (!Objects.equals(showing, sPreviewColorPrimary)) {
+            sPreviewColorPrimary = showing;
+            notifyObservers();
+        }
+        return sPreviewColorPrimary != null;
+    }
+
+    @UiThread
+    public static boolean previewColorAccent(int colorAccent) {
+        if (sInstance == null) {
+            return false;
+        }
+        Integer showing = colorAccent == sInstance.getStoredColorAccent() ? null : colorAccent;
+        if (!Objects.equals(showing, sPreviewColorAccent)) {
+            sPreviewColorAccent = showing;
+            notifyObservers();
+        }
+        return sPreviewColorAccent != null;
+    }
+
+    @UiThread
+    public static void clearPreview() {
+        if (sPreviewColorPrimary == null && sPreviewColorAccent == null) {
+            return;
+        }
+        // OK stores the color it was previewing, so by the time the chooser is gone the override
+        // and the stored value are the same color and dropping it moves nothing on screen.
+        boolean showsSomethingElse = sInstance == null
+                || (sPreviewColorPrimary != null && sPreviewColorPrimary != sInstance.getStoredColorPrimary())
+                || (sPreviewColorAccent != null && sPreviewColorAccent != sInstance.getStoredColorAccent());
+        sPreviewColorPrimary = null;
+        sPreviewColorAccent = null;
+        if (showsSomethingElse) {
+            notifyObservers();
+        }
+    }
+
     @UiThread
     public static void setColorPrimary(int colorPrimary) {
         if (sInstance != null) {
-            if (colorPrimary != sInstance.getColorPrimary()) {
+            // Against the stored value, never the getter: a preview of this same color is showing
+            // while the chooser's OK button is what calls this, and comparing with the getter would
+            // read that preview and skip the write.
+            if (colorPrimary != sInstance.getStoredColorPrimary()) {
                 sInstance.mPreferences.edit().putInt(COLOR_PRIMARY, colorPrimary).apply();
                 sInstance.mPreferences.edit().putInt(COLOR_PRIMARY_DARK, Util.darkenColor(colorPrimary)).apply();
                 notifyObservers();
@@ -168,7 +231,7 @@ public class ThemeEngine implements ITheme {
     @UiThread
     public static void setColorAccent(int colorAccent) {
         if (sInstance != null) {
-            if (colorAccent != sInstance.getColorAccent()) {
+            if (colorAccent != sInstance.getStoredColorAccent()) {
                 sInstance.mPreferences.edit().putInt(COLOR_ACCENT, colorAccent).apply();
                 notifyObservers();
             }
@@ -223,18 +286,34 @@ public class ThemeEngine implements ITheme {
         mPreferences = context.getSharedPreferences(FILE_NAME, Context.MODE_PRIVATE);
     }
 
+    // Each getter holds the override it read, since it can be cleared between a null check
+    // and a use.
     @Override
     public int getColorPrimary() {
-        return noAlpha(mPreferences.getInt(COLOR_PRIMARY, DEFAULT_COLOR_PRIMARY));
+        Integer preview = sPreviewColorPrimary;
+        return preview != null ? noAlpha(preview) : getStoredColorPrimary();
     }
 
     @Override
     public int getColorPrimaryDark() {
+        Integer preview = sPreviewColorPrimary;
+        if (preview != null) {
+            return noAlpha(Util.darkenColor(preview));
+        }
         return noAlpha(mPreferences.getInt(COLOR_PRIMARY_DARK, DEFAULT_COLOR_PRIMARY_DARK));
     }
 
     @Override
     public int getColorAccent() {
+        Integer preview = sPreviewColorAccent;
+        return preview != null ? noAlpha(preview) : getStoredColorAccent();
+    }
+
+    private int getStoredColorPrimary() {
+        return noAlpha(mPreferences.getInt(COLOR_PRIMARY, DEFAULT_COLOR_PRIMARY));
+    }
+
+    private int getStoredColorAccent() {
         return noAlpha(mPreferences.getInt(COLOR_ACCENT, DEFAULT_COLOR_ACCENT));
     }
 

--- a/app/src/test/java/com/oriondev/moneywallet/picker/ColorPickerPreviewEndTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/picker/ColorPickerPreviewEndTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.picker;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Ending a preview is not per picker, it drops whatever is being shown, so a picker whose chooser
+ * showed nothing has to stay out of it. Income color and expense color are two of those, and their
+ * chooser closing must not take the theme preview with it.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ColorPickerPreviewEndTest {
+
+    private static final String THEME_TAG = "theme";
+    private static final String PLAIN_TAG = "plain";
+
+    @Test
+    public void aChooserThatShowedNothingEndsNothing() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            RecordingController recorder = new RecordingController();
+            ColorPicker theme = ColorPicker.createPicker(
+                    controller.get().getSupportFragmentManager(), THEME_TAG, 0xFF3F51B5, false, recorder);
+            ColorPicker plain = ColorPicker.createPicker(
+                    controller.get().getSupportFragmentManager(), PLAIN_TAG, 0xFF2196F3, false, recorder);
+
+            assertTrue(theme.onColorPreview(null, 0xFF009688));
+            plain.onColorPreview(null, 0xFF4CAF50);
+            plain.onColorChooserDismissed(null);
+            assertEquals("the chooser that showed nothing ended the one that did", 0, recorder.mEnded);
+
+            theme.onColorChooserDismissed(null);
+            assertEquals(1, recorder.mEnded);
+        } finally {
+            controller.close();
+        }
+    }
+
+    /** Answers the way the settings screen does, where only the theme colors reach the engine. */
+    private static class RecordingController implements ColorPicker.Controller {
+
+        private int mEnded;
+
+        @Override
+        public void onColorChanged(String tag, int color, boolean autoFired) {}
+
+        @Override
+        public boolean onColorPreview(String tag, int color) {
+            return THEME_TAG.equals(tag);
+        }
+
+        @Override
+        public void onColorPreviewEnded() {
+            mEnded++;
+        }
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivityTeardownTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivityTeardownTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.activity.base;
+
+import androidx.fragment.app.Fragment;
+
+import com.oriondev.moneywallet.ui.view.theme.ITheme;
+import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * A color chooser ends its preview as it is torn down, and an activity being destroyed tears its
+ * fragments down, so the theme can change inside the destruction of a screen that is in no state to
+ * be repainted.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ThemedActivityTeardownTest {
+
+    @After
+    public void clearThePreview() {
+        ThemeEngine.clearPreview();
+    }
+
+    @Test
+    public void anActivityIsNotRepaintedByItsOwnFragmentsBeingTornDown() {
+        ActivityController<CountingActivity> controller =
+                Robolectric.buildActivity(CountingActivity.class).setup();
+        CountingActivity activity = controller.get();
+        activity.getSupportFragmentManager()
+                .beginTransaction().add(new PreviewEndingFragment(), "ending").commitNow();
+        ThemeEngine.previewColorPrimary(ThemeEngine.getTheme().getColorPrimary() ^ 0x00FFFFFF);
+
+        controller.pause().stop().destroy();
+
+        assertEquals("a dying activity was repainted", 0, activity.mRepaintsWhileDying);
+    }
+
+    /** Stands in for the color chooser, which ends its preview from the same point. */
+    public static class PreviewEndingFragment extends Fragment {
+
+        @Override
+        public void onDestroy() {
+            super.onDestroy();
+            ThemeEngine.clearPreview();
+        }
+    }
+
+    public static class CountingActivity extends ThemedActivity {
+
+        private boolean mDying;
+        private int mRepaintsWhileDying;
+
+        @Override
+        protected void onDestroy() {
+            mDying = true;
+            super.onDestroy();
+        }
+
+        @Override
+        public void onThemeChanged(ITheme theme) {
+            if (mDying) {
+                mRepaintsWhileDying++;
+                return;
+            }
+            super.onThemeChanged(theme);
+        }
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorChooserPreviewTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/dialog/ColorChooserPreviewTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.fragment.dialog;
+
+import android.app.Dialog;
+import android.view.WindowManager;
+import android.view.View;
+import android.widget.EditText;
+import android.widget.GridView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.Fragment;
+
+import com.oriondev.moneywallet.R;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.android.controller.ActivityController;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A preview repaints every screen behind the chooser, so it happens once, and only for a color the
+ * user picked.
+ * <p>
+ * The hex field's watcher is what makes a typed color take effect, and the dialog writes that field
+ * itself when it opens and on every tap, so both of those reach the watcher too.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ColorChooserPreviewTest {
+
+    private static final int PRESELECT = 0xFF3F51B5;
+
+    @Test
+    public void openingTheChooserPreviewsNothingAndOneTapPreviewsOnce() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            CountingHost host = new CountingHost();
+            controller.get().getSupportFragmentManager()
+                    .beginTransaction().add(host, "host").commitNow();
+            ColorChooserDialog chooser =
+                    ColorChooserDialog.newInstance(R.string.dialog_color_picker_title, false, PRESELECT);
+            chooser.showNow(host.getChildFragmentManager(), "chooser");
+
+            assertEquals("the color the chooser opened on was previewed before anyone picked it",
+                    0, host.mPreviews);
+
+            firstSwatchOf(chooser).performClick();
+            assertEquals("one tap, one repaint of every screen", 1, host.mPreviews);
+        } finally {
+            controller.close();
+        }
+    }
+
+    /**
+     * The field's own watcher is what puts a preview back when the framework restores the field,
+     * and it ignores anything that is not six digits of a real color, which is what half typing a
+     * custom value leaves behind.
+     */
+    @Test
+    public void aPreviewOutlivesTheScreenBeingRebuiltUnderAHalfTypedHexValue() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            AppCompatActivity activity = controller.get();
+            CountingHost host = new CountingHost();
+            activity.getSupportFragmentManager()
+                    .beginTransaction().add(host, "host").commitNow();
+            ColorChooserDialog chooser =
+                    ColorChooserDialog.newInstance(R.string.dialog_color_picker_title, false, PRESELECT);
+            chooser.showNow(host.getChildFragmentManager(), "chooser");
+            firstSwatchOf(chooser).performClick();
+            hexFieldOf(chooser).setText("F4433");
+
+            controller.recreate();
+
+            CountingHost restored = (CountingHost) controller.get()
+                    .getSupportFragmentManager().findFragmentByTag("host");
+            assertNotNull(restored);
+            assertEquals("the rebuilt screen was left showing the stored color while the chooser"
+                    + " still held the picked one", 1, restored.mPreviews);
+        } finally {
+            controller.close();
+        }
+    }
+
+    /**
+     * The dim is over the surface being previewed, so it goes while one is up. Walking back to
+     * the color that is stored ends the preview and has to look like it did on opening.
+     */
+    @Test
+    public void theDimFollowsWhatIsBeingPreviewed() {
+        ActivityController<AppCompatActivity> controller =
+                Robolectric.buildActivity(AppCompatActivity.class).setup();
+        try {
+            CountingHost host = new CountingHost();
+            controller.get().getSupportFragmentManager()
+                    .beginTransaction().add(host, "host").commitNow();
+            ColorChooserDialog chooser =
+                    ColorChooserDialog.newInstance(R.string.dialog_color_picker_title, false, PRESELECT);
+            chooser.showNow(host.getChildFragmentManager(), "chooser");
+            assertTrue("the chooser opened over an undimmed screen", isDimmed(chooser));
+
+            firstSwatchOf(chooser).performClick();
+            assertFalse("the dim stayed over the color being previewed", isDimmed(chooser));
+
+            hexFieldOf(chooser).setText("3F51B5");
+            assertTrue("nothing is previewed and the dim never came back", isDimmed(chooser));
+        } finally {
+            controller.close();
+        }
+    }
+
+    private boolean isDimmed(ColorChooserDialog chooser) {
+        Dialog dialog = chooser.getDialog();
+        assertNotNull(dialog);
+        assertNotNull(dialog.getWindow());
+        return (dialog.getWindow().getAttributes().flags
+                & WindowManager.LayoutParams.FLAG_DIM_BEHIND) != 0;
+    }
+
+    private EditText hexFieldOf(ColorChooserDialog chooser) {
+        Dialog dialog = chooser.getDialog();
+        assertNotNull(dialog);
+        return dialog.findViewById(R.id.color_chooser_hex_edit_text);
+    }
+
+    private View firstSwatchOf(ColorChooserDialog chooser) {
+        Dialog dialog = chooser.getDialog();
+        assertNotNull(dialog);
+        GridView grid = dialog.findViewById(R.id.color_chooser_grid_view);
+        assertNotNull(grid);
+        return grid.getAdapter().getView(0, null, grid);
+    }
+
+    public static class CountingHost extends Fragment implements ColorChooserDialog.Callback {
+
+        private int mPreviews;
+
+        @Override
+        public void onColorSelection(ColorChooserDialog dialog, int color) {}
+
+        @Override
+        public void onColorChooserDismissed(ColorChooserDialog dialog) {}
+
+        /** As the engine does, which refuses to override the color that is stored. */
+        @Override
+        public boolean onColorPreview(ColorChooserDialog dialog, int color) {
+            mPreviews++;
+            return color != PRESELECT;
+        }
+    }
+}

--- a/app/src/test/java/com/oriondev/moneywallet/ui/view/theme/ThemePreviewTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/view/theme/ThemePreviewTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.view.theme;
+
+import androidx.core.graphics.ColorUtils;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * The color a chooser is sitting on is shown without being stored, so cancelling costs nothing and
+ * OK is still what writes.
+ * <p>
+ * Every color here is derived from what is stored when the test starts, because the engine is one
+ * static holding one preferences file for the whole JVM and a test that ran earlier may have
+ * written to it.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class ThemePreviewTest {
+
+    private int mOriginalPrimary;
+    private int mOriginalAccent;
+
+    @Before
+    public void readTheStoredTheme() {
+        // The getters answer with a preview while one is live, so one left behind by anything
+        // else would be read here as the stored color and then written by the teardown.
+        ThemeEngine.clearPreview();
+        mOriginalPrimary = ThemeEngine.getTheme().getColorPrimary();
+        mOriginalAccent = ThemeEngine.getTheme().getColorAccent();
+    }
+
+    /**
+     * The dark primary comes back derived from the primary instead of whatever it held, because the
+     * engine writes the pair together and nothing writes one of them alone. That is the state of any
+     * install where a color has been picked, and it cannot be put back, so nothing in this class may
+     * assert anything that only holds on the pair a fresh install ships with. Such an assertion
+     * cannot fail once any method here has run, which is every method but the first.
+     */
+    @After
+    public void restoreTheStoredTheme() {
+        ThemeEngine.clearPreview();
+        ThemeEngine.setColorPrimary(mOriginalPrimary);
+        ThemeEngine.setColorAccent(mOriginalAccent);
+    }
+
+    @Test
+    public void aPreviewIsWhatTheThemeReadsBackAndClearingItPutsTheStoredColorsBack() {
+        ITheme theme = ThemeEngine.getTheme();
+        int previewedPrimary = inverted(mOriginalPrimary);
+        int previewedAccent = inverted(mOriginalAccent);
+
+        ThemeEngine.previewColorPrimary(previewedPrimary);
+        ThemeEngine.previewColorAccent(previewedAccent);
+        assertEquals(previewedPrimary, theme.getColorPrimary());
+        assertEquals(previewedAccent, theme.getColorAccent());
+        assertEquals("the status bar follows the previewed primary, not the stored one",
+                opaque(Util.darkenColor(previewedPrimary)), theme.getColorPrimaryDark());
+
+        ThemeEngine.clearPreview();
+        assertEquals(mOriginalPrimary, theme.getColorPrimary());
+        assertEquals(mOriginalAccent, theme.getColorAccent());
+    }
+
+    /**
+     * OK arrives while the preview of that same color is still up, so a write that compared what it
+     * was handed against the theme would find no change and store nothing.
+     */
+    @Test
+    public void aColorStoredWhileItsOwnPreviewIsUpSurvivesThePreviewBeingCleared() {
+        ITheme theme = ThemeEngine.getTheme();
+        int chosenPrimary = inverted(mOriginalPrimary);
+        int chosenAccent = inverted(mOriginalAccent);
+
+        ThemeEngine.previewColorPrimary(chosenPrimary);
+        ThemeEngine.setColorPrimary(chosenPrimary);
+        ThemeEngine.previewColorAccent(chosenAccent);
+        ThemeEngine.setColorAccent(chosenAccent);
+        ThemeEngine.clearPreview();
+
+        assertEquals(chosenPrimary, theme.getColorPrimary());
+        assertEquals(chosenAccent, theme.getColorAccent());
+        assertEquals(opaque(Util.darkenColor(chosenPrimary)), theme.getColorPrimaryDark());
+    }
+
+    /**
+     * The chooser opens on the color that is stored and can be walked back to it, and neither
+     * is an override. Showing one would repaint every screen for a color nobody picked, and
+     * move the status bar with it, because a stored dark primary is its own value and an
+     * untouched one is not a darkened primary.
+     */
+    @Test
+    public void theStoredColorIsNeverAnOverride() {
+        ITheme theme = ThemeEngine.getTheme();
+        int[] repaints = new int[1];
+        ThemeEngine.ThemeObserver observer = ignored -> repaints[0]++;
+        ThemeEngine.registerObserver(observer);
+        try {
+            assertFalse("opening on the stored color previewed it",
+                    ThemeEngine.previewColorPrimary(mOriginalPrimary));
+            assertFalse(ThemeEngine.previewColorAccent(mOriginalAccent));
+            assertEquals("previewing what is already stored repainted the screen", 0, repaints[0]);
+
+            assertTrue(ThemeEngine.previewColorPrimary(inverted(mOriginalPrimary)));
+            assertEquals(1, repaints[0]);
+            ThemeEngine.previewColorPrimary(inverted(mOriginalPrimary));
+            assertEquals("the color that is already showing repainted again", 1, repaints[0]);
+
+            assertFalse("walking back to the stored color left an override showing",
+                    ThemeEngine.previewColorPrimary(mOriginalPrimary));
+            assertEquals(mOriginalPrimary, theme.getColorPrimary());
+        } finally {
+            ThemeEngine.unregisterObserver(observer);
+        }
+    }
+
+    /**
+     * OK stores the color that is showing and the chooser then goes, so the drop is not a change
+     * and repainting every screen for it is work nobody sees.
+     */
+    @Test
+    public void droppingAPreviewThatWasJustStoredRepaintsNothing() {
+        int[] repaints = new int[1];
+        ThemeEngine.ThemeObserver observer = ignored -> repaints[0]++;
+        ThemeEngine.previewColorPrimary(inverted(mOriginalPrimary));
+        ThemeEngine.setColorPrimary(inverted(mOriginalPrimary));
+        ThemeEngine.registerObserver(observer);
+        try {
+            ThemeEngine.clearPreview();
+            assertEquals(0, repaints[0]);
+
+            ThemeEngine.previewColorPrimary(mOriginalPrimary);
+            ThemeEngine.clearPreview();
+            assertEquals("a color that is not stored has to repaint on the way in and on the way out",
+                    2, repaints[0]);
+        } finally {
+            ThemeEngine.unregisterObserver(observer);
+        }
+    }
+
+    /** Opaque, and never the color it was handed. */
+    private int inverted(int color) {
+        return color ^ 0x00FFFFFF;
+    }
+
+    private int opaque(int color) {
+        return ColorUtils.setAlphaComponent(color, 255);
+    }
+}


### PR DESCRIPTION
Picking a theme color meant pressing OK, looking at the result, and going back into the picker if it was wrong.

The screen behind the picker now repaints as you tap a swatch or type a hex value, so you can see the header and the status bar change before committing to anything. The dim over that screen lifts while a color is being shown, since what you are looking at is behind the picker.

Nothing is written until OK. Cancel leaves the theme exactly as it was, and so does backing out, or the app being killed with the picker open.

Walking back to the color you started on ends the preview, so the screen goes back to showing what is stored.

Both theme pickers do this, primary and accent. Income and expense are unchanged.

Tested on an emulator by reading the pixels: the color lands as you tap, cancel writes nothing at all, and rotating with a half typed value keeps what you picked.