### PR TITLE
Follow the calendar day strip with the month row above it

### DIFF
--- a/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java
@@ -61,7 +61,7 @@ import java.util.Set;
 /**
  * Created by andrea on 06/04/18.
  */
-public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment implements MonthView.OnMonthSelectedListener, OnDateSelectedListener, SwipeRefreshLayout.OnRefreshListener, TransactionCursorAdapter.ActionListener, LoaderManager.LoaderCallbacks<Cursor>, CurrentWalletController {
+public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment implements MonthView.OnMonthSelectedListener, OnDateSelectedListener, TimelineView.OnMonthScrolledListener, SwipeRefreshLayout.OnRefreshListener, TransactionCursorAdapter.ActionListener, LoaderManager.LoaderCallbacks<Cursor>, CurrentWalletController {
 
     private static final String SECONDARY_PANEL_FRAGMENT_TAG = "CalendarMultiPanelFragment::Tag::TransactionItemFragment";
 
@@ -135,6 +135,7 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
         // After setFirstDate above that day is 1 January 1900, which a restored date can equal.
         mTimelineView.setSelectedDate(year, month, day);
         mTimelineView.setOnDateSelectedListener(this);
+        mTimelineView.setOnMonthScrolledListener(this);
         onDateSelected(year, month, day, mTimelineView.getSelectedPosition());
         LoaderManager.getInstance(this).initLoader(MARKED_DAYS_LOADER_ID, null, mMarkedDaysCallbacks);
     }
@@ -187,6 +188,27 @@ public class CalendarMultiPanelFragment extends MultiPanelAppBarItemFragment imp
         mMonthView.setSelectedMonth(year, month, false, true);
         loadTransactions(year, month, day);
         mAdvancedRecyclerView.setState(AdvancedRecyclerView.State.LOADING);
+    }
+
+    /**
+     * The month row names the month the strip is on, so dragging the strip into another month
+     * moves the row with it. A day number says nothing about which month it belongs to, and the
+     * row is the only thing on the screen that appears to answer that.
+     *
+     * Nothing is done while the strip is still inside the month the row already shows, because
+     * setSelectedMonth centers the row on every call and the row would slide under the finger
+     * through a whole month of cells.
+     *
+     * Without callListener the row would call back into onMonthSelected below, which sends the
+     * strip to the first of the month and takes it out from under the drag. The day selected and
+     * the list under the strip are left alone, which is why the transactions are not loaded again.
+     */
+    @Override
+    public void onMonthScrolled(int year, int month) {
+        if (year == mMonthView.getSelectedYear() && month == mMonthView.getSelectedMonth()) {
+            return;
+        }
+        mMonthView.setSelectedMonth(year, month, false, true);
     }
 
     @Override

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/MonthView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/MonthView.java
@@ -184,6 +184,12 @@ public class MonthView extends RecyclerView {
             if (centerOnPosition) {
                 centerOnPosition(selectedPosition);
             }
+            // the month tapped is the one already marked. That used to be a request for the month
+            // the selected day was already in, and the listener was skipped; the mark now follows
+            // a strip that scrolls, so this is somebody asking to go to the month they can see
+            if (callListener && onMonthSelectedListener != null) {
+                onMonthSelectedListener.onMonthSelected(year, month, selectedPosition);
+            }
             return;
         }
 

