### PR TITLE
Draw behind the system bars instead of padding the content clear of them

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -671,71 +671,11 @@
             column="13"/>
     </issue>
 
-    <issue
-        id="NewApi"
-        message="Field requires API level 29 (current min is 24): `android.graphics.Insets#left`"
-        errorLine1="        if (params.height != bars.top || params.leftMargin != bars.left"
-        errorLine2="                                                              ~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java"
-            line="213"
-            column="63"/>
-    </issue>
 
-    <issue
-        id="NewApi"
-        message="Field requires API level 29 (current min is 24): `android.graphics.Insets#top`"
-        errorLine1="        if (params.height != bars.top || params.leftMargin != bars.left"
-        errorLine2="                             ~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java"
-            line="213"
-            column="30"/>
-    </issue>
 
-    <issue
-        id="NewApi"
-        message="Field requires API level 29 (current min is 24): `android.graphics.Insets#right`"
-        errorLine1="                || params.rightMargin != bars.right) {"
-        errorLine2="                                         ~~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java"
-            line="214"
-            column="42"/>
-    </issue>
 
-    <issue
-        id="NewApi"
-        message="Field requires API level 29 (current min is 24): `android.graphics.Insets#top`"
-        errorLine1="            params.height = bars.top;"
-        errorLine2="                            ~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java"
-            line="215"
-            column="29"/>
-    </issue>
 
-    <issue
-        id="NewApi"
-        message="Field requires API level 29 (current min is 24): `android.graphics.Insets#left`"
-        errorLine1="            params.leftMargin = bars.left;"
-        errorLine2="                                ~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java"
-            line="216"
-            column="33"/>
-    </issue>
 
-    <issue
-        id="NewApi"
-        message="Field requires API level 29 (current min is 24): `android.graphics.Insets#right`"
-        errorLine1="            params.rightMargin = bars.right;"
-        errorLine2="                                 ~~~~~~~~~~">
-        <location
-            file="src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java"
-            line="217"
-            column="34"/>
-    </issue>
 
     <issue
         id="OldTargetApi"
@@ -26930,4 +26870,73 @@
             column="13"/>
     </issue>
 
+    <issue
+        id="InconsistentLayout"
+        severity="Warning"
+        message="The id &quot;toolbar_delimiter_horizontal_guideline&quot; in layout &quot;activity_single_panel&quot; is missing from the following layout configurations: layout (present in layout-w600dp)"
+        category="Correctness"
+        priority="6"
+        summary="Inconsistent Layouts"
+        explanation="This check ensures that a layout resource which is defined in multiple resource folders, specifies the same set of widgets.&#xA;&#xA;This finds cases where you have accidentally forgotten to add a widget to all variations of the layout, which could result in a runtime crash for some resource configurations when a `findViewById()` fails.&#xA;&#xA;There **are** cases where this is intentional. For example, you may have a dedicated large tablet layout which adds some extra widgets that are not present in the phone version of the layout. As long as the code accessing the layout resource is careful to handle this properly, it is valid. In that case, you can suppress this lint check for the given extra or missing views, or the whole layout"
+        errorLine1="        android:id=&quot;@+id/toolbar_delimiter_horizontal_guideline&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="C:\Users\herre\code\moneywallet\app\src\main\res\layout-w600dp\activity_single_panel.xml"
+            line="35"
+            column="9"
+            message="Occurrence in layout-w600dp"/>
+    </issue>
+    <issue
+        id="InconsistentLayout"
+        severity="Warning"
+        message="The id &quot;toolbar_delimiter_horizontal_guideline&quot; in layout &quot;activity_single_panel_appbar&quot; is missing from the following layout configurations: layout (present in layout-w600dp)"
+        category="Correctness"
+        priority="6"
+        summary="Inconsistent Layouts"
+        explanation="This check ensures that a layout resource which is defined in multiple resource folders, specifies the same set of widgets.&#xA;&#xA;This finds cases where you have accidentally forgotten to add a widget to all variations of the layout, which could result in a runtime crash for some resource configurations when a `findViewById()` fails.&#xA;&#xA;There **are** cases where this is intentional. For example, you may have a dedicated large tablet layout which adds some extra widgets that are not present in the phone version of the layout. As long as the code accessing the layout resource is careful to handle this properly, it is valid. In that case, you can suppress this lint check for the given extra or missing views, or the whole layout"
+        errorLine1="        android:id=&quot;@+id/toolbar_delimiter_horizontal_guideline&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="C:\Users\herre\code\moneywallet\app\src\main\res\layout-w600dp\activity_single_panel_appbar.xml"
+            line="35"
+            column="9"
+            message="Occurrence in layout-w600dp"/>
+    </issue>
+    <issue
+        id="InconsistentLayout"
+        severity="Warning"
+        message="The id &quot;toolbar_delimiter_horizontal_guideline&quot; in layout &quot;activity_single_panel_scroll&quot; is missing from the following layout configurations: layout (present in layout-w600dp)"
+        category="Correctness"
+        priority="6"
+        summary="Inconsistent Layouts"
+        explanation="This check ensures that a layout resource which is defined in multiple resource folders, specifies the same set of widgets.&#xA;&#xA;This finds cases where you have accidentally forgotten to add a widget to all variations of the layout, which could result in a runtime crash for some resource configurations when a `findViewById()` fails.&#xA;&#xA;There **are** cases where this is intentional. For example, you may have a dedicated large tablet layout which adds some extra widgets that are not present in the phone version of the layout. As long as the code accessing the layout resource is careful to handle this properly, it is valid. In that case, you can suppress this lint check for the given extra or missing views, or the whole layout"
+        errorLine1="        android:id=&quot;@+id/toolbar_delimiter_horizontal_guideline&quot;"
+        errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="C:\Users\herre\code\moneywallet\app\src\main\res\layout-w600dp\activity_single_panel_scroll.xml"
+            line="35"
+            column="9"
+            message="Occurrence in layout-w600dp"/>
+    </issue>
+    <issue
+        id="InconsistentLayout"
+        severity="Warning"
+        message="The id &quot;toolbar_delimiter_horizontal_guideline&quot; in layout &quot;fragment_multi_panel&quot; is missing from the following layout configurations: layout (present in layout-w600dp, layout-w840dp)"
+        category="Correctness"
+        priority="6"
+        summary="Inconsistent Layouts"
+        explanation="This check ensures that a layout resource which is defined in multiple resource folders, specifies the same set of widgets.&#xA;&#xA;This finds cases where you have accidentally forgotten to add a widget to all variations of the layout, which could result in a runtime crash for some resource configurations when a `findViewById()` fails.&#xA;&#xA;There **are** cases where this is intentional. For example, you may have a dedicated large tablet layout which adds some extra widgets that are not present in the phone version of the layout. As long as the code accessing the layout resource is careful to handle this properly, it is valid. In that case, you can suppress this lint check for the given extra or missing views, or the whole layout"
+        errorLine1="            android:id=&quot;@+id/toolbar_delimiter_horizontal_guideline&quot;"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="C:\Users\herre\code\moneywallet\app\src\main\res\layout-w600dp\fragment_multi_panel.xml"
+            line="41"
+            column="13"
+            message="Occurrence in layout-w600dp"/>
+        <location
+            file="C:\Users\herre\code\moneywallet\app\src\main\res\layout-w840dp\fragment_multi_panel.xml"
+            line="41"
+            column="9"
+            message="Occurrence in layout-w840dp"/>
+    </issue>
 </issues>

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/CalculatorActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/CalculatorActivity.java
@@ -34,8 +34,10 @@ import android.widget.EditText;
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.CurrencyUnit;
 import com.oriondev.moneywallet.ui.activity.base.SinglePanelActivity;
+import com.oriondev.moneywallet.ui.view.theme.ITheme;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.utils.EquationSolver;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 /**
  * Created by andre on 23/03/2018.
@@ -102,9 +104,22 @@ public class CalculatorActivity extends SinglePanelActivity implements View.OnCl
     private boolean mAllowNegative;
     private boolean mRendering;
 
+    /**
+     * The keypad fills the bottom of this screen and carries the primary color, so that is what is
+     * behind the navigation bar here, not the list background the base class assumes.
+     */
+    @Override
+    protected int getColorBehindNavigationBar(ITheme theme) {
+        return theme.getColorPrimary();
+    }
+
     @Override
     protected void onCreatePanelView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.layout_panel_calculator, parent, true);
+        // The keypad fills the lower half of the window and nothing here scrolls, so the keys
+        // would otherwise sit partly under the navigation bar.
+        SystemBars.pad(view.findViewById(R.id.keypad_container),
+                false, getResources().getBoolean(R.bool.panel_fills_window), true);
         mDisplayEditText = view.findViewById(R.id.display_text_view);
         // The keypad is the only writer of the field, and the filter refuses every other change.
         // The field's own state restore would go through that filter and come back empty, so the

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/CurrencyConverterActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/CurrencyConverterActivity.java
@@ -46,8 +46,10 @@ import com.oriondev.moneywallet.picker.CurrencyPicker;
 import com.oriondev.moneywallet.service.AbstractCurrencyRateDownloadIntentService;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.activity.base.SinglePanelActivity;
+import com.oriondev.moneywallet.ui.view.theme.ITheme;
 import com.oriondev.moneywallet.utils.CurrencyManager;
 import com.oriondev.moneywallet.utils.MoneyFormatter;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 import java.math.BigDecimal;
 
@@ -98,9 +100,23 @@ public class CurrencyConverterActivity extends SinglePanelActivity implements Vi
         return false;
     }
 
+    /**
+     * The keypad fills the bottom of this screen and carries the primary color, so that is what is
+     * behind the navigation bar here, not the list background the base class assumes.
+     */
+    @Override
+    protected int getColorBehindNavigationBar(ITheme theme) {
+        return theme.getColorPrimary();
+    }
+
     @Override
     protected void onCreatePanelView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.layout_panel_currency_converter, parent, true);
+        // The bottom row of keys reaches the bottom of the window and cannot be scrolled out of the
+        // way of the navigation bar. It carries the primary color, so the color keeps running under
+        // the bar and only the keys move up.
+        SystemBars.pad(view.findViewById(R.id.keypad_last_row),
+                false, getResources().getBoolean(R.bool.panel_fills_window), true);
         mImageCurrencyFrom = view.findViewById(R.id.image_currency_from);
         mImageCurrencyTo = view.findViewById(R.id.image_currency_to);
         mTextCurrencyFrom = view.findViewById(R.id.text_currency_from);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/LauncherActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/LauncherActivity.java
@@ -41,7 +41,9 @@ import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.activity.base.ThemedActivity;
+import com.oriondev.moneywallet.ui.view.theme.ITheme;
 import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 import java.util.Arrays;
 
@@ -58,11 +60,21 @@ public class LauncherActivity extends ThemedActivity {
 
     private View mProgressWheel;
 
+    /**
+     * Neither screen this activity shows has a toolbar. Both paint the window foreground across the
+     * whole window, so that is what is behind both bars and the icons have to be picked for it.
+     */
+    @Override
+    protected int getColorBehindStatusBar(ITheme theme) {
+        return theme.getColorWindowForeground();
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (UpgradeLegacyEditionIntentService.isLegacyEditionDetected(this)) {
             setContentView(R.layout.activity_launcher_legacy_edition_upgrade);
+            SystemBars.pad(findViewById(R.id.legacy_upgrade_layout), true, true, true);
             mProgressWheel = findViewById(R.id.progress_wheel);
             // prepare the broadcast receiver
             IntentFilter intentFilter = new IntentFilter();
@@ -81,6 +93,7 @@ public class LauncherActivity extends ThemedActivity {
         } else {
             if (isFirstStart()) {
                 setContentView(R.layout.activity_launcher_first_start);
+                SystemBars.pad(findViewById(R.id.first_start_layout), true, true, true);
                 Button firstStartButton = findViewById(R.id.first_start_button);
                 Button restoreBackupButton = findViewById(R.id.restore_backup_button);
                 firstStartButton.setOnClickListener(new View.OnClickListener() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/LockActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/LockActivity.java
@@ -41,6 +41,8 @@ import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.LockMode;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.activity.base.ThemedActivity;
+import com.oriondev.moneywallet.ui.view.theme.ITheme;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 import java.util.List;
 
@@ -232,8 +234,23 @@ public class LockActivity extends ThemedActivity {
         }
     }
 
+    /**
+     * This screen has no toolbar and no list. It paints the primary color over the whole window,
+     * so that is what is behind both bars.
+     */
+    @Override
+    protected int getColorBehindStatusBar(ITheme theme) {
+        return theme.getColorPrimary();
+    }
+
+    @Override
+    protected int getColorBehindNavigationBar(ITheme theme) {
+        return theme.getColorPrimary();
+    }
+
     private void initializeUi(Bundle savedInstanceState) {
         setContentView(R.layout.activity_lock);
+        SystemBars.pad(findViewById(R.id.lock_layout), true, true, true);
         mPinLayout = findViewById(R.id.pin_layout);
         mPinHelpTextView = findViewById(R.id.pin_help_text_view);
         IndicatorDots indicatorDotsView = findViewById(R.id.indicator_dots);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MainActivity.java
@@ -42,6 +42,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.ActionBarDrawerToggle;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.content.ContextCompat;
 import androidx.core.graphics.ColorUtils;
 import androidx.core.graphics.drawable.DrawableCompat;
 import androidx.core.view.GravityCompat;
@@ -92,6 +93,7 @@ import com.oriondev.moneywallet.ui.view.theme.ThemedDialog;
 import com.oriondev.moneywallet.ui.view.theme.ThemedRecyclerView;
 import com.oriondev.moneywallet.utils.IconLoader;
 import com.oriondev.moneywallet.utils.MoneyFormatter;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -141,6 +143,7 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
     private NavigationView mNavigationView;
     private ActionBarDrawerToggle mDrawerToggle;
     private View mHeaderView;
+
     private ImageView mWalletIconView;
     private ImageView mFirstWalletView;
     private ImageView mSecondWalletView;
@@ -178,7 +181,23 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
      */
     private void initializeNavigationDrawer() {
         mDrawerLayout = findViewById(R.id.drawer_layout);
+        // Here and not beside the toggle in setToolbar, which every section calls, so a listener
+        // added there would be added again on each one and never taken off.
+        mDrawerLayout.addDrawerListener(new DrawerLayout.SimpleDrawerListener() {
+
+            @Override
+            public void onDrawerOpened(View drawerView) {
+                onThemeSystemBarIcons(ThemeEngine.getTheme());
+            }
+
+            @Override
+            public void onDrawerClosed(View drawerView) {
+                onThemeSystemBarIcons(ThemeEngine.getTheme());
+            }
+
+        });
         mNavigationView = findViewById(R.id.navigation_view);
+        SystemBars.padDrawerStart(mDrawerLayout, mNavigationView);
         mNavigationView.setNavigationItemSelectedListener(this);
         // the section icons are tinted one by one below, so the wallet icons keep their colors
         mNavigationView.setItemIconTintList(null);
@@ -202,6 +221,10 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
         addEntry(menu, GROUP_SETTINGS, ID_SECTION_SETTING, R.drawable.ic_settings_24dp, R.string.menu_setting).setCheckable(true);
         addEntry(menu, GROUP_SETTINGS, ID_SECTION_ABOUT, R.drawable.ic_info_outline_24dp, R.string.menu_about);
         mHeaderView = mNavigationView.getHeaderView(0);
+        // Top only, to match the menu below it. The navigation view pads its own list from the
+        // top and bottom and leaves the sides to its inset scrims, so a header that also took
+        // the sides would sit inset from the rows under it.
+        SystemBars.pad(mHeaderView, true, false, false);
         mHeaderView.setOnClickListener(view -> showWalletList(!mWalletListShown));
         mWalletIconView = mHeaderView.findViewById(R.id.wallet_icon_image_view);
         mFirstWalletView = mHeaderView.findViewById(R.id.first_wallet_image_view);
@@ -495,6 +518,9 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
      * @param identifier of the section.
      */
     private void loadSection(int identifier) {
+        // The outgoing screen may have left the icons set for a scrolled panel, and nothing
+        // else runs on this path.
+        resetStatusBarIconsToAppBar();
         FragmentManager manager = getSupportFragmentManager();
         String tag = getTagById(identifier);
         mCurrentFragment = manager.findFragmentByTag(tag);
@@ -762,14 +788,19 @@ public class MainActivity extends BaseActivity implements DrawerController, Navi
     }
 
     /**
-     * Below Android 15 the drawer slides under a see through status bar and the drawer layout
-     * paints the band behind it, so the window's own color is cleared here. From Android 15 the
-     * base class pads the content and paints that band itself.
+     * An open drawer covers the toolbar, and the menu scrolls under the status bar, so what is up
+     * there is the drawer's own scrim over its background, not anything the rest of the app
+     * painted. The two are composited here instead of guessed, since the drawer background follows
+     * the theme and the scrim does not. The drawer is asked directly, because a drawer restored
+     * already open after a rotation never fires the opened callback.
      */
     @Override
-    protected void onThemeStatusBar(ITheme theme) {
-        getWindow().setStatusBarColor(Color.TRANSPARENT);
-        mDrawerLayout.setStatusBarBackgroundColor(theme.getColorPrimaryDark());
+    protected int getColorBehindStatusBar(ITheme theme) {
+        if (!mDrawerLayout.isDrawerOpen(GravityCompat.START)) {
+            return super.getColorBehindStatusBar(theme);
+        }
+        int scrim = ContextCompat.getColor(this, R.color.system_bar_scrim_dark);
+        return ColorUtils.compositeColors(scrim, theme.getDrawerBackgroundColor());
     }
 
     private BroadcastReceiver mBroadcastReceiver = new BroadcastReceiver() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/MapActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/MapActivity.java
@@ -56,6 +56,8 @@ public class MapActivity extends SinglePanelActivity implements LoaderManager.Lo
     protected void onCreatePanelView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.layout_panel_map, parent, true);
         mMapView = new MapViewWrapper(view.findViewById(R.id.map_view));
+        // This map fills the panel down to the bottom of the window.
+        mMapView.keepCopyrightClearOfSystemBars();
         mMapView.onCreate(savedInstanceState);
         mMapView.loadMapAsync(this);
     }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/TutorialActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/TutorialActivity.java
@@ -24,14 +24,13 @@ import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Color;
-import android.graphics.Insets;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
-import android.view.WindowInsets;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.StringRes;
+import androidx.core.view.ViewGroupCompat;
+import androidx.core.view.WindowCompat;
 import androidx.fragment.app.Fragment;
 
 import com.github.paolorotolo.appintro.AppIntro2;
@@ -44,6 +43,7 @@ import com.oriondev.moneywallet.model.Icon;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.utils.IconLoader;
+import com.oriondev.moneywallet.utils.SystemBars;
 import com.oriondev.moneywallet.utils.Utils;
 
 import java.util.ArrayList;
@@ -59,6 +59,7 @@ public class TutorialActivity extends AppIntro2 {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        WindowCompat.enableEdgeToEdge(getWindow());
         addSlide(R.drawable.ic_intro_slide_1, R.string.activity_intro_title_slide_1, R.string.activity_intro_description_slide_1, Color.parseColor("#76bec0"));
         addSlide(R.drawable.ic_intro_slide_2, R.string.activity_intro_title_slide_2, R.string.activity_intro_description_slide_2, Color.parseColor("#8464a9"));
         addSlide(R.drawable.ic_intro_slide_3, R.string.activity_intro_title_slide_3, R.string.activity_intro_description_slide_3, Color.parseColor("#19beed"));
@@ -69,25 +70,23 @@ public class TutorialActivity extends AppIntro2 {
         applySystemBarInsets();
     }
 
-    // This intro screen does not go through ThemedActivity (it extends the AppIntro base class), so it
-    // needs its own edge to edge handling on Android 15 (API 35), otherwise the bottom navigation with
-    // the Next and Done actions sits under the navigation bar. Pad the content with the system bar and
-    // display cutout insets so those controls stay reachable.
+    // This intro screen does not go through ThemedActivity, it extends the AppIntro base class, so it
+    // asks for edge to edge itself. Only the bar holding Skip, Next and Done is held clear of the
+    // navigation bar; the slides keep their full bleed colors, which is what the color transition
+    // between them is for. The status bar is hidden here, so nothing is owed at the top.
     private void applySystemBarInsets() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        View content = findViewById(android.R.id.content);
+        if (content != null) {
+            // Below Android 11 the first child to consume an inset stops its siblings from seeing
+            // it, and something in the intro's own layout does. Without this the bar below never
+            // hears about the navigation bar at all, which is what it looked like on Android 7.
+            ViewGroupCompat.installCompatInsetsDispatch(content);
+        }
+        View bottomBar = findViewById(com.github.paolorotolo.appintro.R.id.bottom);
+        if (bottomBar == null) {
             return;
         }
-        final View content = findViewById(android.R.id.content);
-        if (content == null) {
-            return;
-        }
-        content.setOnApplyWindowInsetsListener((view, insets) -> {
-            Insets bars = insets.getInsets(WindowInsets.Type.systemBars()
-                    | WindowInsets.Type.displayCutout());
-            view.setPadding(bars.left, bars.top, bars.right, bars.bottom);
-            return WindowInsets.CONSUMED;
-        });
-        content.requestApplyInsets();
+        SystemBars.pad(bottomBar, false, true, true);
     }
 
     private void addSlide(@DrawableRes int drawable, @StringRes int title, @StringRes int description, int backgroundColor) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/base/SinglePanelActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/base/SinglePanelActivity.java
@@ -32,6 +32,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.utils.SystemBars;
 import com.oriondev.moneywallet.utils.Utils;
 
 /**
@@ -46,6 +47,8 @@ public abstract class SinglePanelActivity extends BaseActivity implements Toolba
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         onInflateRootLayout();
+        // Only the width qualified copies of these layouts carry one.
+        SystemBars.offsetGuidelineByStatusBar(findViewById(R.id.toolbar_delimiter_horizontal_guideline));
         onSetupRootLayout();
         onConfigureRootLayout(savedInstanceState);
         onSetupFloatingActionButton(mFloatingActionButton);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/base/SinglePanelScrollActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/base/SinglePanelScrollActivity.java
@@ -24,6 +24,7 @@ import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.view.theme.ITheme;
 import com.oriondev.moneywallet.utils.Utils;
 
 /**
@@ -47,6 +48,7 @@ public abstract class SinglePanelScrollActivity extends SinglePanelActivity {
         );
         onCreateHeaderView(inflater, headerContainer, savedInstanceState);
         onCreatePanelView(inflater, panelContainer, savedInstanceState);
+        followScrollForStatusBarIcons(findViewById(R.id.primary_panel_scroll_view), headerContainer);
     }
 
     protected abstract void onCreateHeaderView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/activity/base/ThemedActivity.java
@@ -28,14 +28,15 @@ import android.os.Bundle;
 import android.util.AttributeSet;
 import androidx.annotation.CallSuper;
 import androidx.annotation.Nullable;
-import android.graphics.Insets;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.content.ContextCompat;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.ViewGroupCompat;
+import androidx.core.view.WindowCompat;
+import androidx.core.view.WindowInsetsCompat;
+import androidx.core.view.WindowInsetsControllerCompat;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Gravity;
-import android.view.WindowInsets;
-import android.view.WindowInsetsController;
-import android.widget.FrameLayout;
 
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.ui.view.theme.ITheme;
@@ -62,11 +63,15 @@ public abstract class ThemedActivity extends AppCompatActivity implements ThemeE
 
     private static final Map<String, Constructor<?>> sThemedViewConstructors = new HashMap<>();
 
-    private View mStatusBarScrim;
+    private boolean mAppBarScrolledPastStatusBar;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        // Both bars go transparent and the window stops reserving space for them, on every release
+        // and not only where Android 15 enforces it, so one arrangement covers the whole range.
+        // Each surface then asks for the insets it needs through SystemBars.
+        WindowCompat.enableEdgeToEdge(getWindow());
         ThemeEngine.registerObserver(this);
     }
 
@@ -131,92 +136,49 @@ public abstract class ThemedActivity extends AppCompatActivity implements ThemeE
         onThemeSetup(ThemeEngine.getTheme());
     }
 
-    // From Android 15 (API 35) edge to edge is enforced for apps targeting SDK 35: the system bars
-    // no longer reserve space, so without this the toolbar would sit under the status bar and the
-    // bottom controls (first run buttons, keypad, FABs) under the navigation bar. We opt the content
-    // back into the safe area by padding it with the system bar and display cutout insets, and paint
-    // the strip the status bar leaves behind ourselves, since setStatusBarColor does nothing at this
-    // target. Centralized here so every activity that goes through this base class inherits both.
-
     @Override
     public void setContentView(int layoutResID) {
         super.setContentView(layoutResID);
-        applySystemBarInsets();
+        applyKeyboardInset();
     }
 
     @Override
     public void setContentView(View view) {
         super.setContentView(view);
-        applySystemBarInsets();
+        applyKeyboardInset();
     }
 
     @Override
     public void setContentView(View view, ViewGroup.LayoutParams params) {
         super.setContentView(view, params);
-        applySystemBarInsets();
+        applyKeyboardInset();
     }
 
-    private void applySystemBarInsets() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            return;
-        }
+    /**
+     * The window no longer resizes itself for the keyboard once it stops fitting system windows, so
+     * the keyboard arrives as an inset and the content root is lifted by it here. Only the part of
+     * the keyboard that reaches past the navigation bar is taken, because whatever sits at the
+     * bottom of the screen has already asked SystemBars for the bar itself and the two would
+     * otherwise stack.
+     * <p>
+     * installCompatInsetsDispatch is what makes the rest of this work below Android 11. There the
+     * first child to consume an inset stops its siblings from ever seeing it, and this app has
+     * several windows where a drawer and a panel are siblings. It does nothing from Android 11 up,
+     * where the platform already hands every child the same insets.
+     */
+    private void applyKeyboardInset() {
         final View content = findViewById(android.R.id.content);
         if (content == null) {
             return;
         }
-        content.setOnApplyWindowInsetsListener((view, insets) -> {
-            Insets bars = insets.getInsets(WindowInsets.Type.systemBars()
-                    | WindowInsets.Type.displayCutout());
-            view.setPadding(bars.left, bars.top, bars.right, bars.bottom);
-            setStatusBarScrimBounds(bars);
-            return WindowInsets.CONSUMED;
+        ViewGroupCompat.installCompatInsetsDispatch(content);
+        ViewCompat.setOnApplyWindowInsetsListener(content, (view, insets) -> {
+            int keyboard = insets.getInsets(WindowInsetsCompat.Type.ime()).bottom;
+            int bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+            view.setPadding(0, 0, 0, Math.max(keyboard - bars, 0));
+            return insets;
         });
         content.requestApplyInsets();
-    }
-
-    /**
-     * The strip behind the status bar, painted by us because the platform no longer paints it. It
-     * lives in the decor and not in any layout, so it covers the padding applied above on every
-     * screen and needs no change to a layout to reach a new one. It is added last, which puts it
-     * over the navigation drawer the way the platform's own status bar tint used to sit over it.
-     * <p>
-     * Its bounds come from the insets, so it is zero high where the bar takes no space, and the
-     * color comes from onThemeStatusBarScrim. Below API 35 nothing here runs, the platform still
-     * paints the bar from setStatusBarColor, and on the main screen the drawer paints its own.
-     */
-    private View getStatusBarScrim() {
-        if (mStatusBarScrim == null) {
-            View decor = getWindow().getDecorView();
-            if (!(decor instanceof ViewGroup)) {
-                return null;
-            }
-            mStatusBarScrim = new View(this);
-            ((ViewGroup) decor).addView(mStatusBarScrim, new FrameLayout.LayoutParams(
-                    FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.TOP));
-        }
-        return mStatusBarScrim;
-    }
-
-    /**
-     * Sized and inset by the same insets the content above is padded by, so the band caps the
-     * content exactly. Every edge the content is held out of, the band is held out of too. That
-     * matters on a device with a display cutout down one side, where the content is letterboxed
-     * away from the curve or the notch, and a band run to the full window width would overhang
-     * that letterbox and leave a window background sliver under a colored bar.
-     */
-    private void setStatusBarScrimBounds(Insets bars) {
-        View scrim = getStatusBarScrim();
-        if (scrim == null) {
-            return;
-        }
-        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) scrim.getLayoutParams();
-        if (params.height != bars.top || params.leftMargin != bars.left
-                || params.rightMargin != bars.right) {
-            params.height = bars.top;
-            params.leftMargin = bars.left;
-            params.rightMargin = bars.right;
-            scrim.setLayoutParams(params);
-        }
     }
 
     @Override
@@ -244,56 +206,107 @@ public abstract class ThemedActivity extends AppCompatActivity implements ThemeE
     }
 
     private void setupActivityBaseTheme(ITheme theme) {
-        onThemeStatusBar(theme);
-        onThemeStatusBarScrim(theme);
-        onThemeStatusBarIcons(theme);
+        onThemeSystemBarScrim(theme);
+        onThemeSystemBarIcons(theme);
         onThemeTaskDescription(theme);
         onThemeWindowBackground(theme);
     }
 
-    protected void onThemeStatusBar(ITheme theme) {
-        getWindow().setStatusBarColor(theme.getColorPrimaryDark());
+    /**
+     * The color the app itself draws behind the status bar. On nearly every screen that is the
+     * toolbar, which now runs under the bar instead of stopping below it. A screen where something
+     * else ends up there says so by overriding this, and the icon color follows.
+     */
+    protected int getColorBehindStatusBar(ITheme theme) {
+        return mAppBarScrolledPastStatusBar
+                ? theme.getColorWindowForeground() : theme.getColorPrimary();
     }
 
     /**
-     * Kept apart from onThemeStatusBar because the main screen overrides that one to color the
-     * drawer's own status bar background instead, and does not call through. The strip has to be
-     * painted on every screen, that one included.
+     * For the screens that put their toolbar inside the scrolling content, the new and edit forms
+     * and the detail panels, where it leaves the top of the window as soon as the user scrolls and
+     * the content behind the status bar changes color underneath them. Without this the icons stay
+     * chosen for the toolbar and go white on a white form.
+     * <p>
+     * Does nothing when the app bar is not inside the scroller, which is how the wide layouts are
+     * built, there the app bar belongs to the window and never moves, so the answer never changes.
      */
-    protected void onThemeStatusBarScrim(ITheme theme) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            View scrim = getStatusBarScrim();
-            if (scrim != null) {
-                scrim.setBackgroundColor(theme.getColorPrimaryDark());
-            }
+    public void followScrollForStatusBarIcons(View scroller, View appBar) {
+        if (scroller == null || appBar == null || !isDescendant(scroller, appBar)) {
+            return;
+        }
+        scroller.setOnScrollChangeListener(
+                (view, x, y, oldX, oldY) -> updateStatusBarIconsForScroll(scroller, appBar));
+        // A rotation restores the scroll position without a scroll event, so the answer has to be
+        // worked out again once the restored geometry exists.
+        scroller.addOnLayoutChangeListener(
+                (v, l, t, r, b, ol, ot, or_, ob) -> updateStatusBarIconsForScroll(scroller, appBar));
+    }
+
+    private void updateStatusBarIconsForScroll(View scroller, View appBar) {
+        WindowInsetsCompat insets = ViewCompat.getRootWindowInsets(scroller);
+        int statusBar = insets == null ? 0
+                : insets.getInsets(WindowInsetsCompat.Type.statusBars()).top;
+        boolean past = appBar.getBottom() - scroller.getScrollY() <= statusBar;
+        if (past != mAppBarScrolledPastStatusBar) {
+            mAppBarScrolledPastStatusBar = past;
+            onThemeSystemBarIcons(ThemeEngine.getTheme());
         }
     }
 
-    protected void onThemeStatusBarIcons(ITheme theme) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-            // The status bar sits over the scrim painted above, so its icons follow that color while
-            // the navigation bar, which nothing paints, still follows the window background.
-            WindowInsetsController controller = getWindow().getInsetsController();
-            if (controller != null) {
-                int statusMask = WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS;
-                int navigationMask = WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS;
-                controller.setSystemBarsAppearance(
-                        Utils.isColorLight(theme.getColorPrimaryDark()) ? statusMask : 0, statusMask);
-                controller.setSystemBarsAppearance(
-                        Utils.isColorLight(theme.getColorWindowBackground()) ? navigationMask : 0,
-                        navigationMask);
-            }
-        } else {
-            View decorView = getWindow().getDecorView();
-            int systemUiVisibility = decorView.getSystemUiVisibility();
-            int statusBarColor = theme.getColorPrimaryDark();
-            boolean isStatusBarLight = Utils.isColorLight(statusBarColor);
-            if (isStatusBarLight) {
-                decorView.setSystemUiVisibility(systemUiVisibility | View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
-            } else {
-                decorView.setSystemUiVisibility(systemUiVisibility & ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR);
+    /**
+     * A screen whose toolbar scrolls away hands the icon color back when it leaves. A panel is
+     * closed by being made invisible, so no scroll event says the toolbar is back at the top and
+     * nothing else would put the icons right.
+     */
+    public void resetStatusBarIconsToAppBar() {
+        if (mAppBarScrolledPastStatusBar) {
+            mAppBarScrolledPastStatusBar = false;
+            onThemeSystemBarIcons(ThemeEngine.getTheme());
+        }
+    }
+
+    private static boolean isDescendant(View ancestor, View view) {
+        for (Object parent = view.getParent(); parent instanceof View; parent = ((View) parent).getParent()) {
+            if (parent == ancestor) {
+                return true;
             }
         }
+        return false;
+    }
+
+    /**
+     * The color the app itself draws behind the navigation bar, which on a scrolling screen is the
+     * content the list is drawn on.
+     */
+    protected int getColorBehindNavigationBar(ITheme theme) {
+        return theme.getColorWindowForeground();
+    }
+
+    /**
+     * What keeps three button navigation readable over the content is the icon color, and
+     * onThemeSystemBarIcons below picks that from whatever the app draws behind the bar. That only
+     * works from Android 8, which is the first release that can put dark icons on the navigation
+     * bar; before it they are always white, so a pale list needs a scrim under them instead.
+     * <p>
+     * From Android 8 up the bar is left fully transparent. Asking the platform to enforce contrast
+     * instead would paint a band over the bottom of every list, which is the letterbox this whole
+     * change exists to remove.
+     */
+    protected void onThemeSystemBarScrim(ITheme theme) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return;
+        }
+        getWindow().setNavigationBarColor(
+                ContextCompat.getColor(this, R.color.system_bar_scrim_dark));
+    }
+
+    protected void onThemeSystemBarIcons(ITheme theme) {
+        WindowInsetsControllerCompat controller =
+                WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
+        controller.setAppearanceLightStatusBars(Utils.isColorLight(getColorBehindStatusBar(theme)));
+        controller.setAppearanceLightNavigationBars(
+                Utils.isColorLight(getColorBehindNavigationBar(theme)));
     }
 
     protected void onThemeTaskDescription(ITheme theme) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/behavior/ScrollingFloatingActionButtonBehavior.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/behavior/ScrollingFloatingActionButtonBehavior.java
@@ -20,8 +20,6 @@
 package com.oriondev.moneywallet.ui.behavior;
 
 import android.content.Context;
-import android.content.res.TypedArray;
-import com.google.android.material.appbar.AppBarLayout;
 import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.snackbar.Snackbar;
@@ -33,34 +31,23 @@ import com.oriondev.moneywallet.R;
 import java.util.List;
 
 /**
- * This class implements a custom behavior of the Floating Action Button when attached to a
- * CoordinatorLayout: it allows to show and hide the fab when a nested view is scrolled.
+ * A custom behavior for the Floating Action Button when it is attached to a CoordinatorLayout. It
+ * shrinks the button as a snackbar comes up under it, so the two do not overlap.
  */
 public class ScrollingFloatingActionButtonBehavior extends CoordinatorLayout.Behavior<FloatingActionButton> {
 
-    private int mToolbarHeight;
-
     public ScrollingFloatingActionButtonBehavior(Context context, AttributeSet attrs) {
         super(context, attrs);
-        TypedArray styledAttributes = context.getTheme().obtainStyledAttributes(new int[]{android.R.attr.actionBarSize});
-        mToolbarHeight = (int) styledAttributes.getDimension(0, 0);
-        styledAttributes.recycle();
     }
 
     @Override
     public boolean layoutDependsOn(CoordinatorLayout parent, FloatingActionButton fab, View dependency) {
-        return dependency instanceof AppBarLayout || dependency instanceof Snackbar.SnackbarLayout;
+        return dependency instanceof Snackbar.SnackbarLayout;
     }
 
     @Override
     public boolean onDependentViewChanged(CoordinatorLayout parent, FloatingActionButton fab, View dependency) {
-        if (dependency instanceof AppBarLayout) {
-            CoordinatorLayout.LayoutParams lp = (CoordinatorLayout.LayoutParams) fab.getLayoutParams();
-            int fabBottomMargin = lp.bottomMargin;
-            int distanceToScroll = fab.getHeight() + fabBottomMargin;
-            float ratio = dependency.getY() / (float) mToolbarHeight;
-            fab.setTranslationY(distanceToScroll * ratio * -1);
-        } else if (dependency instanceof Snackbar.SnackbarLayout) {
+        if (dependency instanceof Snackbar.SnackbarLayout) {
             float translationY = getFabTranslationYForSnackBar(parent, fab);
             float percentComplete = -translationY / dependency.getHeight();
             float scaleFactor = 1 - percentComplete;

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/CursorListFragment.java
@@ -37,7 +37,9 @@ import android.view.ViewGroup;
 import com.oriondev.moneywallet.storage.preference.CurrentWalletController;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.adapter.recycler.AbstractCursorAdapter;
+import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.ui.view.AdvancedRecyclerView;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 /**
  * Created by andrea on 11/02/18.
@@ -66,6 +68,11 @@ public abstract class CursorListFragment extends Fragment implements SwipeRefres
     @Nullable
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         mAdvancedRecyclerView = new AdvancedRecyclerView(getActivity());
+        // Built here and not inflated, so the layout attribute that asks for the navigation bar
+        // clearance never reaches it. These are the pager pages behind most of the drawer, so
+        // without this the last row of the app's main lists cannot be scrolled clear of the bar.
+        SystemBars.pad(mAdvancedRecyclerView.getRecyclerView(),
+                false, getResources().getBoolean(R.bool.panel_fills_window), true);
         onPrepareRecyclerView(mAdvancedRecyclerView);
         mAbstractCursorAdapter = onCreateAdapter();
         mAdvancedRecyclerView.setAdapter(mAbstractCursorAdapter);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/MultiPanelFragment.java
@@ -45,6 +45,8 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.utils.SystemBars;
+import com.oriondev.moneywallet.ui.activity.base.ThemedActivity;
 import com.oriondev.moneywallet.storage.database.Contract;
 import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.preference.CurrentWalletController;
@@ -103,6 +105,8 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
     @Nullable
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = onInflateRootLayout(inflater, container, savedInstanceState);
+        // Only the width qualified copies of these layouts carry one.
+        SystemBars.offsetGuidelineByStatusBar(view.findViewById(R.id.toolbar_delimiter_horizontal_guideline));
         onSetupRootLayout(view);
         onConfigureRootLayout(inflater, container, savedInstanceState);
         setupPrimaryToolbar(mPrimaryToolbar);
@@ -227,6 +231,9 @@ public abstract class MultiPanelFragment extends Fragment implements MultiPanelC
     }
 
     protected void hideSecondaryPanel() {
+        if (getActivity() instanceof ThemedActivity) {
+            ((ThemedActivity) getActivity()).resetStatusBarIconsToAppBar();
+        }
         if (!mExtendedLayout) {
             mSecondaryPanelVisible = false;
             mPrimaryPanel.setVisibility(View.VISIBLE);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SecondaryPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SecondaryPanelFragment.java
@@ -37,6 +37,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.ui.activity.base.ThemedActivity;
 import com.oriondev.moneywallet.storage.database.SQLiteDataException;
 import com.oriondev.moneywallet.utils.Utils;
 
@@ -79,6 +80,10 @@ public abstract class SecondaryPanelFragment extends Fragment implements Toolbar
         ViewGroup bodyLayout = view.findViewById(R.id.body_secondary_panel_layout);
         onCreateHeaderView(inflater, headerLayout, savedInstanceState);
         onCreateBodyView(inflater, bodyLayout, savedInstanceState);
+        if (getActivity() instanceof ThemedActivity) {
+            ((ThemedActivity) getActivity()).followScrollForStatusBarIcons(
+                    view.findViewById(R.id.main_screen_secondary_panel_scroll_view), headerLayout);
+        }
         if (mToolbar != null) {
             if (getParentFragment() instanceof MultiPanelController && !((MultiPanelController) getParentFragment()).isExtendedLayout()) {
                 mToolbar.setNavigationIcon(R.drawable.ic_arrow_back_black_24dp);

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SinglePanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/base/SinglePanelFragment.java
@@ -48,6 +48,7 @@ import com.oriondev.moneywallet.storage.database.DataContentProvider;
 import com.oriondev.moneywallet.storage.preference.CurrentWalletController;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
 import com.oriondev.moneywallet.ui.activity.ToolbarController;
+import com.oriondev.moneywallet.utils.SystemBars;
 import com.oriondev.moneywallet.utils.Utils;
 
 /**
@@ -91,6 +92,8 @@ public abstract class SinglePanelFragment extends Fragment implements Toolbar.On
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.activity_single_panel, container, false);
+        // Only the width qualified copies of these layouts carry one.
+        SystemBars.offsetGuidelineByStatusBar(view.findViewById(R.id.toolbar_delimiter_horizontal_guideline));
         mToolbar = view.findViewById(R.id.primary_toolbar);
         ViewGroup parent = Utils.findViewGroupByIds(view,
                 R.id.primary_panel_container_frame_layout,

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/DatabaseSettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/DatabaseSettingFragment.java
@@ -31,6 +31,7 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.utils.SystemBars;
 import com.oriondev.moneywallet.ui.activity.BackupListActivity;
 import com.oriondev.moneywallet.ui.activity.ImportExportActivity;
 
@@ -93,6 +94,10 @@ public class DatabaseSettingFragment extends PreferenceFragmentCompat {
     public RecyclerView onCreateRecyclerView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         RecyclerView recyclerView = super.onCreateRecyclerView(inflater, parent, savedInstanceState);
         recyclerView.setPadding(0, 0, 0, 0);
+        // After the reset above, not before it, or the navigation bar clearance is the
+        // padding that gets zeroed.
+        SystemBars.pad(recyclerView,
+                false, getResources().getBoolean(R.bool.secondary_panel_fills_window), true);
         return recyclerView;
     }
 }

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UserInterfaceSettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UserInterfaceSettingFragment.java
@@ -38,6 +38,7 @@ import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Group;
 import com.oriondev.moneywallet.picker.ColorPicker;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.utils.SystemBars;
 import com.oriondev.moneywallet.ui.fragment.dialog.CustomDigitSetupDialog;
 import com.oriondev.moneywallet.ui.preference.ColorPreference;
 import com.oriondev.moneywallet.ui.preference.ThemedListPreference;
@@ -295,6 +296,10 @@ public class UserInterfaceSettingFragment extends PreferenceFragmentCompat imple
     public RecyclerView onCreateRecyclerView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         RecyclerView recyclerView = super.onCreateRecyclerView(inflater, parent, savedInstanceState);
         recyclerView.setPadding(0, 0, 0, 0);
+        // After the reset above, not before it, or the navigation bar clearance is the
+        // padding that gets zeroed.
+        SystemBars.pad(recyclerView,
+                false, getResources().getBoolean(R.bool.secondary_panel_fills_window), true);
         return recyclerView;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UtilitySettingFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/secondary/UtilitySettingFragment.java
@@ -48,6 +48,7 @@ import com.oriondev.moneywallet.broadcast.LocalAction;
 import com.oriondev.moneywallet.model.LockMode;
 import com.oriondev.moneywallet.service.AbstractCurrencyRateDownloadIntentService;
 import com.oriondev.moneywallet.storage.preference.PreferenceManager;
+import com.oriondev.moneywallet.utils.SystemBars;
 import com.oriondev.moneywallet.ui.activity.CurrencyListActivity;
 import com.oriondev.moneywallet.ui.activity.LockActivity;
 import com.oriondev.moneywallet.ui.preference.ThemedInputPreference;
@@ -314,6 +315,10 @@ public class UtilitySettingFragment extends PreferenceFragmentCompat {
     public RecyclerView onCreateRecyclerView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         RecyclerView recyclerView = super.onCreateRecyclerView(inflater, parent, savedInstanceState);
         recyclerView.setPadding(0, 0, 0, 0);
+        // After the reset above, not before it, or the navigation bar clearance is the
+        // padding that gets zeroed.
+        SystemBars.pad(recyclerView,
+                false, getResources().getBoolean(R.bool.secondary_panel_fills_window), true);
         return recyclerView;
     }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/single/AboutFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/single/AboutFragment.java
@@ -21,6 +21,12 @@ package com.oriondev.moneywallet.ui.fragment.single;
 
 import android.content.ActivityNotFoundException;
 import android.content.Context;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
 import android.content.Intent;
 import android.graphics.PorterDuff;
 import android.net.Uri;
@@ -43,6 +49,7 @@ import com.oriondev.moneywallet.ui.fragment.dialog.ChangeLogDialog;
 import com.oriondev.moneywallet.ui.fragment.dialog.LicenseDialog;
 import com.oriondev.moneywallet.ui.view.theme.ITheme;
 import com.oriondev.moneywallet.ui.view.theme.ThemeEngine;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -59,6 +66,21 @@ public class AboutFragment extends MaterialAboutFragment {
 
     private static final String TAG_CHANGE_LOG = "AboutFragment::Tag::ChangeLogDialog";
     private static final String TAG_LICENSE = "AboutFragment::Tag::LicenseDialog";
+
+    /**
+     * The list on this screen is built by the about library, not by a layout of ours, so it is
+     * reached through the library's own id once the view exists. Without this its last card sits
+     * under the navigation bar.
+     */
+    @Override
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = super.onCreateView(inflater, container, savedInstanceState);
+        if (view != null) {
+            SystemBars.pad(view.findViewById(com.danielstone.materialaboutlibrary.R.id.mal_recyclerview),
+                    false, getResources().getBoolean(R.bool.panel_fills_window), true);
+        }
+        return view;
+    }
 
     @Override
     protected MaterialAboutList getMaterialAboutList(Context context) {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/AdvancedRecyclerView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/AdvancedRecyclerView.java
@@ -20,6 +20,7 @@
 package com.oriondev.moneywallet.ui.view;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
@@ -30,6 +31,7 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 /**
  * Created by andrea on 26/01/18.
@@ -46,19 +48,37 @@ public class AdvancedRecyclerView extends SwipeRefreshLayout {
 
     public AdvancedRecyclerView(Context context) {
         super(context);
-        initialize(context);
+        initialize(context, null);
     }
 
     public AdvancedRecyclerView(@NonNull Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
-        initialize(context);
+        initialize(context, attrs);
     }
 
-    private void initialize(@NonNull Context context) {
+    /**
+     * The navigation bar inset is asked for here and not in view_advanced_recycler, because every
+     * instance in the app inflates that one file, an attribute set there would turn the inset on
+     * for all of them at once, and some of these lists are inside a secondary panel or a pager
+     * page where it does not belong.
+     */
+    private void initialize(@NonNull Context context, @Nullable AttributeSet attrs) {
         inflate(context, R.layout.view_advanced_recycler, this);
         mRecyclerView = findViewById(R.id.recycler_view);
         mProgressWheel = findViewById(R.id.progress_wheel);
         mEmptyTextView = findViewById(R.id.empty_text_view);
+        TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.AdvancedRecyclerView, 0, 0);
+        boolean insetSides;
+        boolean insetBottom;
+        try {
+            insetSides = typedArray.getBoolean(R.styleable.AdvancedRecyclerView_systemBarInsetSides, true);
+            insetBottom = typedArray.getBoolean(R.styleable.AdvancedRecyclerView_systemBarInsetBottom, false);
+        } finally {
+            typedArray.recycle();
+        }
+        if (insetBottom) {
+            SystemBars.pad(mRecyclerView, false, insetSides, true);
+        }
     }
 
     public RecyclerView getRecyclerView() {

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedAppBarLayout.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedAppBarLayout.java
@@ -21,8 +21,13 @@ package com.oriondev.moneywallet.ui.view.theme;
 
 import android.content.Context;
 import android.content.res.TypedArray;
-import com.google.android.material.appbar.AppBarLayout;
 import android.util.AttributeSet;
+import android.view.WindowInsets;
+
+import androidx.core.graphics.Insets;
+import androidx.core.view.WindowInsetsCompat;
+
+import com.google.android.material.appbar.AppBarLayout;
 
 import com.oriondev.moneywallet.R;
 
@@ -32,6 +37,12 @@ import com.oriondev.moneywallet.R;
 public class ThemedAppBarLayout extends AppBarLayout implements ThemeEngine.ThemeConsumer {
 
     private BackgroundColor mBackgroundColor;
+
+    private boolean mInsetSides;
+
+    private int mBasePaddingLeft;
+
+    private int mBasePaddingRight;
 
     public ThemedAppBarLayout(Context context) {
         super(context);
@@ -45,13 +56,45 @@ public class ThemedAppBarLayout extends AppBarLayout implements ThemeEngine.Them
 
     private void initialize(Context context, AttributeSet attrs) {
         TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.ThemedAppBarLayout, 0, 0);
+        boolean insetTop = true;
+        boolean insetSides = true;
         try {
             mBackgroundColor = BackgroundColor.fromValue(typedArray.getInt(R.styleable.ThemedAppBarLayout_theme_backgroundColor, 0));
+            insetTop = typedArray.getBoolean(R.styleable.ThemedAppBarLayout_systemBarInsetTop, true);
+            insetSides = typedArray.getBoolean(R.styleable.ThemedAppBarLayout_systemBarInsetSides, true);
         } catch (Exception e) {
             e.printStackTrace();
         } finally {
             typedArray.recycle();
         }
+        mInsetSides = insetSides;
+        mBasePaddingLeft = getPaddingLeft();
+        mBasePaddingRight = getPaddingRight();
+        if (insetTop) {
+            // AppBarLayout does the status bar itself when this is set, it grows by the inset,
+            // offsets its children down by it, and subtracts it from the range it will scroll. That
+            // last part is why this is not padding of ours. A bar with scroll flags carries its own
+            // padding away as it collapses, which slid the toolbar under the status bar on the
+            // tabbed screens; the inset the library keeps is pinned and cannot scroll off.
+            setFitsSystemWindows(true);
+        }
+    }
+
+    /**
+     * The sides are still ours, because the library only handles the top. Done around the dispatch
+     * instead of through a listener, the library installs its own listener in its constructor, and
+     * a second one would replace it and take the status bar handling above with it. The background
+     * is not shrunk by padding, so the bar still paints its color out to the edge of the display.
+     */
+    @Override
+    public WindowInsets dispatchApplyWindowInsets(WindowInsets insets) {
+        if (mInsetSides) {
+            Insets bars = WindowInsetsCompat.toWindowInsetsCompat(insets).getInsets(
+                    WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout());
+            setPadding(mBasePaddingLeft + bars.left, getPaddingTop(),
+                    mBasePaddingRight + bars.right, getPaddingBottom());
+        }
+        return super.dispatchApplyWindowInsets(insets);
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedFloatingActionButton.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedFloatingActionButton.java
@@ -21,15 +21,23 @@ package com.oriondev.moneywallet.ui.view.theme;
 
 import android.content.Context;
 import android.content.res.ColorStateList;
+import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
 import androidx.annotation.Nullable;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import android.util.AttributeSet;
 
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.utils.SystemBars;
+
 /**
  * Created by andrea on 11/04/18.
  */
 public class ThemedFloatingActionButton extends FloatingActionButton implements ThemeEngine.ThemeConsumer {
+
+    private boolean mInsetBottom = true;
+
+    private boolean mInsetApplied;
 
     public ThemedFloatingActionButton(Context context) {
         super(context);
@@ -37,10 +45,35 @@ public class ThemedFloatingActionButton extends FloatingActionButton implements 
 
     public ThemedFloatingActionButton(Context context, AttributeSet attrs) {
         super(context, attrs);
+        readInsetAttribute(context, attrs);
     }
 
     public ThemedFloatingActionButton(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        readInsetAttribute(context, attrs);
+    }
+
+    private void readInsetAttribute(Context context, AttributeSet attrs) {
+        TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.ThemedFloatingActionButton, 0, 0);
+        try {
+            mInsetBottom = typedArray.getBoolean(R.styleable.ThemedFloatingActionButton_systemBarInsetBottom, true);
+        } finally {
+            typedArray.recycle();
+        }
+    }
+
+    /**
+     * Not the constructor: the parent sets the layout params during inflation, after the view is
+     * built, so there is no margin to read yet at that point. Once only, because a second pass
+     * would read a margin that already carries the inset and treat it as the baseline.
+     */
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        if (mInsetBottom && !mInsetApplied) {
+            mInsetApplied = true;
+            SystemBars.marginBottomAndSides(this);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedRecyclerView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedRecyclerView.java
@@ -20,9 +20,13 @@
 package com.oriondev.moneywallet.ui.view.theme;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
 import android.util.AttributeSet;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 /**
  * Created by andrea on 20/08/18.
@@ -35,10 +39,27 @@ public class ThemedRecyclerView extends RecyclerView implements ThemeEngine.Them
 
     public ThemedRecyclerView(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
+        initialize(context, attrs);
     }
 
     public ThemedRecyclerView(Context context, @Nullable AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        initialize(context, attrs);
+    }
+
+    private void initialize(Context context, AttributeSet attrs) {
+        TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.ThemedRecyclerView, 0, 0);
+        boolean insetSides;
+        boolean insetBottom;
+        try {
+            insetSides = typedArray.getBoolean(R.styleable.ThemedRecyclerView_systemBarInsetSides, true);
+            insetBottom = typedArray.getBoolean(R.styleable.ThemedRecyclerView_systemBarInsetBottom, false);
+        } finally {
+            typedArray.recycle();
+        }
+        if (insetBottom) {
+            SystemBars.pad(this, false, insetSides, true);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedScrollView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/theme/ThemedScrollView.java
@@ -20,8 +20,12 @@
 package com.oriondev.moneywallet.ui.view.theme;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.widget.ScrollView;
+
+import com.oriondev.moneywallet.R;
+import com.oriondev.moneywallet.utils.SystemBars;
 
 /**
  * Created by andrea on 20/08/18.
@@ -34,14 +38,34 @@ public class ThemedScrollView extends ScrollView implements ThemeEngine.ThemeCon
 
     public ThemedScrollView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        initialize(context, attrs);
     }
 
     public ThemedScrollView(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        initialize(context, attrs);
     }
 
     public ThemedScrollView(Context context, AttributeSet attrs, int defStyleAttr, int defStyleRes) {
         super(context, attrs, defStyleAttr, defStyleRes);
+        initialize(context, attrs);
+    }
+
+    private void initialize(Context context, AttributeSet attrs) {
+        TypedArray typedArray = context.obtainStyledAttributes(attrs, R.styleable.ThemedScrollView, 0, 0);
+        boolean insetTop;
+        boolean insetSides;
+        boolean insetBottom;
+        try {
+            insetTop = typedArray.getBoolean(R.styleable.ThemedScrollView_systemBarInsetTop, false);
+            insetSides = typedArray.getBoolean(R.styleable.ThemedScrollView_systemBarInsetSides, true);
+            insetBottom = typedArray.getBoolean(R.styleable.ThemedScrollView_systemBarInsetBottom, false);
+        } finally {
+            typedArray.recycle();
+        }
+        if (insetTop || insetBottom) {
+            SystemBars.pad(this, insetTop, insetSides, insetBottom);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/utils/SystemBars.java
+++ b/app/src/main/java/com/oriondev/moneywallet/utils/SystemBars.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2018.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.utils;
+
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.constraintlayout.widget.ConstraintLayout;
+import androidx.constraintlayout.widget.Guideline;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+/**
+ * The app draws behind the status bar and the navigation bar, so every surface that must not end up
+ * underneath one asks for the insets here.
+ * <p>
+ * Each call reads the view's current padding or margin once and treats it as the baseline. The
+ * listener then sets the value to that baseline plus the inset rather than adding to what is already
+ * there: insets are dispatched again on every rotation, keyboard toggle and multi window resize, so
+ * an increment would grow without bound.
+ * <p>
+ * Neither method consumes. Siblings further down the same window need the same insets, and a view
+ * that swallowed them would leave the others under a bar.
+ */
+public final class SystemBars {
+
+    private SystemBars() {
+    }
+
+    /**
+     * Holds a view clear of the bars it asks about. The background still paints to the edge of the
+     * display, since padding does not shrink it, so a toolbar keeps its color running under the
+     * status bar while its content moves down.
+     * <p>
+     * Asking for both edges is how a screen that centers its content stays centered between the
+     * bars: padding only one of them would move the content half as far, because the centering
+     * follows the padding.
+     * <p>
+     * The sides are separate because a view is not always at the edge of the window. Two of the
+     * app bars sit inside a scroll view that has already taken the sides, and on the wide layouts a
+     * scroll view sits inside a card that never reaches the edge; taking the sides again there
+     * indents the content twice.
+     * <p>
+     * clipToPadding goes off whenever the bottom is taken, so rows pass under the navigation bar
+     * and are still reachable by scrolling, which is the point of drawing behind it. Padding alone
+     * would only move the cut.
+     */
+    public static void pad(View view, boolean top, boolean sides, boolean bottom) {
+        final int baseLeft = view.getPaddingLeft();
+        final int baseTop = view.getPaddingTop();
+        final int baseRight = view.getPaddingRight();
+        final int baseBottom = view.getPaddingBottom();
+        if (bottom && view instanceof ViewGroup) {
+            ((ViewGroup) view).setClipToPadding(false);
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, insets) -> {
+            Insets bars = barsAndCutout(insets);
+            v.setPadding(sides ? baseLeft + bars.left : baseLeft,
+                    top ? baseTop + bars.top : baseTop,
+                    sides ? baseRight + bars.right : baseRight,
+                    bottom ? baseBottom + bars.bottom : baseBottom);
+            return insets;
+        });
+        requestInsetsOnAttach(view);
+    }
+
+    /**
+     * For a control anchored to the bottom of the window that cannot scroll out of the way, a
+     * floating action button or a keypad row. Margin and not padding, so the control moves whole
+     * instead of growing.
+     */
+    public static void marginBottomAndSides(View view) {
+        ViewGroup.LayoutParams params = view.getLayoutParams();
+        if (!(params instanceof ViewGroup.MarginLayoutParams)) {
+            return;
+        }
+        ViewGroup.MarginLayoutParams margins = (ViewGroup.MarginLayoutParams) params;
+        final int baseLeft = margins.leftMargin;
+        final int baseRight = margins.rightMargin;
+        final int baseBottom = margins.bottomMargin;
+        ViewCompat.setOnApplyWindowInsetsListener(view, (v, insets) -> {
+            Insets bars = barsAndCutout(insets);
+            ViewGroup.MarginLayoutParams current = (ViewGroup.MarginLayoutParams) v.getLayoutParams();
+            current.leftMargin = baseLeft + bars.left;
+            current.rightMargin = baseRight + bars.right;
+            current.bottomMargin = baseBottom + bars.bottom;
+            v.setLayoutParams(current);
+            return insets;
+        });
+        requestInsetsOnAttach(view);
+    }
+
+    /**
+     * View.requestApplyInsets walks up to the window and returns without doing anything when the
+     * view has no parent yet, which is every view still inside its own constructor and every view
+     * built in onCreateView. So the request is made again on attach, which is the only moment that
+     * reliably comes after the view joins a window. Without it a subtree added after the window's
+     * first dispatch, a settings category opened from the list for instance, waits for something
+     * else to ask before it ever hears about the bars.
+     */
+    private static void requestInsetsOnAttach(View view) {
+        view.requestApplyInsets();
+        view.addOnAttachStateChangeListener(new View.OnAttachStateChangeListener() {
+
+            @Override
+            public void onViewAttachedToWindow(View attached) {
+                attached.requestApplyInsets();
+            }
+
+            @Override
+            public void onViewDetachedFromWindow(View detached) {
+                // nothing to undo: the inset listener lives on the view and is still wanted
+            }
+        });
+    }
+
+    /**
+     * Pushes a horizontal guideline down by the status bar. The wide layouts start their panel
+     * cards partway up an extended app bar, measured from the top of the window, and that top is
+     * now behind the status bar. A guideline is not a view that can be constrained to another one,
+     * so its distance is set here instead.
+     * <p>
+     * The listener goes on the parent because a guideline has no size of its own and is never
+     * laid out; the parent is the view the insets actually reach.
+     */
+    public static void offsetGuidelineByStatusBar(Guideline guideline) {
+        if (guideline == null || !(guideline.getParent() instanceof View)) {
+            return;
+        }
+        final int base = ((ConstraintLayout.LayoutParams) guideline.getLayoutParams()).guideBegin;
+        View parent = (View) guideline.getParent();
+        ViewCompat.setOnApplyWindowInsetsListener(parent, (v, insets) -> {
+            guideline.setGuidelineBegin(base + barsAndCutout(insets).top);
+            return insets;
+        });
+        requestInsetsOnAttach(parent);
+    }
+
+    /**
+     * A drawer takes the bar or cutout on the side it opens from, so its rows and header are not
+     * under a side navigation bar in landscape. The listener goes on the drawer's parent and not on
+     * the drawer, whose own listener is material's and is what pads its menu and paints its status
+     * bar scrim; setting one on the drawer would replace that.
+     */
+    public static void padDrawerStart(View parent, View drawer) {
+        final int baseStart = drawer.getPaddingStart();
+        ViewCompat.setOnApplyWindowInsetsListener(parent, (v, insets) -> {
+            Insets bars = barsAndCutout(insets);
+            boolean rtl = v.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL;
+            drawer.setPaddingRelative(baseStart + (rtl ? bars.right : bars.left),
+                    drawer.getPaddingTop(), drawer.getPaddingEnd(), drawer.getPaddingBottom());
+            return insets;
+        });
+        requestInsetsOnAttach(parent);
+    }
+
+    private static Insets barsAndCutout(WindowInsetsCompat insets) {
+        return insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                | WindowInsetsCompat.Type.displayCutout());
+    }
+}

--- a/app/src/main/res/layout-w600dp/activity_single_panel.xml
+++ b/app/src/main/res/layout-w600dp/activity_single_panel.xml
@@ -25,6 +25,12 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <!--
+      ~ Where the panel cards start, which is partway up the extended app bar so they overlap it;
+      ~ the translationZ each card carries is what draws them over it. A guideline and not the app
+      ~ bar's own bottom, because that bottom now includes the status bar and the cards would leave
+      ~ a band of primary color above them. SystemBars pushes this down by the status bar at runtime.
+      -->
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/toolbar_delimiter_horizontal_guideline"
         android:layout_width="0dp"

--- a/app/src/main/res/layout-w600dp/activity_single_panel_appbar.xml
+++ b/app/src/main/res/layout-w600dp/activity_single_panel_appbar.xml
@@ -25,6 +25,12 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <!--
+      ~ Where the panel cards start, which is partway up the extended app bar so they overlap it;
+      ~ the translationZ each card carries is what draws them over it. A guideline and not the app
+      ~ bar's own bottom, because that bottom now includes the status bar and the cards would leave
+      ~ a band of primary color above them. SystemBars pushes this down by the status bar at runtime.
+      -->
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/toolbar_delimiter_horizontal_guideline"
         android:layout_width="0dp"
@@ -33,6 +39,7 @@
         app:layout_constraintGuide_begin="?attr/actionBarSize" />
 
     <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
+        android:id="@+id/window_app_bar_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
@@ -69,6 +76,8 @@
 
             <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
                 android:id="@+id/app_bar_container"
+                app:systemBarInsetTop="false"
+                app:systemBarInsetSides="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"

--- a/app/src/main/res/layout-w600dp/activity_single_panel_scroll.xml
+++ b/app/src/main/res/layout-w600dp/activity_single_panel_scroll.xml
@@ -25,6 +25,12 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <!--
+      ~ Where the panel cards start, which is partway up the extended app bar so they overlap it;
+      ~ the translationZ each card carries is what draws them over it. A guideline and not the app
+      ~ bar's own bottom, because that bottom now includes the status bar and the cards would leave
+      ~ a band of primary color above them. SystemBars pushes this down by the status bar at runtime.
+      -->
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/toolbar_delimiter_horizontal_guideline"
         android:layout_width="0dp"
@@ -33,6 +39,7 @@
         app:layout_constraintGuide_begin="?attr/actionBarSize" />
 
     <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
+        android:id="@+id/window_app_bar_container"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
@@ -68,6 +75,8 @@
 
             <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
                 android:id="@+id/app_bar_container"
+                app:systemBarInsetTop="false"
+                app:systemBarInsetSides="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
@@ -78,6 +87,9 @@
             </com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout>
 
             <com.oriondev.moneywallet.ui.view.theme.ThemedScrollView
+                android:id="@+id/primary_panel_scroll_view"
+                app:systemBarInsetSides="false"
+                app:systemBarInsetBottom="true"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 

--- a/app/src/main/res/layout-w600dp/fragment_multi_panel.xml
+++ b/app/src/main/res/layout-w600dp/fragment_multi_panel.xml
@@ -31,6 +31,12 @@
         android:layout_height="match_parent"
         android:orientation="vertical" >
 
+        <!--
+          ~ Where the panel cards start, which is partway up the extended app bar so they overlap it;
+          ~ the translationZ each card carries is what draws them over it. A guideline and not the app
+          ~ bar's own bottom, because that bottom now includes the status bar and the cards would leave
+          ~ a band of primary color above them. SystemBars pushes this down by the status bar at runtime.
+          -->
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/toolbar_delimiter_horizontal_guideline"
             android:layout_width="0dp"

--- a/app/src/main/res/layout-w600dp/fragment_multi_panel_appbar.xml
+++ b/app/src/main/res/layout-w600dp/fragment_multi_panel_appbar.xml
@@ -45,8 +45,7 @@
                 android:id="@+id/primary_toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:theme_backgroundColor="colorPrimary"
-                app:layout_scrollFlags="scroll|enterAlways" />
+                app:theme_backgroundColor="colorPrimary" />
 
             <!-- In this area will be placed the primary panel layout -->
 

--- a/app/src/main/res/layout-w600dp/fragment_multi_panel_appbar_without_scroll.xml
+++ b/app/src/main/res/layout-w600dp/fragment_multi_panel_appbar_without_scroll.xml
@@ -43,8 +43,7 @@
                 android:id="@+id/primary_toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:theme_backgroundColor="colorPrimary"
-                app:layout_scrollFlags="scroll|enterAlways" />
+                app:theme_backgroundColor="colorPrimary" />
 
             <!-- In this area will be placed the primary panel layout -->
 

--- a/app/src/main/res/layout-w600dp/layout_secondary_panel_item.xml
+++ b/app/src/main/res/layout-w600dp/layout_secondary_panel_item.xml
@@ -68,6 +68,8 @@
             android:id="@+id/header_secondary_panel_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            app:systemBarInsetTop="@bool/secondary_panel_fills_window"
+            app:systemBarInsetSides="@bool/secondary_panel_fills_window"
             app:theme_backgroundColor="colorPrimary" >
 
             <com.oriondev.moneywallet.ui.view.theme.ThemedToolbar
@@ -81,6 +83,8 @@
         </com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout>
 
         <com.oriondev.moneywallet.ui.view.theme.ThemedScrollView
+            app:systemBarInsetSides="@bool/secondary_panel_fills_window"
+            app:systemBarInsetBottom="true"
             android:layout_width="match_parent"
             android:layout_height="match_parent" >
 

--- a/app/src/main/res/layout-w840dp/fragment_multi_panel.xml
+++ b/app/src/main/res/layout-w840dp/fragment_multi_panel.xml
@@ -31,6 +31,12 @@
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.5"/>
 
+    <!--
+      ~ Where the panel cards start, which is partway up the extended app bar so they overlap it;
+      ~ the translationZ each card carries is what draws them over it. A guideline and not the app
+      ~ bar's own bottom, because that bottom now includes the status bar and the cards would leave
+      ~ a band of primary color above them. SystemBars pushes this down by the status bar at runtime.
+      -->
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/toolbar_delimiter_horizontal_guideline"
         android:layout_width="0dp"

--- a/app/src/main/res/layout-w840dp/fragment_multi_panel_appbar.xml
+++ b/app/src/main/res/layout-w840dp/fragment_multi_panel_appbar.xml
@@ -31,13 +31,6 @@
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.5"/>
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/toolbar_delimiter_horizontal_guideline"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_begin="?attr/actionBarSize" />
-
     <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
         android:id="@+id/primary_app_bar_container"
         android:layout_width="match_parent"
@@ -101,7 +94,7 @@
         android:layout_marginRight="@dimen/layout_multi_panel_primary_panel_margin_right"
         android:layout_marginEnd="@dimen/layout_multi_panel_primary_panel_margin_right"
         android:translationZ="@dimen/layout_multi_panel_secondary_panel_elevation"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar_delimiter_horizontal_guideline"
+        app:layout_constraintTop_toBottomOf="@+id/primary_app_bar_container"
         app:layout_constraintStart_toEndOf="@+id/half_screen_vertical_guideline"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" >

--- a/app/src/main/res/layout-w840dp/fragment_multi_panel_appbar_without_scroll.xml
+++ b/app/src/main/res/layout-w840dp/fragment_multi_panel_appbar_without_scroll.xml
@@ -31,13 +31,6 @@
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.5"/>
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/toolbar_delimiter_horizontal_guideline"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_begin="?attr/actionBarSize" />
-
     <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
         android:id="@+id/primary_app_bar_container"
         android:layout_width="match_parent"
@@ -101,7 +94,7 @@
         android:layout_marginRight="@dimen/layout_multi_panel_primary_panel_margin_right"
         android:layout_marginEnd="@dimen/layout_multi_panel_primary_panel_margin_right"
         android:translationZ="@dimen/layout_multi_panel_secondary_panel_elevation"
-        app:layout_constraintTop_toBottomOf="@+id/toolbar_delimiter_horizontal_guideline"
+        app:layout_constraintTop_toBottomOf="@+id/primary_app_bar_container"
         app:layout_constraintStart_toEndOf="@+id/half_screen_vertical_guideline"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" >

--- a/app/src/main/res/layout/activity_launcher_first_start.xml
+++ b/app/src/main/res/layout/activity_launcher_first_start.xml
@@ -19,6 +19,7 @@
   -->
 
 <com.oriondev.moneywallet.ui.view.theme.ThemedConstraintLayout
+    android:id="@+id/first_start_layout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_launcher_legacy_edition_upgrade.xml
+++ b/app/src/main/res/layout/activity_launcher_legacy_edition_upgrade.xml
@@ -19,6 +19,7 @@
   -->
 
 <com.oriondev.moneywallet.ui.view.theme.ThemedConstraintLayout
+    android:id="@+id/legacy_upgrade_layout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_lock.xml
+++ b/app/src/main/res/layout/activity_lock.xml
@@ -19,6 +19,7 @@
   -->
 
 <com.oriondev.moneywallet.ui.view.theme.ThemedFrameLayout
+    android:id="@+id/lock_layout"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,8 +23,15 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true">
+    android:layout_height="match_parent">
+
+    <!--
+      ~ No fitsSystemWindows here on purpose. DrawerLayout reads that flag in its constructor and,
+      ~ when it is set, installs a listener that consumes the insets and writes them into the
+      ~ margins of the content child, which would hold every screen inside the drawer clear of the
+      ~ bars again. The navigation view below is unaffected, it installs its own listener from
+      ~ ScrimInsetsFrameLayout regardless of the parent, so the drawer still pads its own menu.
+      -->
 
     <FrameLayout
         android:id="@+id/fragment_container"
@@ -37,6 +44,9 @@
         android:layout_height="match_parent"
         android:layout_gravity="start"
         android:maxWidth="320dp"
-        app:headerLayout="@layout/layout_navigation_drawer_header" />
+        app:headerLayout="@layout/layout_navigation_drawer_header"
+        app:insetForeground="@color/system_bar_scrim_dark"
+        app:startInsetScrimEnabled="false"
+        app:endInsetScrimEnabled="false" />
 
 </androidx.drawerlayout.widget.DrawerLayout>

--- a/app/src/main/res/layout/activity_single_panel_appbar.xml
+++ b/app/src/main/res/layout/activity_single_panel_appbar.xml
@@ -38,8 +38,7 @@
             android:id="@+id/primary_toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:theme_backgroundColor="colorPrimary"
-            app:layout_scrollFlags="scroll|enterAlways" />
+            app:theme_backgroundColor="colorPrimary" />
 
         <!-- In this area is placed the app bar layout -->
 

--- a/app/src/main/res/layout/activity_single_panel_scroll.xml
+++ b/app/src/main/res/layout/activity_single_panel_scroll.xml
@@ -19,6 +19,8 @@
   -->
 
 <com.oriondev.moneywallet.ui.view.theme.ThemedScrollView
+    android:id="@+id/primary_panel_scroll_view"
+    app:systemBarInsetBottom="true"
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -33,6 +35,7 @@
 
         <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
             android:id="@+id/app_bar_container"
+            app:systemBarInsetSides="false"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"

--- a/app/src/main/res/layout/fragment_multi_panel_appbar.xml
+++ b/app/src/main/res/layout/fragment_multi_panel_appbar.xml
@@ -41,8 +41,7 @@
                 android:id="@+id/primary_toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:theme_backgroundColor="colorPrimary"
-                app:layout_scrollFlags="scroll|enterAlways" />
+                app:theme_backgroundColor="colorPrimary" />
 
             <!-- In this area will be placed the primary panel layout -->
 

--- a/app/src/main/res/layout/fragment_secondary_panel_backup_list.xml
+++ b/app/src/main/res/layout/fragment_secondary_panel_backup_list.xml
@@ -33,7 +33,9 @@
         <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/colorPrimary" >
+            android:background="@color/colorPrimary"
+            app:systemBarInsetTop="@bool/secondary_panel_fills_window"
+            app:systemBarInsetSides="@bool/secondary_panel_fills_window" >
 
             <com.oriondev.moneywallet.ui.view.theme.ThemedToolbar
                 android:id="@+id/secondary_toolbar"
@@ -48,6 +50,8 @@
             android:layout_height="match_parent">
 
             <com.oriondev.moneywallet.ui.view.AdvancedRecyclerView
+                app:systemBarInsetSides="@bool/secondary_panel_fills_window"
+                app:systemBarInsetBottom="true"
                 android:id="@+id/advanced_recycler_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
@@ -98,12 +102,26 @@
 
         </LinearLayout>
 
-        <com.oriondev.moneywallet.ui.view.theme.ThemedToolbar
-            android:id="@+id/cover_toolbar"
+        <!--
+          ~ The only toolbar in the app that was not inside an app bar layout, which is what asks
+          ~ for the status bar. This cover is what a user sees on Backup before a service is signed
+          ~ in to, and its back arrow was drawn behind the clock. Wrapped to match the header above.
+          -->
+        <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
-            app:theme_backgroundColor="colorPrimary" />
+            android:background="@color/colorPrimary"
+            app:systemBarInsetTop="@bool/secondary_panel_fills_window"
+            app:systemBarInsetSides="@bool/secondary_panel_fills_window" >
+
+            <com.oriondev.moneywallet.ui.view.theme.ThemedToolbar
+                android:id="@+id/cover_toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:theme_backgroundColor="colorPrimary" />
+
+        </com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout>
 
     </com.oriondev.moneywallet.ui.view.theme.ThemedRelativeLayout>
 

--- a/app/src/main/res/layout/layout_calendar_primary_panel.xml
+++ b/app/src/main/res/layout/layout_calendar_primary_panel.xml
@@ -39,6 +39,8 @@
     </com.oriondev.moneywallet.ui.view.theme.ThemedCardView>
 
     <com.oriondev.moneywallet.ui.view.AdvancedRecyclerView
+        app:systemBarInsetSides="@bool/panel_fills_window"
+        app:systemBarInsetBottom="true"
         android:id="@+id/advanced_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/app/src/main/res/layout/layout_fab_list_primary_panel.xml
+++ b/app/src/main/res/layout/layout_fab_list_primary_panel.xml
@@ -19,9 +19,12 @@
   -->
 
 <merge
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
 
     <com.oriondev.moneywallet.ui.view.AdvancedRecyclerView
+        app:systemBarInsetSides="@bool/panel_fills_window"
+        app:systemBarInsetBottom="true"
         android:id="@+id/advanced_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />

--- a/app/src/main/res/layout/layout_navigation_drawer_header.xml
+++ b/app/src/main/res/layout/layout_navigation_drawer_header.xml
@@ -19,21 +19,28 @@
   -->
 
 <!-- The drawer header: the current wallet, two more wallets one tap away, and the arrow that
-     swaps the sections below for the wallet list. Below Android 15 the drawer slides under the
-     status bar, so the root fits the system windows and grows by that height. -->
+     swaps the sections below for the wallet list. It sits behind the status bar and takes the top
+     inset, but from MainActivity and not from fitsSystemWindows, because that flag applies all
+     four edges and would put a navigation bar of empty space under the header as well. -->
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/navigation_drawer_header"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:clickable="true"
-    android:fitsSystemWindows="true"
     android:focusable="true"
     android:foreground="?attr/selectableItemBackground">
 
+    <!--
+      ~ The two cannot be collapsed. The parent is the tap target and the ripple, it is what the
+      ~ status bar padding is applied to, and it wraps its height so that padding grows it; this
+      ~ one is a fixed height that positions the wallet rows against each other.
+      -->
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="148dp">
+        android:layout_height="148dp"
+        tools:ignore="UselessParent">
 
         <ImageView
             android:id="@+id/wallet_icon_image_view"

--- a/app/src/main/res/layout/layout_panel_calculator.xml
+++ b/app/src/main/res/layout/layout_panel_calculator.xml
@@ -49,13 +49,21 @@
         app:theme_backgroundColor="colorWindowForeground"
         tools:text="568,89 * 3,56" />
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <!--
+      ~ The keys each paint the primary color and the container painted nothing, so once the keys
+      ~ were held clear of the navigation bar the window background showed through behind it. The
+      ~ container carries the color now, and from the theme instead of the static attribute,
+      ~ so it follows a color the user picks.
+      -->
+    <com.oriondev.moneywallet.ui.view.theme.ThemedConstraintLayout
+        android:id="@+id/keypad_container"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/vertical_guideline"
-        app:layout_constraintBottom_toBottomOf="parent" >
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:theme_backgroundColor="colorPrimary" >
 
         <androidx.constraintlayout.widget.Guideline
             android:id="@+id/vertical_guideline_1"
@@ -372,6 +380,6 @@
             app:theme_backgroundColor="colorAccent"
             style="?android:attr/borderlessButtonStyle" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.oriondev.moneywallet.ui.view.theme.ThemedConstraintLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/layout_panel_currency_converter.xml
+++ b/app/src/main/res/layout/layout_panel_currency_converter.xml
@@ -130,11 +130,17 @@
 
         </LinearLayout>
 
+        <!--
+          ~ The one button in the app that is centered instead of anchored to the bottom of the
+          ~ window, so it must not move for the navigation bar. It sits on the divider between the
+          ~ two currency rows and an inset would lift it off.
+          -->
         <com.oriondev.moneywallet.ui.view.theme.ThemedFloatingActionButton
             android:id="@+id/floating_action_button"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerInParent="true"
+            app:systemBarInsetBottom="false"
             android:src="@drawable/ic_swap_vert_black_24dp" />
 
     </RelativeLayout>
@@ -263,6 +269,7 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/keypad_last_row"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="0.25"

--- a/app/src/main/res/layout/layout_panel_import_export.xml
+++ b/app/src/main/res/layout/layout_panel_import_export.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.oriondev.moneywallet.ui.view.theme.ThemedScrollView
+    app:systemBarInsetSides="@bool/panel_fills_window"
+    app:systemBarInsetBottom="true"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/layout_panel_overview.xml
+++ b/app/src/main/res/layout/layout_panel_overview.xml
@@ -48,6 +48,8 @@
         </androidx.viewpager.widget.ViewPager>
 
         <com.oriondev.moneywallet.ui.view.theme.ThemedRecyclerView
+            app:systemBarInsetSides="@bool/panel_fills_window"
+            app:systemBarInsetBottom="true"
             android:id="@+id/recycler_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/layout_panel_period_detail.xml
+++ b/app/src/main/res/layout/layout_panel_period_detail.xml
@@ -49,6 +49,8 @@
         </androidx.viewpager.widget.ViewPager>
 
         <com.oriondev.moneywallet.ui.view.theme.ThemedRecyclerView
+            app:systemBarInsetSides="@bool/panel_fills_window"
+            app:systemBarInsetBottom="true"
             android:id="@+id/recycler_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"

--- a/app/src/main/res/layout/layout_recycler_view.xml
+++ b/app/src/main/res/layout/layout_recycler_view.xml
@@ -19,7 +19,10 @@
   -->
 
 <com.oriondev.moneywallet.ui.view.theme.ThemedRecyclerView
+    app:systemBarInsetSides="@bool/panel_fills_window"
+    app:systemBarInsetBottom="true"
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/recycler_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/layout_secondary_panel_item.xml
+++ b/app/src/main/res/layout/layout_secondary_panel_item.xml
@@ -57,6 +57,7 @@
     </com.oriondev.moneywallet.ui.view.theme.ThemedFrameLayout>
 
     <com.oriondev.moneywallet.ui.view.theme.ThemedScrollView
+        app:systemBarInsetBottom="true"
         android:id="@+id/main_screen_secondary_panel_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent" >
@@ -70,6 +71,7 @@
 
             <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
                 android:id="@+id/header_secondary_panel_layout"
+                app:systemBarInsetSides="false"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:theme_backgroundColor="colorPrimary" >

--- a/app/src/main/res/layout/layout_setting_primary_panel.xml
+++ b/app/src/main/res/layout/layout_setting_primary_panel.xml
@@ -19,7 +19,10 @@
   -->
 
 <com.oriondev.moneywallet.ui.view.theme.ThemedRecyclerView
+    app:systemBarInsetSides="@bool/panel_fills_window"
+    app:systemBarInsetBottom="true"
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/recycler_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/layout_setting_secondary_panel.xml
+++ b/app/src/main/res/layout/layout_setting_secondary_panel.xml
@@ -28,6 +28,8 @@
     <com.oriondev.moneywallet.ui.view.theme.ThemedAppBarLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:systemBarInsetTop="@bool/secondary_panel_fills_window"
+        app:systemBarInsetSides="@bool/secondary_panel_fills_window"
         app:theme_backgroundColor="colorPrimary" >
 
         <com.oriondev.moneywallet.ui.view.theme.ThemedToolbar

--- a/app/src/main/res/layout/view_wallet_list.xml
+++ b/app/src/main/res/layout/view_wallet_list.xml
@@ -23,6 +23,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto" >
 
     <com.oriondev.moneywallet.ui.view.AdvancedRecyclerView
+        app:systemBarInsetSides="@bool/panel_fills_window"
+        app:systemBarInsetBottom="true"
         android:id="@+id/advanced_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/values-w600dp/bools.xml
+++ b/app/src/main/res/values-w600dp/bools.xml
@@ -18,15 +18,9 @@
   ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto" >
+<resources>
 
-    <com.oriondev.moneywallet.ui.view.AdvancedRecyclerView
-        app:systemBarInsetSides="@bool/panel_fills_window"
-        app:systemBarInsetBottom="true"
-        android:id="@+id/advanced_recycler_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+    <!-- Here the primary panel is a card inset from both sides, so it reaches neither. -->
+    <bool name="panel_fills_window">false</bool>
 
-</merge>
+</resources>

--- a/app/src/main/res/values-w840dp/bools.xml
+++ b/app/src/main/res/values-w840dp/bools.xml
@@ -18,15 +18,9 @@
   ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<merge
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto" >
+<resources>
 
-    <com.oriondev.moneywallet.ui.view.AdvancedRecyclerView
-        app:systemBarInsetSides="@bool/panel_fills_window"
-        app:systemBarInsetBottom="true"
-        android:id="@+id/advanced_recycler_view"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+    <!-- Here the secondary panel is a card below the app bar, not the whole window. -->
+    <bool name="secondary_panel_fills_window">false</bool>
 
-</merge>
+</resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -46,8 +46,46 @@
         <attr name="theme_backgroundColor" />
     </declare-styleable>
 
+    <!--
+      ~ The app draws behind the system bars, so a view at the edge of the window has to be told to
+      ~ hold its own content clear of one. Each default is whichever value is right for most uses of
+      ~ that widget. An app bar takes the top unless told not to, since only the ones inside a card
+      ~ or a secondary panel are anywhere but the top of a window. A floating action button takes
+      ~ the bottom unless told not to, since only the currency converter's is centered instead of
+      ~ anchored to the bottom. A list does not take the bottom unless told to, since one is just as
+      ~ often nested inside another scroller, a dialog or a pager page, where it would open a space
+      ~ in the middle of the content instead of clearing a bar. The sides are taken unless told not
+      ~ to, and the exceptions are the views that are not at the edge of the window at all: an app
+      ~ bar inside a scroll view that already took them, and a scroll view inside a centered card.
+      -->
+    <attr name="systemBarInsetTop" format="boolean" />
+    <attr name="systemBarInsetSides" format="boolean" />
+    <attr name="systemBarInsetBottom" format="boolean" />
+
     <declare-styleable name="ThemedAppBarLayout">
         <attr name="theme_backgroundColor" />
+        <attr name="systemBarInsetTop" />
+        <attr name="systemBarInsetSides" />
+    </declare-styleable>
+
+    <declare-styleable name="ThemedRecyclerView">
+        <attr name="systemBarInsetSides" />
+        <attr name="systemBarInsetBottom" />
+    </declare-styleable>
+
+    <declare-styleable name="ThemedScrollView">
+        <attr name="systemBarInsetTop" />
+        <attr name="systemBarInsetSides" />
+        <attr name="systemBarInsetBottom" />
+    </declare-styleable>
+
+    <declare-styleable name="AdvancedRecyclerView">
+        <attr name="systemBarInsetSides" />
+        <attr name="systemBarInsetBottom" />
+    </declare-styleable>
+
+    <declare-styleable name="ThemedFloatingActionButton">
+        <attr name="systemBarInsetBottom" />
     </declare-styleable>
 
     <declare-styleable name="ThemedConstraintLayout">

--- a/app/src/main/res/values/bools.xml
+++ b/app/src/main/res/values/bools.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018.
+  ~
+  ~ This file is part of MoneyWallet.
+  ~
+  ~ MoneyWallet is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ MoneyWallet is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<resources>
+
+    <!--
+      ~ The secondary panel covers the whole window at these widths, so its toolbar is what sits
+      ~ behind the status bar and has to hold its content clear of it. Only at w840dp does the panel
+      ~ move into a card partway down the screen, where growing the toolbar would leave an empty
+      ~ colored band floating mid screen. Three of the panel layouts have no width qualified copy of
+      ~ their own, so they read the answer from here instead.
+      -->
+    <bool name="secondary_panel_fills_window">true</bool>
+
+    <!--
+      ~ The primary panel reaches the sides of the window here. From w600dp up it is a card with
+      ~ 88dp of margin on each side, so it is already clear of a side navigation bar and a cutout,
+      ~ and anything inside it that took the side insets would be indented a second time.
+      -->
+    <bool name="panel_fills_window">true</bool>
+
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -34,4 +34,12 @@
     <color name="dialogDarkTextSecondary">#B3FFFFFF</color>
     <color name="dialogDarkTextHint">#80FFFFFF</color>
     <color name="dialogDarkControlHighlight">#33FFFFFF</color>
+
+    <!--
+      ~ Painted over a system bar that the platform will not darken for us: the navigation bar below
+      ~ Android 8, and the strip of the drawer behind the status bar. Half black over anything the
+      ~ app draws leaves the light icons readable. Taken from androidx, which faces the same problem.
+      -->
+    <color name="system_bar_scrim_dark">#801B1B1B</color>
+
 </resources>

--- a/app/src/osm/java/com/oriondev/moneywallet/ui/activity/PlacePickerActivity.java
+++ b/app/src/osm/java/com/oriondev/moneywallet/ui/activity/PlacePickerActivity.java
@@ -46,6 +46,8 @@ public class PlacePickerActivity extends SinglePanelActivity {
     protected void onCreatePanelView(LayoutInflater inflater, ViewGroup parent, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.layout_panel_place_picker, parent, true);
         mMapView = new MapViewWrapper(view.findViewById(R.id.map_view));
+        // This map fills the panel down to the bottom of the window.
+        mMapView.keepCopyrightClearOfSystemBars();
         mMapView.onCreate(savedInstanceState);
         mMapView.setMinZoomLevel();
     }

--- a/app/src/osm/java/com/oriondev/moneywallet/view/MapViewWrapper.java
+++ b/app/src/osm/java/com/oriondev/moneywallet/view/MapViewWrapper.java
@@ -27,6 +27,10 @@ import android.text.TextUtils;
 import android.view.MotionEvent;
 import android.view.View;
 
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
 import com.oriondev.moneywallet.R;
 import com.oriondev.moneywallet.model.Coordinates;
 import com.oriondev.moneywallet.model.Place;
@@ -177,9 +181,55 @@ public class MapViewWrapper {
         return true;
     }
 
+    /**
+     * What CopyrightOverlay's own constructor sets both offsets to in osmdroid 6.1.1, in pixels and
+     * not scaled. Repeated here because the fields are package private, so setting an offset at all
+     * means replacing that default instead of adding to it.
+     */
+    private static final int COPYRIGHT_EDGE_MARGIN = 10;
+
+    private CopyrightOverlay mCopyrightOverlay;
+
+    private boolean mOffsetCopyrightForSystemBars;
+
+    /**
+     * Only the maps that fill a window ask for this. Two of the four do; the other two are short
+     * maps inside a card on the place screens, where offsetting the notice by a navigation bar they
+     * never touch would park it in the middle of the card.
+     */
+    public void keepCopyrightClearOfSystemBars() {
+        mOffsetCopyrightForSystemBars = true;
+        if (mCopyrightOverlay != null) {
+            applyCopyrightOffset();
+        }
+    }
+
     private void setupCopyrightOverlay() {
         // OpenStreetMap requires that you add “© OpenStreetMap contributors” to the map
-        mMapView.getOverlayManager().add(0, new CopyrightOverlay(mMapView.getContext()));
+        mCopyrightOverlay = new CopyrightOverlay(mMapView.getContext());
+        mMapView.getOverlayManager().add(0, mCopyrightOverlay);
+        applyCopyrightOffset();
+    }
+
+    /**
+     * A map that fills a window is not padded, because it is meant to run under the navigation bar.
+     * The notice still has to stay readable, and it is drawn on the canvas instead of laid out, so
+     * it moves by its own offset. A larger offset draws it higher, since it is aligned to the
+     * bottom of the canvas.
+     */
+    private void applyCopyrightOffset() {
+        if (!mOffsetCopyrightForSystemBars) {
+            return;
+        }
+        final CopyrightOverlay overlay = mCopyrightOverlay;
+        ViewCompat.setOnApplyWindowInsetsListener(mMapView, (view, insets) -> {
+            Insets bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    | WindowInsetsCompat.Type.displayCutout());
+            overlay.setOffset(bars.left + COPYRIGHT_EDGE_MARGIN, bars.bottom + COPYRIGHT_EDGE_MARGIN);
+            view.invalidate();
+            return insets;
+        });
+        mMapView.requestApplyInsets();
     }
 
     public void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
Every screen now draws behind the status bar and the navigation bar instead of stopping short of them, on every Android version and not only where Android 15 makes it mandatory. Lists run under the navigation bar and the last row scrolls up clear of it. Toolbars keep their color up into the status bar with the title below it, and the status bar icons switch between light and dark to match whatever is behind them, including the open drawer and a form whose toolbar has scrolled away.

The toolbar on the screens where it used to scroll away now stays put, because the collapsing bar came to rest with its title inside the status bar. The add button on those screens no longer hides on scroll.

In landscape the drawer keeps its rows clear of a navigation bar or a display cutout on its side, and no longer paints a gray band there.

On Android 7 the navigation bar keeps a dark tint, since that version cannot draw dark icons on it.

Tested on Android 7 and Android 16 emulators in both themes and both orientations, with the keyboard up, the drawer open right to left, and the wide tablet layouts.

Fixes #280