--- a/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
+++ b/app/src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java
@@ -56,6 +56,7 @@ public class TimelineView extends RecyclerView {
     private TimelineAdapter adapter;
     private LinearLayoutManager layoutManager;
     private OnDateSelectedListener onDateSelectedListener;
+    private OnMonthScrolledListener onMonthScrolledListener;
     private MonthView.DateLabelAdapter dateLabelAdapter;
 
     private Set<Integer> markedDays = Collections.emptySet();
@@ -150,6 +151,49 @@ public class TimelineView extends RecyclerView {
         adapter = new TimelineAdapter();
         setLayoutManager(layoutManager);
         setAdapter(adapter);
+        addOnScrollListener(new OnScrollListener() {
+
+            @Override
+            public void onScrolled(@NonNull RecyclerView recyclerView, int dx, int dy) {
+                // A layout that changes which cells are laid out arrives here with nothing
+                // scrolled, and the first layout of all lays the strip out on its own first day,
+                // before the runnable that puts it on the selected day has run. A cell the strip
+                // was placed on is reported by centerOnPosition instead.
+                if (dx != 0) {
+                    reportMonthAt(centerPosition());
+                }
+            }
+
+        });
+    }
+
+    /**
+     * The cell in the middle of the strip, or {@link #NO_POSITION} when there is no cell there.
+     *
+     * The middle and not the first visible cell, which would name a month while every cell of it
+     * is still off the screen.
+     */
+    private int centerPosition() {
+        View center = findChildViewUnder(getWidth() / 2f, getHeight() / 2f);
+        return center == null ? NO_POSITION : getChildAdapterPosition(center);
+    }
+
+    /**
+     * Hands the listener the month of one cell.
+     *
+     * Reported on every scroll and not only when that month changes, because what a listener does
+     * with it depends on what the listener is showing, which this view cannot see. The month
+     * comes from the same count the adapter binds a cell with, so the month reported is the month
+     * of the numbers a person is looking at.
+     */
+    private void reportMonthAt(int position) {
+        if (onMonthScrolledListener == null || position == NO_POSITION) {
+            return;
+        }
+        resetCalendar();
+        calendar.add(Calendar.DAY_OF_YEAR, position);
+        onMonthScrolledListener.onMonthScrolled(calendar.get(Calendar.YEAR),
+                calendar.get(Calendar.MONTH));
     }
 
     private void resetCalendar() {
@@ -190,6 +234,10 @@ public class TimelineView extends RecyclerView {
         // Animate scroll
         int offset = getMeasuredWidth() / 2 - getChildAt(0).getMeasuredWidth() / 2;
         layoutManager.scrollToPositionWithOffset(position, offset);
+        // the cell this lands on, which the scroll listener above does not report because
+        // nothing is scrolled to get here. Tapping the day already selected reaches only this,
+        // and it is how the strip is first put on the selected day
+        reportMonthAt(position);
     }
 
     public void centerOnSelection() {
@@ -232,6 +280,10 @@ public class TimelineView extends RecyclerView {
 
     public void setOnDateSelectedListener(OnDateSelectedListener onDateSelectedListener) {
         this.onDateSelectedListener = onDateSelectedListener;
+    }
+
+    public void setOnMonthScrolledListener(OnMonthScrolledListener onMonthScrolledListener) {
+        this.onMonthScrolledListener = onMonthScrolledListener;
     }
 
     /**
@@ -415,5 +467,15 @@ public class TimelineView extends RecyclerView {
             dotMarker.setColor(dateColor);
             dotMarker.setVisibility(marked ? VISIBLE : INVISIBLE);
         }
+    }
+
+    /**
+     * Told the month of the cell in the middle of the strip, every time the strip scrolls. A day
+     * number on its own does not say which month it belongs to, so anything naming that month
+     * elsewhere on the screen listens here to keep the name and the numbers in step.
+     */
+    public interface OnMonthScrolledListener {
+
+        void onMonthScrolled(int year, int month);
     }
 }

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMonthRowSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMonthRowSourceTest.java
@@ -33,11 +33,11 @@ import static org.junit.Assert.fail;
 
 /**
  * The month row above the calendar day strip names the month the strip is on. What holds that up
- * is spread over two files: the strip reports the month it scrolls through and the month it is
- * placed on, the fragment listens and moves the row, and the row is left alone while the strip
- * stays inside the month it already marks.
+ * is spread over three files: the strip reports the month it scrolls through and the month it is
+ * placed on, the fragment listens and moves the row, the row is left alone while the strip stays
+ * inside the month it already marks, and a tap on the marked month reaches the row's listener.
  *
- * Neither view can be built here, so this reads the source, and what that buys is
+ * None of the three views can be built here, so this reads the source, and what that buys is
  * narrow. It pins spellings. An edit that keeps the behavior and changes a pinned spelling fails
  * this with nothing wrong, and an edit that changes the behavior without touching a pinned
  * spelling passes it. Whole method bodies are pinned instead of single statements, which catches
@@ -55,6 +55,9 @@ public class CalendarMonthRowSourceTest {
 
     private static final String STRIP =
             "src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java";
+
+    private static final String MONTH_ROW =
+            "src/main/java/com/oriondev/moneywallet/ui/view/calendar/MonthView.java";
 
     private static final String CALENDAR =
             "src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java";
@@ -121,6 +124,18 @@ public class CalendarMonthRowSourceTest {
     private static final String MOVE_THE_ROW =
             "mMonthView.setSelectedMonth(year, month, false, true);";
 
+    /** The month tapped is the month already marked, and the fragment is told anyway. */
+    private static final String TELL_ON_A_TAP_OF_THE_MARKED_MONTH =
+            "if (selectedPosition == oldPosition) { if (centerOnPosition) { "
+            + "centerOnPosition(selectedPosition); } if (callListener "
+            + "&& onMonthSelectedListener != null) { "
+            + "onMonthSelectedListener.onMonthSelected(year, month, selectedPosition); } return; }";
+
+    /** The only caller that asks for the listener, so the only way a tap reaches the fragment. */
+    private static final String A_CELL_IS_TAPPED =
+            "root.setOnClickListener(new OnClickListener() { @Override public void onClick("
+            + "View view) { onMonthSelected(year, month, true, true); } });";
+
     @Test
     public void theStripReportsTheMonthItScrollsThrough() {
         assertTrue("a strip that reports nothing while it scrolls leaves the month row naming the "
@@ -172,6 +187,18 @@ public class CalendarMonthRowSourceTest {
                         + "true. The listening form calls onMonthSelected, which sends the strip "
                         + "to the first of the month and takes it out from under the drag",
                 2, count(source, MOVE_THE_ROW));
+    }
+
+    @Test
+    public void tappingTheMonthTheRowMarksReachesTheFragment() {
+        String source = readSource(MONTH_ROW);
+        assertTrue("the row returns early when the month tapped is the one it already marks, and "
+                        + "that mark now follows a strip that scrolls, so the cell a person has "
+                        + "the most reason to tap would be the only one in the row that neither "
+                        + "moves the strip nor loads a day",
+                source.contains(TELL_ON_A_TAP_OF_THE_MARKED_MONTH));
+        assertTrue("and the cell has to ask for the listener, which is the only caller that does",
+                source.contains(A_CELL_IS_TAPPED));
     }
 
     private static int count(String source, String statement) {

--- a/app/src/test/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMonthRowSourceTest.java
+++ b/app/src/test/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMonthRowSourceTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026.
+ *
+ * This file is part of MoneyWallet.
+ *
+ * MoneyWallet is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MoneyWallet is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MoneyWallet.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.oriondev.moneywallet.ui.fragment.multipanel;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * The month row above the calendar day strip names the month the strip is on. What holds that up
+ * is spread over two files: the strip reports the month it scrolls through and the month it is
+ * placed on, the fragment listens and moves the row, and the row is left alone while the strip
+ * stays inside the month it already marks.
+ *
+ * Neither view can be built here, so this reads the source, and what that buys is
+ * narrow. It pins spellings. An edit that keeps the behavior and changes a pinned spelling fails
+ * this with nothing wrong, and an edit that changes the behavior without touching a pinned
+ * spelling passes it. Whole method bodies are pinned instead of single statements, which catches
+ * a line added above or deleted below and drags pre existing lines into the pins as its cost. The
+ * screen itself is what proves any of this, and a failure here means read the file and decide.
+ *
+ * Comments are stripped before anything is matched, which cuts both ways: a comment cannot stand
+ * in for a statement, and a comment can hide one. Whitespace is collapsed and the space a line
+ * break leaves against a bracket is dropped, so a call may be broken there, and not at a dot or
+ * in front of a comma.
+ */
+public class CalendarMonthRowSourceTest {
+
+    private static final Pattern COMMENTS = Pattern.compile("//.*?$|/[*].*?[*]/", Pattern.DOTALL | Pattern.MULTILINE);
+
+    private static final String STRIP =
+            "src/main/java/com/oriondev/moneywallet/ui/view/calendar/TimelineView.java";
+
+    private static final String CALENDAR =
+            "src/main/java/com/oriondev/moneywallet/ui/fragment/multipanel/CalendarMultiPanelFragment.java";
+
+    /**
+     * The whole listener, because a report added above the dx test is what puts the row on
+     * January 1900 on every open, and pinning the two statements apart would not see it.
+     */
+    private static final String WHILE_IT_SCROLLS =
+            "addOnScrollListener(new OnScrollListener() { @Override public void onScrolled("
+            + "@NonNull RecyclerView recyclerView, int dx, int dy) { if (dx != 0) { "
+            + "reportMonthAt(centerPosition()); } } });";
+
+    /** The whole method, because emptying any line of it kills the report on its own. */
+    private static final String THE_REPORT =
+            "private void reportMonthAt(int position) { if (onMonthScrolledListener == null "
+            + "|| position == NO_POSITION) { return; } resetCalendar(); "
+            + "calendar.add(Calendar.DAY_OF_YEAR, position); "
+            + "onMonthScrolledListener.onMonthScrolled(calendar.get(Calendar.YEAR), "
+            + "calendar.get(Calendar.MONTH)); }";
+
+    /** Which cell is in the middle, since the listener above only names the call. */
+    private static final String WHICH_CELL =
+            "private int centerPosition() { View center = findChildViewUnder(getWidth() / 2f, "
+            + "getHeight() / 2f); return center == null ? NO_POSITION : "
+            + "getChildAdapterPosition(center); }";
+
+    /** A cell the strip is placed on, which no scroll reports because nothing scrolled. */
+    private static final String WHEN_IT_IS_PLACED =
+            "public void centerOnPosition(int position) { if (getChildCount() == 0 "
+            + "|| !isLaidOut()) { return; } int offset = getMeasuredWidth() / 2 - "
+            + "getChildAt(0).getMeasuredWidth() / 2; "
+            + "layoutManager.scrollToPositionWithOffset(position, offset); "
+            + "reportMonthAt(position); }";
+
+    /**
+     * What tells the strip where to report, with the two lines around it, because the statement
+     * on its own reads the same sitting in a method nothing calls.
+     */
+    private static final String WIRING =
+            "mTimelineView.setSelectedDate(year, month, day); "
+            + "mTimelineView.setOnDateSelectedListener(this); "
+            + "mTimelineView.setOnMonthScrolledListener(this); "
+            + "onDateSelected(year, month, day, mTimelineView.getSelectedPosition());";
+
+    /** And what the strip does with it. */
+    private static final String THE_STRIP_KEEPS_IT =
+            "public void setOnMonthScrolledListener(OnMonthScrolledListener onMonthScrolledListener) "
+            + "{ this.onMonthScrolledListener = onMonthScrolledListener; }";
+
+    /**
+     * The whole method, because the guard's condition without its return re centers the row on
+     * every scrolled pixel, which is the slide under the finger the guard is there to stop.
+     */
+    private static final String THE_ROW_FOLLOWS =
+            "public void onMonthScrolled(int year, int month) { if (year == "
+            + "mMonthView.getSelectedYear() && month == mMonthView.getSelectedMonth()) { return; } "
+            + "mMonthView.setSelectedMonth(year, month, false, true); }";
+
+    /** Every call that moves the row, whatever arguments it carries. */
+    private static final String ANY_MOVE = "mMonthView.setSelectedMonth(";
+
+    /** Moving the row with the listening form turned off. */
+    private static final String MOVE_THE_ROW =
+            "mMonthView.setSelectedMonth(year, month, false, true);";
+
+    @Test
+    public void theStripReportsTheMonthItScrollsThrough() {
+        assertTrue("a strip that reports nothing while it scrolls leaves the month row naming the "
+                        + "month the screen opened on, and a report above the dx test names "
+                        + "January 1900 on the first layout of all",
+                readSource(STRIP).contains(WHILE_IT_SCROLLS));
+        assertTrue("and the listener only names the call, so a middle cell that is never worked "
+                        + "out reports nothing on every scroll",
+                readSource(STRIP).contains(WHICH_CELL));
+    }
+
+    @Test
+    public void theStripWorksOutTheMonthAndSendsIt() {
+        assertTrue("everything else here is plumbing that leads to this, and the strip can be "
+                        + "left working the month out and telling nobody",
+                readSource(STRIP).contains(THE_REPORT));
+    }
+
+    @Test
+    public void theStripReportsACellItIsPlacedOn() {
+        assertTrue("a cell the strip is placed on is scrolled to by a layout, so it reaches the "
+                        + "listener only from here. Without it, tapping the day already selected "
+                        + "leaves the row on the month the last drag reached",
+                readSource(STRIP).contains(WHEN_IT_IS_PLACED));
+    }
+
+    @Test
+    public void theStripIsToldWhereToReportTo() {
+        assertTrue("without this line the strip reports to nobody and the row never follows",
+                readSource(CALENDAR).contains(WIRING));
+        assertTrue("and being told is no use if the strip does not keep it",
+                readSource(STRIP).contains(THE_STRIP_KEEPS_IT));
+    }
+
+    @Test
+    public void theRowFollowsTheStripAndIsLeftAloneInsideOneMonth() {
+        assertTrue("the row has to move to the month reported, and has to be left alone while "
+                        + "the strip is inside the month it already marks, or it is re centered "
+                        + "on every scrolled pixel and slides under the finger",
+                readSource(CALENDAR).contains(THE_ROW_FOLLOWS));
+    }
+
+    @Test
+    public void nothingElseMovesTheMonthRow() {
+        String source = readSource(CALENDAR);
+        assertEquals("the day tapped and the month scrolled onto are the only two things that "
+                        + "move the row", 2, count(source, ANY_MOVE));
+        assertEquals("both have to pass callListener false, and a two argument call passes it "
+                        + "true. The listening form calls onMonthSelected, which sends the strip "
+                        + "to the first of the month and takes it out from under the drag",
+                2, count(source, MOVE_THE_ROW));
+    }
+
+    private static int count(String source, String statement) {
+        int found = 0;
+        for (int at = source.indexOf(statement); at >= 0; at = source.indexOf(statement, at + 1)) {
+            found++;
+        }
+        return found;
+    }
+
+    private String readSource(String path) {
+        File file = new File(path);
+        if (!file.exists()) {
+            // a runner rooted at the repo root instead of the module, which the precedent
+            // handles the same way
+            file = new File("app/" + path);
+        }
+        if (!file.exists()) {
+            fail("Cannot find " + path + " at " + file.getAbsolutePath());
+        }
+        try {
+            String source = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+            String collapsed = COMMENTS.matcher(source).replaceAll(" ").replaceAll("\\s+", " ");
+            // a line broken after an open bracket leaves a space the pinned spelling has not got
+            return collapsed.replace("( ", "(").replace(" )", ")");
+        } catch (IOException e) {
+            fail("Cannot read " + path + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
### What is broken

The calendar screen has a month row above a day strip you scroll sideways. The row named the month of the day you had selected and nothing else, so dragging the strip left it naming a month the numbers underneath no longer belonged to. The day numbers do not say which month they are in, so the row is the only thing on screen that appears to answer it.

The row now follows the strip. While you drag, it marks the month of the cell in the middle of the screen, and it holds still while you stay inside one month so it does not slide under your finger. The day you picked is untouched, so the list below the strip still belongs to it.

Tapping the month the row already marks did nothing. Now that the mark follows the strip, that is the cell you have the most reason to tap, so it sends the strip to the first of that month.

### Tested

On an Android 16 emulator holding a seeded ledger. Dragging back into August moves the mark to AUG 26 where the old build left it on SEP 26, and dragging forward moves it to SEP and OCT. Tapping a day still loads it, a fling either way lands on the right month, the row comes back correct after process death, and landscape follows. Not tested: right to left.

Closes #206
